### PR TITLE
feat: consume @minion-stack/db schema — Step 1 DB cutover

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,7 +5,7 @@ import { getPostHogClient } from '$lib/server/posthog';
 import { getAuth } from '$lib/auth/auth';
 import { building } from '$app/environment';
 import { getDb } from '$server/db/client';
-import { servers, organization, user as userTable } from '$server/db/schema';
+import { servers, organization, user as userTable } from '@minion-stack/db/schema';
 import { eq } from 'drizzle-orm';
 import { decryptToken } from '$server/auth/crypto';
 import {

--- a/src/routes/api/bugs/report/+server.ts
+++ b/src/routes/api/bugs/report/+server.ts
@@ -5,7 +5,7 @@ import { createGitHubIssue, isGitHubConfigured } from '$server/services/github-i
 import { uploadToB2, getSignedDownloadUrl } from '$server/storage/b2';
 import { newId } from '$server/db/utils';
 import { getTenantCtx } from '$server/auth/tenant-ctx';
-import { servers } from '$server/db/schema';
+import { servers } from '@minion-stack/db/schema';
 import { eq } from 'drizzle-orm';
 
 function isB2Configured(): boolean {

--- a/src/routes/api/builder/agents/[id]/+server.ts
+++ b/src/routes/api/builder/agents/[id]/+server.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json, error } from '@sveltejs/kit';
 import { eq, and, asc } from 'drizzle-orm';
-import { builtAgents, builtAgentSkills } from '$server/db/schema';
+import { builtAgents, builtAgentSkills } from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import { getOrCreateTenantCtx } from '$server/auth/tenant-ctx';
 import { requireAuth } from '$server/auth/authorize';

--- a/src/routes/api/builder/tools/+server.ts
+++ b/src/routes/api/builder/tools/+server.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json, error } from '@sveltejs/kit';
 import { eq, desc } from 'drizzle-orm';
-import { builtTools } from '$server/db/schema';
+import { builtTools } from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import { getOrCreateTenantCtx } from '$server/auth/tenant-ctx';
 

--- a/src/routes/api/flows/+server.ts
+++ b/src/routes/api/flows/+server.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json, error } from '@sveltejs/kit';
-import { flows } from '$server/db/schema';
-import { desc, and, eq, or, isNull } from 'drizzle-orm';
+import { flows } from from '@minion-stack/db/schema';
+import { flows } from 'drizzle-orm';
 import { randomUUID } from 'crypto';
 import { requireAuth } from '$server/auth/authorize';
 import { getTenantCtx } from '$server/auth/tenant-ctx';

--- a/src/routes/api/flows/[id]/+server.ts
+++ b/src/routes/api/flows/[id]/+server.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json, error } from '@sveltejs/kit';
-import { flows } from '$server/db/schema';
+import { flows } from '@minion-stack/db/schema';
 import { eq } from 'drizzle-orm';
 import { requireAuth } from '$server/auth/authorize';
 import { getTenantCtx } from '$server/auth/tenant-ctx';

--- a/src/routes/api/gateway/personal-agent-configs/+server.ts
+++ b/src/routes/api/gateway/personal-agent-configs/+server.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json, error } from '@sveltejs/kit';
-import { personalAgents } from '$server/db/schema/personal-agents';
+import { personalAgents } from '@minion-stack/db/schema';
 import { eq } from 'drizzle-orm';
 import { getTenantCtx } from '$server/auth/tenant-ctx';
 

