### PR TITLE
Hub: add /compare/ironclaw-vs-openclaw-vs-minion landing page [MIN-464]

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -34,8 +34,11 @@
   let { children }: { children: Snippet } = $props();
 
   const isVoxelized = $derived(theme.preset.id === 'voxelized');
+  const isPublicPage = $derived(page.url.pathname.startsWith('/compare'));
 
   onMount(async () => {
+    if (isPublicPage) return;
+
     installInterceptor();
     await loadUser();
 
@@ -67,32 +70,36 @@
   });
 </script>
 
-<ParaglideJS {i18n} languageTag={locale.current}>
-  {#if isVoxelized && page.url.pathname !== '/login'}
-    <VoxelShader />
-  {/if}
-  {#if !isVoxelized}
-    <ParticleCanvas />
-  {/if}
-  {#if page.url.pathname !== '/login' && !isVoxelized}
-    <BgPattern />
-  {/if}
-  <Toaster />
-  <BugReporter />
+{#if isPublicPage}
+  {@render children()}
+{:else}
+  <ParaglideJS {i18n} languageTag={locale.current}>
+    {#if isVoxelized && page.url.pathname !== '/login'}
+      <VoxelShader />
+    {/if}
+    {#if !isVoxelized}
+      <ParticleCanvas />
+    {/if}
+    {#if page.url.pathname !== '/login' && !isVoxelized}
+      <BgPattern />
+    {/if}
+    <Toaster />
+    <BugReporter />
 
-  {#if conn.connecting}
-    <div class="fixed top-14 left-0 right-0 h-[2px] bg-bg3 z-40 overflow-hidden">
-      <div class="h-full w-1/3 bg-accent animate-loading-slide"></div>
-    </div>
-  {/if}
+    {#if conn.connecting}
+      <div class="fixed top-14 left-0 right-0 h-[2px] bg-bg3 z-40 overflow-hidden">
+        <div class="h-full w-1/3 bg-accent animate-loading-slide"></div>
+      </div>
+    {/if}
 
-  {#key page.url.pathname.split('/')[1]}
-    <div style="animation: page-fade-in 120ms ease-out">
-      {@render children()}
-    </div>
-  {/key}
+    {#key page.url.pathname.split('/')[1]}
+      <div style="animation: page-fade-in 120ms ease-out">
+        {@render children()}
+      </div>
+    {/key}
 
-  {#if ui.overlayOpen}
-    <HostsOverlay />
-  {/if}
-</ParaglideJS>
+    {#if ui.overlayOpen}
+      <HostsOverlay />
+    {/if}
+  </ParaglideJS>
+{/if}

--- a/src/routes/compare/ironclaw-vs-openclaw-vs-minion/+layout.svelte
+++ b/src/routes/compare/ironclaw-vs-openclaw-vs-minion/+layout.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import '../../../app.css';
+  import { type Snippet } from 'svelte';
+
+  let { children }: { children: Snippet } = $props();
+</script>
+
+{@render children()}

--- a/src/routes/compare/ironclaw-vs-openclaw-vs-minion/+page.svelte
+++ b/src/routes/compare/ironclaw-vs-openclaw-vs-minion/+page.svelte
@@ -15,7 +15,8 @@
     name="twitter:description"
     content="IronClaw secures your agents. Minion governs your company. See how they compare."
   />
-  <link rel="canonical" href="https://minion.ai/compare/ironclaw-vs-openclaw-vs-minion" />
+  <meta name="keywords" content="IronClaw vs OpenClaw, AI agent governance platform, enterprise agent audit trail, OpenClaw alternative, multi-agent orchestration enterprise" />
+  <link rel="canonical" href="/compare/ironclaw-vs-openclaw-vs-minion" />
 </svelte:head>
 
 <main class="min-h-screen bg-gray-950 text-gray-100 font-sans">

--- a/src/routes/compare/ironclaw-vs-openclaw-vs-minion/+page.svelte
+++ b/src/routes/compare/ironclaw-vs-openclaw-vs-minion/+page.svelte
@@ -9,14 +9,17 @@
     property="og:description"
     content="IronClaw and OpenClaw handle agent execution. Minion handles the layer above: board approval, CEO delegation, full audit trail, and organizational accountability — from the top of your company down."
   />
+  <meta property="og:url" content="https://minion.ai/compare/ironclaw-vs-openclaw-vs-minion" />
+  <meta property="og:image" content="https://minion.ai/og/compare-ironclaw-openclaw.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Minion vs IronClaw vs OpenClaw" />
   <meta
     name="twitter:description"
     content="IronClaw secures your agents. Minion governs your company. See how they compare."
   />
+  <meta name="twitter:image" content="https://minion.ai/og/compare-ironclaw-openclaw.png" />
   <meta name="keywords" content="IronClaw vs OpenClaw, AI agent governance platform, enterprise agent audit trail, OpenClaw alternative, multi-agent orchestration enterprise" />
-  <link rel="canonical" href="/compare/ironclaw-vs-openclaw-vs-minion" />
+  <link rel="canonical" href="https://minion.ai/compare/ironclaw-vs-openclaw-vs-minion" />
 </svelte:head>
 
 <main class="min-h-screen bg-gray-950 text-gray-100 font-sans">

--- a/src/routes/compare/ironclaw-vs-openclaw-vs-minion/+page.svelte
+++ b/src/routes/compare/ironclaw-vs-openclaw-vs-minion/+page.svelte
@@ -1,0 +1,384 @@
+<svelte:head>
+  <title>Minion vs IronClaw vs OpenClaw | AI Agent Governance</title>
+  <meta
+    name="description"
+    content="IronClaw secures what your agents do. Minion governs who authorized it and why. Compare Minion, IronClaw, and OpenClaw on governance, audit trails, and enterprise readiness."
+  />
+  <meta property="og:title" content="Minion vs IronClaw vs OpenClaw — Governance vs Runtime" />
+  <meta
+    property="og:description"
+    content="IronClaw and OpenClaw handle agent execution. Minion handles the layer above: board approval, CEO delegation, full audit trail, and organizational accountability — from the top of your company down."
+  />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Minion vs IronClaw vs OpenClaw" />
+  <meta
+    name="twitter:description"
+    content="IronClaw secures your agents. Minion governs your company. See how they compare."
+  />
+  <link rel="canonical" href="https://minion.ai/compare/ironclaw-vs-openclaw-vs-minion" />
+</svelte:head>
+
+<main class="min-h-screen bg-gray-950 text-gray-100 font-sans">
+  <!-- ── Nav ──────────────────────────────────────────────────────────────── -->
+  <nav class="sticky top-0 z-50 bg-gray-950/90 backdrop-blur border-b border-gray-800">
+    <div class="max-w-5xl mx-auto px-6 h-14 flex items-center justify-between">
+      <span class="font-bold text-white tracking-tight">Minion</span>
+      <div class="flex items-center gap-3">
+        <a
+          href="/compare/ironclaw-vs-openclaw-vs-minion#compare"
+          class="hidden sm:block text-sm text-gray-400 hover:text-white transition-colors"
+        >
+          Compare
+        </a>
+        <a
+          href="https://minion.ai/signup?utm_source=compare-page&utm_medium=nav&utm_campaign=ironclaw-compare"
+          class="text-sm bg-indigo-600 hover:bg-indigo-500 transition-colors px-4 py-1.5 rounded-md font-medium text-white"
+        >
+          Start Free
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <!-- ── Hero ─────────────────────────────────────────────────────────────── -->
+  <section class="max-w-5xl mx-auto px-6 pt-20 pb-16 text-center">
+    <div
+      class="inline-block mb-4 text-xs font-mono text-indigo-400 bg-indigo-950/60 border border-indigo-800 px-3 py-1 rounded-full"
+    >
+      Governance vs Runtime · Three platforms, three different jobs
+    </div>
+    <h1 class="text-4xl sm:text-5xl font-bold text-white leading-tight mb-6">
+      Not just a safer agent runtime.<br />
+      <span class="text-indigo-400">A smarter company.</span>
+    </h1>
+    <p class="text-lg text-gray-400 max-w-2xl mx-auto mb-4 leading-relaxed">
+      IronClaw secures what your agents do. Minion governs <em>who authorized it</em>, why it
+      happened, and who is accountable — at every level of your organization.
+    </p>
+    <p class="text-sm text-gray-500 max-w-2xl mx-auto mb-10 leading-relaxed">
+      When teams evaluate AI agent platforms, the real questions are never about runtime performance
+      or sandbox isolation. They are: who authorized this agent to act? How do I trace any output
+      back to the human decision that approved it? When something goes wrong, who is responsible?
+      OpenClaw and IronClaw answer the runtime question. Minion answers the governance question.
+    </p>
+    <div class="flex flex-col sm:flex-row gap-4 justify-center">
+      <a
+        href="https://minion.ai/signup?utm_source=compare-page&utm_medium=hero-cta&utm_campaign=ironclaw-compare"
+        class="inline-flex items-center justify-center gap-2 bg-indigo-600 hover:bg-indigo-500 transition-colors text-white font-semibold px-8 py-3.5 rounded-lg text-base"
+      >
+        Start Free — No Credit Card Required
+      </a>
+      <a
+        href="https://minion.ai/demo?utm_source=compare-page&utm_medium=hero-cta&utm_campaign=ironclaw-compare"
+        class="inline-flex items-center justify-center gap-2 border border-gray-700 hover:border-gray-500 transition-colors text-gray-300 font-medium px-8 py-3.5 rounded-lg text-base"
+      >
+        View Demo
+      </a>
+      <a
+        href="https://minion.ai/enterprise?utm_source=compare-page&utm_medium=hero-cta&utm_campaign=ironclaw-compare"
+        class="inline-flex items-center justify-center gap-2 border border-gray-700 hover:border-gray-500 transition-colors text-gray-300 font-medium px-8 py-3.5 rounded-lg text-base"
+      >
+        Talk to Sales
+      </a>
+    </div>
+  </section>
+
+  <!-- ── Intro ─────────────────────────────────────────────────────────────── -->
+  <section class="max-w-5xl mx-auto px-6 py-16 border-t border-gray-800 text-center">
+    <h2 class="text-2xl font-bold text-white mb-6">Three platforms. Three different jobs.</h2>
+    <p class="text-gray-400 max-w-3xl mx-auto leading-relaxed">
+      OpenClaw made agent development accessible. IronClaw made it secure. Neither one was built to
+      run your <em class="text-gray-200">company</em>.
+    </p>
+    <p class="text-gray-400 max-w-3xl mx-auto mt-4 leading-relaxed">
+      Minion is a different category entirely — an organizational governance platform that operates
+      above the runtime layer. It is where your board approves, your CEO delegates, your engineers
+      execute, and your audit trail lives. Permanently.
+    </p>
+  </section>
+
+  <!-- ── Three-Way Comparison Table ──────────────────────────────────────── -->
+  <section id="compare" class="max-w-5xl mx-auto px-6 py-16 border-t border-gray-800">
+    <h2 class="text-2xl font-bold text-white mb-3">How they compare</h2>
+    <p class="text-gray-500 text-sm mb-8">Judge them at the layer that matters for your business.</p>
+    <div class="overflow-x-auto rounded-xl border border-gray-800">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="bg-gray-900">
+            <th class="text-left px-5 py-3.5 text-gray-400 font-medium w-2/5">Feature</th>
+            <th class="text-center px-5 py-3.5 text-indigo-400 font-semibold">Minion</th>
+            <th class="text-center px-5 py-3.5 text-gray-400 font-medium">IronClaw</th>
+            <th class="text-center px-5 py-3.5 text-gray-400 font-medium">OpenClaw</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each [
+            ['What it is', 'Company-scale agent governance platform', 'Secure Rust agent runtime', 'Developer-first agent framework'],
+            ['Operates at', 'Org / company layer', 'Runtime layer', 'Runtime layer'],
+            ['Board approval flow', '✅ Yes — built-in, first-class', '❌ No', '❌ No'],
+            ['CEO-to-agent delegation chain', '✅ Yes — first-class', '❌ No', '❌ No'],
+            ['Full audit trail', '✅ Yes — task lineage, end-to-end', '⚠️ Partial (execution logs only)', '❌ No — known security gaps'],
+            ['Multi-agent org hierarchy', '✅ Yes — CCO, CPO, engineers, QA with reporting lines', '❌ No — flat agent pool', '❌ No — flat agent pool'],
+            ['Non-technical user access', '✅ Yes — board and executive UI', '❌ No — engineering only', '⚠️ Dev-focused'],
+            ['WASM sandboxing', '⚠️ Via adapter', '✅ Yes — native', '❌ No (138 CVEs, unpatched)'],
+            ['OIDC / SSO', '✅ Yes', '✅ Yes (v0.24.0+)', '❌ No — known gaps'],
+            ['Self-hosted', '✅ Yes', '✅ Yes', '✅ Yes'],
+            ['Best for', 'Enterprise governance, compliance, regulated industries', 'Security-first self-hosters', 'Developers, prototyping'],
+          ] as row, i}
+            <tr class={i % 2 === 0 ? 'bg-gray-950' : 'bg-gray-900/40'}>
+              <td class="px-5 py-3 text-gray-300 font-medium">{row[0]}</td>
+              <td class="px-5 py-3 text-center text-indigo-300">{row[1]}</td>
+              <td class="px-5 py-3 text-center text-gray-400">{row[2]}</td>
+              <td class="px-5 py-3 text-center text-gray-400">{row[3]}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+    <p class="text-xs text-gray-600 mt-3 text-center italic">
+      Minion is not a runtime replacement. It is the governance layer that makes any runtime
+      enterprise-ready.
+    </p>
+  </section>
+
+  <!-- ── Governance Narrative ──────────────────────────────────────────────── -->
+  <section class="max-w-5xl mx-auto px-6 py-16 border-t border-gray-800">
+    <h2 class="text-2xl font-bold text-white mb-8">The layer above the runtime</h2>
+    <p class="text-gray-400 leading-relaxed mb-6">
+      IronClaw and OpenClaw are agent runtimes — they execute tasks and manage tool calls. Minion is
+      the only platform that operates at the <strong class="text-white">organizational level</strong>:
+      board governance, CEO delegation chains, cross-team orchestration, accountability trails, and
+      multi-agent company structures that reflect how businesses actually work.
+    </p>
+    <p class="text-gray-400 leading-relaxed mb-8">
+      Every Minion task traces back to a human decision. Board members approve scope. The CEO
+      delegates to department heads. Department heads assign to engineers. QA validates results.
+      Every step is logged, linked, and auditable — permanently. This is not a feature. It is a
+      structural difference in what Minion is.
+    </p>
+    <blockquote
+      class="border-l-4 border-indigo-600 pl-6 italic text-gray-300 text-lg leading-relaxed"
+    >
+      "IronClaw secures what your agent does. Minion governs why it was authorized to do it and who
+      approved it at every level of your organization."
+    </blockquote>
+  </section>
+
+  <!-- ── Governance Flow Diagram ───────────────────────────────────────────── -->
+  <section class="max-w-5xl mx-auto px-6 py-16 border-t border-gray-800">
+    <h2 class="text-2xl font-bold text-white mb-3">
+      From board approval to agent action — every step, every time
+    </h2>
+    <p class="text-gray-500 text-sm mb-10">
+      See how a single decision flows through your organization. Every node is logged. Every handoff
+      is auditable. Nothing happens without authorization.
+    </p>
+
+    <!-- Governance chain diagram -->
+    <div class="relative overflow-x-auto pb-2">
+      <div class="flex items-stretch gap-0 min-w-max mx-auto w-fit">
+        {#each [
+          {
+            label: 'Board Approval',
+            icon: '🏛️',
+            connector: 'Authorizes',
+            tooltip: 'The board reviews the proposed scope and approves the work before any agent takes action. This vote is logged with timestamp, voting members, and the exact scope approved.',
+          },
+          {
+            label: 'CEO Review',
+            icon: '👤',
+            connector: 'Delegates',
+            tooltip: 'The CEO receives the board-approved scope, reviews it for organizational fit, and delegates the work to the appropriate department head. Delegation is explicit and logged as part of the task lineage.',
+          },
+          {
+            label: 'CPO Spec',
+            icon: '📋',
+            connector: 'Assigns',
+            tooltip: 'The CPO translates the executive mandate into an actionable specification — defining requirements, scope, and acceptance criteria. No scope creep is possible without a new approval event.',
+          },
+          {
+            label: 'Engineer Execution',
+            icon: '⚙️',
+            connector: 'Submits',
+            tooltip: 'The assigned agent executes against the approved specification. Every tool call, file change, and decision is logged. The agent cannot exceed the authorized scope.',
+          },
+          {
+            label: 'QA Validation',
+            icon: '🔍',
+            connector: 'Closes',
+            tooltip: 'A QA agent independently validates the output against the original specification. If it passes, the task closes. No output ships without this gate.',
+          },
+          {
+            label: 'Audit Log',
+            icon: '🔒',
+            connector: null,
+            tooltip: 'The completed task — including board vote, CEO delegation, CPO spec, execution log, and QA sign-off — is permanently recorded and linkable.',
+          },
+        ] as node, i}
+          <div class="flex items-center">
+            <!-- Node -->
+            <div class="group relative flex flex-col items-center">
+              <div
+                class="flex flex-col items-center gap-1.5 bg-gray-900 border border-gray-700 hover:border-indigo-600 transition-colors rounded-xl px-5 py-4 cursor-default w-32"
+                class:border-indigo-700={i === 5}
+                class:bg-indigo-950={i === 5}
+              >
+                <span class="text-2xl" aria-hidden="true">{node.icon}</span>
+                <span class="text-xs font-medium text-center text-gray-300 leading-tight"
+                  >{node.label}</span
+                >
+              </div>
+              <!-- Tooltip -->
+              <div
+                class="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 w-56 bg-gray-800 border border-gray-700 rounded-lg p-3 text-xs text-gray-300 leading-relaxed opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10 shadow-xl"
+              >
+                {node.tooltip}
+              </div>
+            </div>
+            <!-- Arrow connector -->
+            {#if node.connector}
+              <div class="flex flex-col items-center px-2">
+                <span class="text-xs text-gray-600 mb-1 whitespace-nowrap">{node.connector}</span>
+                <div class="flex items-center gap-0.5 text-gray-700">
+                  <div class="w-6 h-px bg-gray-700"></div>
+                  <span class="text-gray-600">→</span>
+                </div>
+              </div>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    </div>
+
+    <p class="text-center text-xs text-gray-600 mt-6 italic">
+      Every task in Minion carries this chain. When an auditor asks why an agent did something, you
+      show them this — from the board vote that started it to the QA sign-off that closed it.
+    </p>
+  </section>
+
+  <!-- ── Audience Cards ────────────────────────────────────────────────────── -->
+  <section class="max-w-5xl mx-auto px-6 py-16 border-t border-gray-800">
+    <h2 class="text-2xl font-bold text-white mb-8">
+      Built for everyone in the chain — not just the engineers
+    </h2>
+    <div class="grid sm:grid-cols-3 gap-6">
+      {#each [
+        {
+          audience: 'For Board Members & Executives',
+          headline: 'You approve. You trace. You are never in the dark.',
+          body: 'Minion is the only AI platform with a formal approval chain from board to execution. You see what agents are doing, why they were authorized to do it, and who signed off at every level. Full visibility. Real accountability.',
+        },
+        {
+          audience: 'For Technical Evaluators',
+          headline: 'It sits above the runtime — works with what you have.',
+          body: 'Minion orchestrates multi-agent workflows across your org, tracks dependencies, enforces approval gates, and produces a full audit trail — while delegating execution to the adapters you already run. No runtime migration required.',
+        },
+        {
+          audience: 'For Compliance & Legal',
+          headline: 'Audit trails that survive everything.',
+          body: 'Every task, comment, decision, and delegation is logged and permanently linkable. Traces survive agent restarts, context loss, and team changes. Built for regulated industries where "the agent decided" is not an acceptable answer.',
+        },
+      ] as card}
+        <div class="bg-gray-900 border border-gray-800 rounded-xl p-6">
+          <div
+            class="text-xs font-mono text-indigo-400 uppercase tracking-wider mb-3"
+          >
+            {card.audience}
+          </div>
+          <h3 class="font-semibold text-white mb-3 leading-snug">{card.headline}</h3>
+          <p class="text-gray-400 text-sm leading-relaxed">{card.body}</p>
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <!-- ── Migration Guide ───────────────────────────────────────────────────── -->
+  <section class="max-w-5xl mx-auto px-6 py-16 border-t border-gray-800">
+    <h2 class="text-2xl font-bold text-white mb-3">
+      Migrating from OpenClaw? Here is what you actually need.
+    </h2>
+    <p class="text-gray-500 text-sm mb-8">
+      Minion is not an OpenClaw replacement — it is the governance layer that goes <em
+        class="text-gray-300">above</em
+      > your runtime. You still need a runtime. Here is how to think about the stack.
+    </p>
+    <ol class="space-y-6">
+      {#each [
+        {
+          n: '01',
+          title: 'Choose your runtime',
+          body: 'ZeroClaw delivers performance. Hermes offers Python-ecosystem compatibility. IronClaw adds WASM sandboxing for security-sensitive workloads. Pick what fits your infrastructure.',
+        },
+        {
+          n: '02',
+          title: 'Add Minion above it',
+          body: 'Minion connects to your chosen runtime via adapter. The governance layer — approval flows, org hierarchy, delegation chains — activates immediately. No migration of existing agent logic required.',
+        },
+        {
+          n: '03',
+          title: 'Immediate governance, from day one',
+          body: 'Board approval workflows, full audit trail, and multi-agent org structure are live on setup. Your agents are now employees of an organization — with clear assignments, escalation paths, and accountability.',
+        },
+      ] as step}
+        <li class="flex gap-5">
+          <div class="shrink-0 font-mono text-2xl font-bold text-indigo-800 w-10 pt-0.5">
+            {step.n}
+          </div>
+          <div class="flex-1 border-l border-gray-800 pl-5">
+            <h3 class="font-semibold text-white mb-1">{step.title}</h3>
+            <p class="text-gray-400 text-sm leading-relaxed">{step.body}</p>
+          </div>
+        </li>
+      {/each}
+    </ol>
+    <blockquote
+      class="mt-10 border-l-4 border-indigo-600 pl-6 italic text-gray-400 leading-relaxed"
+    >
+      "Minion is not an OpenClaw replacement. It is the layer above that makes any runtime
+      enterprise-ready."
+    </blockquote>
+  </section>
+
+  <!-- ── Final CTA ─────────────────────────────────────────────────────────── -->
+  <section class="max-w-5xl mx-auto px-6 py-20 border-t border-gray-800 text-center">
+    <h2 class="text-3xl font-bold text-white mb-4">
+      Your board approves. Your CEO delegates. Your agents execute.
+    </h2>
+    <p class="text-gray-400 mb-10 max-w-lg mx-auto leading-relaxed">
+      Minion is the only AI platform where every agent action traces to a human decision.
+    </p>
+    <div class="flex flex-col sm:flex-row gap-4 justify-center">
+      <a
+        href="https://minion.ai/signup?utm_source=compare-page&utm_medium=footer-cta&utm_campaign=ironclaw-compare"
+        class="inline-flex items-center justify-center gap-2 bg-indigo-600 hover:bg-indigo-500 transition-colors text-white font-semibold px-10 py-4 rounded-lg text-base"
+      >
+        Start Free — No Credit Card Required
+      </a>
+      <a
+        href="https://minion.ai/enterprise?utm_source=compare-page&utm_medium=footer-cta&utm_campaign=ironclaw-compare"
+        class="inline-flex items-center justify-center gap-2 border border-gray-700 hover:border-gray-500 transition-colors text-gray-300 font-medium px-10 py-4 rounded-lg text-base"
+      >
+        Talk to Enterprise Sales
+      </a>
+      <a
+        href="https://minion.ai/demo?utm_source=compare-page&utm_medium=footer-cta&utm_campaign=ironclaw-compare"
+        class="inline-flex items-center justify-center gap-2 border border-gray-700 hover:border-gray-500 transition-colors text-gray-300 font-medium px-10 py-4 rounded-lg text-base"
+      >
+        View the Live Demo
+      </a>
+    </div>
+    <p class="mt-6 text-xs text-gray-600">
+      No credit card. No lock-in. Self-hosted option always available.
+    </p>
+  </section>
+
+  <!-- ── Footer ────────────────────────────────────────────────────────────── -->
+  <footer class="border-t border-gray-900 py-8 text-center text-xs text-gray-700">
+    <p>
+      © 2026 Minion · <a
+        href="https://minion.ai"
+        class="hover:text-gray-500 transition-colors">minion.ai</a
+      >
+    </p>
+  </footer>
+</main>

--- a/src/routes/compare/ironclaw-vs-openclaw-vs-minion/+page.ts
+++ b/src/routes/compare/ironclaw-vs-openclaw-vs-minion/+page.ts
@@ -1,0 +1,2 @@
+export const prerender = true;
+export const ssr = true;


### PR DESCRIPTION
## Summary

- Adds `/compare/ironclaw-vs-openclaw-vs-minion` as a static SvelteKit page
- Full copy from MIN-462 (Technical Writer final copy, done)
- Follows migrate-from-openclaw page pattern (standalone, no auth required)

## What is included

- Hero section with three CTA buttons (Start Free / View Demo / Talk to Sales)
- Three-way comparison table (Minion vs IronClaw vs OpenClaw, mobile responsive)
- Governance narrative + flow diagram (Board to CEO to CPO to Engineer to QA to Audit Log)
- Audience cards + migration guide (3 steps for OpenClaw teams)
- SEO meta tags: title, OG, Twitter card, canonical URL

## Deadline

April 15, 2026 — OpenClaw migration window peak.

Resolves MIN-464.