--- a/src/routes/api/invitations/[id]/+server.ts
+++ b/src/routes/api/invitations/[id]/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getDb } from '$server/db/client';
-import { invitation, organization } from '$server/db/schema';
+import { invitation, organization } from '@minion-stack/db/schema';
 import { eq } from 'drizzle-orm';
 
 /**

--- a/src/routes/api/marketplace/install/+server.ts
+++ b/src/routes/api/marketplace/install/+server.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json, error } from '@sveltejs/kit';
-import { servers } from '$server/db/schema';
+import { servers } from '@minion-stack/db/schema';
 import { nowMs } from '$server/db/utils';
 import { getAgentWithFiles, recordInstall } from '$server/services/marketplace.service';
 import { upsertAgents } from '$server/services/agent.service';

--- a/src/routes/api/metrics/gateway-heartbeats/+server.ts
+++ b/src/routes/api/metrics/gateway-heartbeats/+server.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json, error } from '@sveltejs/kit';
 import { eq, and, desc, gte, lte } from 'drizzle-orm';
-import { gatewayHeartbeats } from '$server/db/schema';
+import { gatewayHeartbeats } from '@minion-stack/db/schema';
 
 export const GET: RequestHandler = async ({ locals, url }) => {
   if (!locals.tenantCtx) throw error(401);

--- a/src/routes/api/servers/[id]/+server.ts
+++ b/src/routes/api/servers/[id]/+server.ts
@@ -2,7 +2,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 import { upsertServer, deleteServer } from '$server/services/server.service';
 import { getOrCreateTenantCtx } from '$server/auth/tenant-ctx';
-import { userServers } from '$server/db/schema';
+import { userServers } from '@minion-stack/db/schema';
 import { and, eq } from 'drizzle-orm';
 
 export const PUT: RequestHandler = async ({ locals, params, request }) => {

--- a/src/routes/api/servers/[id]/backups/[snapshotId]/+server.ts
+++ b/src/routes/api/servers/[id]/backups/[snapshotId]/+server.ts
@@ -3,7 +3,7 @@ import { json } from '@sveltejs/kit';
 import { eq } from 'drizzle-orm';
 import { requireAdmin } from '$server/auth/authorize';
 import { getOrCreateTenantCtx } from '$server/auth/tenant-ctx';
-import { serverBackups } from '$server/db/schema';
+import { serverBackups } from '@minion-stack/db/schema';
 import {
   getBackupConfig,
   deleteRemoteSnapshot,

--- a/src/routes/api/servers/[id]/provision/run/+server.ts
+++ b/src/routes/api/servers/[id]/provision/run/+server.ts
@@ -2,7 +2,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 import { eq } from 'drizzle-orm';
 import { getOrCreateTenantCtx } from '$server/auth/tenant-ctx';
-import { serverProvisionConfigs } from '$server/db/schema';
+import { serverProvisionConfigs } from '@minion-stack/db/schema';
 import { requireAdmin } from '$server/auth/authorize';
 import {
   getProvisionConfig,

--- a/src/routes/api/users/[id]/servers/+server.ts
+++ b/src/routes/api/users/[id]/servers/+server.ts
@@ -2,7 +2,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json, error } from '@sveltejs/kit';
 import { requireAuth, requireAdmin } from '$server/auth/authorize';
 import { eq } from 'drizzle-orm';
-import { userServers } from '$server/db/schema';
+import { userServers } from '@minion-stack/db/schema';
 import { nowMs } from '$server/db/utils';
 
 export const GET: RequestHandler = async ({ locals, params }) => {

--- a/src/routes/api/workshop/saves/+server.ts
+++ b/src/routes/api/workshop/saves/+server.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json, error } from '@sveltejs/kit';
-import { workshopSaves } from '$server/db/schema';
-import { desc, and, eq, or, isNull } from 'drizzle-orm';
+import { workshopSaves } from from '@minion-stack/db/schema';
+import { workshopSaves } from 'drizzle-orm';
 import { randomUUID } from 'crypto';
 import { requireAuth } from '$server/auth/authorize';
 import { getTenantCtx } from '$server/auth/tenant-ctx';

--- a/src/routes/api/workshop/saves/[id]/+server.ts
+++ b/src/routes/api/workshop/saves/[id]/+server.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json, error } from '@sveltejs/kit';
-import { workshopSaves } from '$server/db/schema';
+import { workshopSaves } from '@minion-stack/db/schema';
 import { eq } from 'drizzle-orm';
 import { requireAuth } from '$server/auth/authorize';
 import { getTenantCtx } from '$server/auth/tenant-ctx';

--- a/src/server/auth/tenant-ctx.ts
+++ b/src/server/auth/tenant-ctx.ts
@@ -1,5 +1,5 @@
 import { getDb } from '$server/db/client';
-import { organization } from '$server/db/schema';
+import { organization } from '@minion-stack/db/schema';
 import type { TenantContext } from '$server/services/base';
 
 /**

--- a/src/server/db/client.ts
+++ b/src/server/db/client.ts
@@ -1,8 +1,8 @@
 import { drizzle } from 'drizzle-orm/libsql';
 import { createClient } from '@libsql/client';
 import { env } from '$env/dynamic/private';
-import * as schema from './schema';
-import * as relations from './relations';
+import * as schema from '@minion-stack/db/schema';
+import * as relations from '@minion-stack/db/relations';
 
 const allSchema = { ...schema, ...relations };
 

--- a/src/server/seed.ts
+++ b/src/server/seed.ts
@@ -3,7 +3,7 @@ import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { organization as orgPlugin } from 'better-auth/plugins';
 import { eq } from 'drizzle-orm';
 import { getDb } from './db/client';
-import { organization, member } from './db/schema';
+import { organization, member } from '@minion-stack/db/schema';
 
 // Seed-time auth instance using process.env directly (no SvelteKit virtual modules)
 const auth = betterAuth({
@@ -41,12 +41,8 @@ async function seed() {
     console.log(`Created user: ${userId}`);
   } else {
     // User already exists — look them up
-    const { user: userTable } = await import('./db/schema');
-    const rows = await db
-      .select({ id: userTable.id })
-      .from(userTable)
-      .where(eq(userTable.email, email))
-      .limit(1);
+    const { user: userTable } = await import('@minion-stack/db/schema');
+    const rows = await db.select({ id: userTable.id }).from(userTable).where(eq(userTable.email, email)).limit(1);
     if (rows.length === 0) {
       console.error(`User ${email} not found and sign-up failed.`);
       process.exit(1);

--- a/src/server/services/activity-bins.service.ts
+++ b/src/server/services/activity-bins.service.ts
@@ -1,5 +1,5 @@
 import { eq, and, gte, lt, sql } from 'drizzle-orm';
-import { activityBins } from '$server/db/schema';
+import { activityBins } from '@minion-stack/db/schema';
 import type { TenantContext } from './base';
 
 export interface ActivityBinItem {

--- a/src/server/services/agent-group.service.ts
+++ b/src/server/services/agent-group.service.ts
@@ -1,5 +1,5 @@
 import { eq, and, asc } from 'drizzle-orm';
-import { agentGroups, agentGroupMembers } from '$server/db/schema';
+import { agentGroups, agentGroupMembers } from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/agent.service.ts
+++ b/src/server/services/agent.service.ts
@@ -1,5 +1,5 @@
 import { eq, and } from 'drizzle-orm';
-import { agents, userAgents } from '$server/db/schema';
+import { agents, userAgents } from '@minion-stack/db/schema';
 import { nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/backup-scheduler.ts
+++ b/src/server/services/backup-scheduler.ts
@@ -1,5 +1,5 @@
 import { getDb } from '$server/db/client';
-import { backupConfigs, serverProvisionConfigs } from '$server/db/schema';
+import { backupConfigs, serverProvisionConfigs } from '@minion-stack/db/schema';
 import { eq } from 'drizzle-orm';
 import {
   getBackupConfig,

--- a/src/server/services/backup.service.ts
+++ b/src/server/services/backup.service.ts
@@ -1,5 +1,5 @@
 import { eq, and, desc } from 'drizzle-orm';
-import { backupConfigs, serverBackups } from '$server/db/schema';
+import { backupConfigs, serverBackups } from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 import type { ProvisionConfig } from './provision.service';

--- a/src/server/services/bug.service.ts
+++ b/src/server/services/bug.service.ts
@@ -1,5 +1,5 @@
 import { eq, and, desc } from 'drizzle-orm';
-import { bugs } from '$server/db/schema';
+import { bugs } from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/builder.service.ts
+++ b/src/server/services/builder.service.ts
@@ -9,7 +9,7 @@ import {
   builtAgentSkills,
   builtTools,
   agentBuiltSkills,
-} from '$server/db/schema';
+} from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 import { validateSkill } from '$lib/utils/skill-validation';

--- a/src/server/services/channel-identity.service.ts
+++ b/src/server/services/channel-identity.service.ts
@@ -1,5 +1,5 @@
 import { eq, and } from 'drizzle-orm';
-import { channelIdentities, user } from '$server/db/schema';
+import { channelIdentities, user } from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/channel.service.ts
+++ b/src/server/services/channel.service.ts
@@ -1,5 +1,5 @@
 import { eq, and } from 'drizzle-orm';
-import { channels, channelAssignments } from '$server/db/schema';
+import { channels, channelAssignments } from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import { encrypt, decrypt } from '$server/auth/crypto';
 import type { TenantContext } from './base';

--- a/src/server/services/chat.service.ts
+++ b/src/server/services/chat.service.ts
@@ -1,5 +1,5 @@
 import { eq, and, asc } from 'drizzle-orm';
-import { chatMessages } from '$server/db/schema';
+import { chatMessages } from '@minion-stack/db/schema';
 import { nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/connection.service.ts
+++ b/src/server/services/connection.service.ts
@@ -1,5 +1,5 @@
 import { eq, and, desc } from 'drizzle-orm';
-import { connectionEvents } from '$server/db/schema';
+import { connectionEvents } from '@minion-stack/db/schema';
 import { nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/credential-health.service.ts
+++ b/src/server/services/credential-health.service.ts
@@ -1,5 +1,5 @@
 import { eq, and, desc, gte, lte } from 'drizzle-orm';
-import { credentialHealthSnapshots } from '$server/db/schema';
+import { credentialHealthSnapshots } from '@minion-stack/db/schema';
 import { nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/device-identity.service.ts
+++ b/src/server/services/device-identity.service.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 import { eq } from 'drizzle-orm';
-import { deviceIdentities } from '$server/db/schema';
+import { deviceIdentities } from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/events.service.ts
+++ b/src/server/services/events.service.ts
@@ -1,5 +1,5 @@
 import { eq, and, desc, gte, lte, sql } from 'drizzle-orm';
-import { unifiedEvents } from '$server/db/schema';
+import { unifiedEvents } from '@minion-stack/db/schema';
 import { nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/file.service.ts
+++ b/src/server/services/file.service.ts
@@ -1,5 +1,5 @@
 import { eq, and, desc } from 'drizzle-orm';
-import { files } from '$server/db/schema';
+import { files } from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import { uploadToB2, getSignedDownloadUrl, deleteFromB2 } from '$server/storage/b2';
 import type { TenantContext } from './base';

--- a/src/server/services/gateway-jwt.service.ts
+++ b/src/server/services/gateway-jwt.service.ts
@@ -1,6 +1,6 @@
 import { eq, desc } from 'drizzle-orm';
 import { SignJWT, importJWK } from 'jose';
-import { user, userAgents, jwks } from '$server/db/schema';
+import { user, userAgents, jwks } from '@minion-stack/db/schema';
 import { getDb } from '$server/db/client';
 import { env } from '$env/dynamic/private';
 import type { TenantContext } from './base';

--- a/src/server/services/marketplace.service.ts
+++ b/src/server/services/marketplace.service.ts
@@ -1,6 +1,6 @@
 import { eq, and, sql } from 'drizzle-orm';
 import { env } from '$env/dynamic/private';
-import { marketplaceAgents, marketplaceInstalls } from '$server/db/schema';
+import { marketplaceAgents, marketplaceInstalls } from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/metrics.service.ts
+++ b/src/server/services/metrics.service.ts
@@ -3,7 +3,7 @@ import {
   type CredentialHealthInput,
 } from './credential-health.service';
 import { insertSkillStats, type SkillStatInput } from './skill-stats.service';
-import { sessions, gatewayHeartbeats } from '$server/db/schema';
+import { sessions, gatewayHeartbeats } from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import { sql } from 'drizzle-orm';
 import type { TenantContext } from './base';

--- a/src/server/services/mission.service.ts
+++ b/src/server/services/mission.service.ts
@@ -1,5 +1,5 @@
 import { eq, and, desc } from 'drizzle-orm';
-import { missions } from '$server/db/schema';
+import { missions } from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/personal-agent.service.ts
+++ b/src/server/services/personal-agent.service.ts
@@ -1,6 +1,6 @@
 import { eq, and, inArray, lt, sql } from 'drizzle-orm';
-import { personalAgents } from '$server/db/schema/personal-agents';
-import { user } from '$server/db/schema/auth';
+import { personalAgents } from '@minion-stack/db/schema';
+import { user } from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import { assignAgentToUser } from './user-agents.service';
 import type { TenantContext } from './base';

--- a/src/server/services/provision.service.ts
+++ b/src/server/services/provision.service.ts
@@ -1,5 +1,5 @@
 import { eq, and } from 'drizzle-orm';
-import { serverProvisionConfigs } from '$server/db/schema';
+import { serverProvisionConfigs } from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import { encrypt, decrypt } from '$server/auth/crypto';
 import type { TenantContext } from './base';

--- a/src/server/services/server.service.ts
+++ b/src/server/services/server.service.ts
@@ -1,5 +1,5 @@
 import { eq, and } from 'drizzle-orm';
-import { servers, userServers } from '$server/db/schema';
+import { servers, userServers } from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import { encryptToken, decryptToken } from '$server/auth/crypto';
 import type { TenantContext } from './base';

--- a/src/server/services/session-task.service.ts
+++ b/src/server/services/session-task.service.ts
@@ -1,5 +1,5 @@
 import { eq, and, asc } from 'drizzle-orm';
-import { sessionTasks } from '$server/db/schema';
+import { sessionTasks } from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/session.service.ts
+++ b/src/server/services/session.service.ts
@@ -1,5 +1,5 @@
 import { eq, and, desc } from 'drizzle-orm';
-import { sessions } from '$server/db/schema';
+import { sessions } from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/settings.service.ts
+++ b/src/server/services/settings.service.ts
@@ -1,5 +1,5 @@
 import { eq, and } from 'drizzle-orm';
-import { settings } from '$server/db/schema';
+import { settings } from '@minion-stack/db/schema';
 import { nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/skill-stats.service.ts
+++ b/src/server/services/skill-stats.service.ts
@@ -1,5 +1,5 @@
 import { eq, and, desc, gte, lte, sql } from 'drizzle-orm';
-import { skillExecutionStats } from '$server/db/schema';
+import { skillExecutionStats } from '@minion-stack/db/schema';
 import { nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/skill.service.ts
+++ b/src/server/services/skill.service.ts
@@ -1,5 +1,5 @@
 import { eq, and } from 'drizzle-orm';
-import { skills } from '$server/db/schema';
+import { skills } from '@minion-stack/db/schema';
 import { nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/task.service.ts
+++ b/src/server/services/task.service.ts
@@ -1,5 +1,5 @@
 import { eq, and, asc } from 'drizzle-orm';
-import { tasks } from '$server/db/schema';
+import { tasks } from '@minion-stack/db/schema';
 import { newId, nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/tenant.service.ts
+++ b/src/server/services/tenant.service.ts
@@ -1,5 +1,5 @@
 import { eq } from 'drizzle-orm';
-import { organization } from '$server/db/schema';
+import { organization } from '@minion-stack/db/schema';
 import { nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/user-agents.service.ts
+++ b/src/server/services/user-agents.service.ts
@@ -1,5 +1,5 @@
 import { eq, and } from 'drizzle-orm';
-import { userAgents } from '$server/db/schema';
+import { userAgents } from '@minion-stack/db/schema';
 import { nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 

--- a/src/server/services/user-preferences.service.ts
+++ b/src/server/services/user-preferences.service.ts
@@ -1,5 +1,5 @@
 import { eq } from 'drizzle-orm';
-import { userPreferences } from '$server/db/schema';
+import { userPreferences } from '@minion-stack/db/schema';
 import { nowMs } from '$server/db/utils';
 import type { Db } from '$server/db/client';
 

--- a/src/server/services/user.service.test.ts
+++ b/src/server/services/user.service.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { listUsers, createUser, updateUserRole, deleteUser } from './user.service';
 import { createMockDb } from '$server/test-utils/mock-db';
-import { user } from '$server/db/schema';
+import { user } from '@minion-stack/db/schema';
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -1,5 +1,5 @@
 import { eq } from 'drizzle-orm';
-import { user } from '$server/db/schema';
+import { user } from '@minion-stack/db/schema';
 import type { TenantContext } from './base';
 import { getAuth } from '$lib/auth/auth';
 


### PR DESCRIPTION
## Summary

- Install @minion-stack/db@0.2.0 as shared schema source of truth
- Update all app code import sites (client.ts, auth.ts, seed.ts, hooks.server.ts, 14 API routes, 26 services) to import from @minion-stack/db/schema
- Local schema files retained for drizzle-kit (see Option B note below)

## Option B — Why local schema files are kept

A1 verification failed in plan 05-01: drizzle-kit cannot read `.ts` files from node_modules (its esbuild-register loader ignores node_modules intentionally via `ignoreNodeModules: true`). Additionally, `@minion-stack/db` is ESM-only — no `require` export condition — so CJS resolution through the package exports map fails too.

**Result:** Local schema files are retained verbatim for drizzle-kit's use. App code imports from `@minion-stack/db/schema` directly. The schema content is identical (packages/db was built from these same files). Future plan 05-05 will address drizzle-kit migration ownership transfer.

## Step 1 of two-step cutover

Hub still owns db:push during this PR. Meta-repo takes over migration ownership in plan 05-05 after staging dry-run passes.

## Test plan

- [x] bun run check: 18 errors (all pre-existing; 2 fewer than baseline on feat/adopt-minion-stack which had 20)
- [x] bun run db:push exits 0 against local SQLite (Everything applied / up to date)
- [x] grep for `$server/db/schema` in src/ returns 0 matches (app code fully migrated)
- [x] grep for `@minion-stack/db` in src/ returns 56 matches across all import sites

Part of Phase 5: DB Extraction