### PR TITLE
feat(hub): debug stepped-build viewer (Phase D-0c)

### DIFF
--- a/src/lib/components/debug/StepStateView.svelte
+++ b/src/lib/components/debug/StepStateView.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import { GATE_LABEL, type DebugStepEvent } from '$lib/state/debug';
+
+  let {
+    event,
+  }: {
+    event: DebugStepEvent | null;
+  } = $props();
+
+  const formatted = $derived.by(() => {
+    if (!event) return '';
+    return JSON.stringify(event.state, null, 2);
+  });
+</script>
+
+<div class="state-view">
+  <h3>Step state</h3>
+  {#if event}
+    <div class="meta">
+      <div><strong>Gate:</strong> {GATE_LABEL[event.step]}</div>
+      <div><strong>Session:</strong> <code>{event.sessionKey}</code></div>
+      {#if event.agentId}
+        <div><strong>Agent:</strong> <code>{event.agentId}</code></div>
+      {/if}
+      <div>
+        <strong>Time:</strong>
+        {new Date(event.ts).toLocaleTimeString()}
+      </div>
+    </div>
+    <pre>{formatted}</pre>
+  {:else}
+    <p class="empty">Select a gate from the pipeline to inspect its state.</p>
+  {/if}
+</div>
+
+<style>
+  .state-view {
+    border: 1px solid var(--bd, #2a2a2a);
+    border-radius: 8px;
+    padding: 1rem;
+    background: var(--bg-card, #141414);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  h3 {
+    margin: 0;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--fg-muted, #888);
+  }
+
+  .meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.85rem;
+    color: var(--fg-muted, #aaa);
+  }
+
+  code {
+    font-family: var(--font-mono, monospace);
+    font-size: 0.8rem;
+    color: var(--fg, #ddd);
+  }
+
+  pre {
+    margin: 0;
+    padding: 0.75rem;
+    background: var(--bg-deep, #0a0a0a);
+    border-radius: 4px;
+    font-family: var(--font-mono, monospace);
+    font-size: 0.8rem;
+    color: var(--fg, #ddd);
+    overflow-x: auto;
+    max-height: 400px;
+    overflow-y: auto;
+  }
+
+  .empty {
+    color: var(--fg-faint, #666);
+    font-style: italic;
+    margin: 0;
+  }
+</style>

--- a/src/lib/components/debug/StepView.svelte
+++ b/src/lib/components/debug/StepView.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+  import {
+    ALL_GATES,
+    GATE_LABEL,
+    type DebugStepName,
+    type DebugStepEvent,
+  } from '$lib/state/debug';
+
+  let {
+    events,
+    pausedStep,
+    onContinue,
+    onSelect,
+  }: {
+    events: DebugStepEvent[];
+    pausedStep: DebugStepName | null;
+    onContinue: (step: DebugStepName) => void;
+    onSelect: (step: DebugStepName) => void;
+  } = $props();
+
+  /** Map gate → most-recent event (for status icon + selection). */
+  const eventsByStep = $derived.by(() => {
+    const map = new Map<DebugStepName, DebugStepEvent>();
+    for (const e of events) map.set(e.step, e);
+    return map;
+  });
+
+  function statusFor(step: DebugStepName): 'paused' | 'fired' | 'pending' {
+    if (pausedStep === step) return 'paused';
+    if (eventsByStep.has(step)) return 'fired';
+    return 'pending';
+  }
+
+  function statusIcon(status: 'paused' | 'fired' | 'pending'): string {
+    if (status === 'paused') return '⏸';
+    if (status === 'fired') return '✓';
+    return '○';
+  }
+</script>
+
+<div class="step-view">
+  <h3>Pipeline gates</h3>
+  <ul>
+    {#each ALL_GATES as gate (gate)}
+      {@const status = statusFor(gate)}
+      {@const evt = eventsByStep.get(gate)}
+      <li class="row" class:paused={status === 'paused'} class:fired={status === 'fired'}>
+        <button class="gate-btn" type="button" onclick={() => onSelect(gate)}>
+          <span class="icon">{statusIcon(status)}</span>
+          <span class="label">{GATE_LABEL[gate]}</span>
+          {#if evt}
+            <span class="ts">{new Date(evt.ts).toLocaleTimeString()}</span>
+          {/if}
+        </button>
+        {#if status === 'paused'}
+          <button class="continue-btn" type="button" onclick={() => onContinue(gate)}>
+            ▶ Continue
+          </button>
+        {/if}
+      </li>
+    {/each}
+  </ul>
+</div>
+
+<style>
+  .step-view {
+    border: 1px solid var(--bd, #2a2a2a);
+    border-radius: 8px;
+    padding: 1rem;
+    background: var(--bg-card, #141414);
+  }
+
+  h3 {
+    margin: 0 0 0.75rem;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--fg-muted, #888);
+  }
+
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .gate-btn {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    padding: 0.4rem 0.6rem;
+    color: var(--fg-muted, #888);
+    cursor: pointer;
+    text-align: left;
+    font: inherit;
+  }
+
+  .gate-btn:hover {
+    background: var(--bg-hover, rgba(255, 255, 255, 0.04));
+  }
+
+  .row.fired .gate-btn {
+    color: var(--fg, #ddd);
+  }
+
+  .row.paused .gate-btn {
+    color: var(--accent, #ffb84d);
+    background: var(--accent-bg, rgba(255, 184, 77, 0.1));
+    border-color: var(--accent, #ffb84d);
+  }
+
+  .icon {
+    font-family: var(--font-mono, monospace);
+    width: 1em;
+    text-align: center;
+  }
+
+  .label {
+    font-family: var(--font-mono, monospace);
+    font-size: 0.85rem;
+  }
+
+  .ts {
+    margin-left: auto;
+    font-size: 0.75rem;
+    color: var(--fg-faint, #555);
+  }
+
+  .continue-btn {
+    background: var(--accent, #ffb84d);
+    color: #000;
+    border: none;
+    border-radius: 4px;
+    padding: 0.35rem 0.75rem;
+    font-weight: 600;
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+
+  .continue-btn:hover {
+    filter: brightness(1.15);
+  }
+</style>

--- a/src/lib/services/gateway.svelte.ts
+++ b/src/lib/services/gateway.svelte.ts
@@ -1,5 +1,11 @@
 import { conn } from '$lib/state/gateway/connection.svelte';
 import {
+  type DebugStepEvent,
+  type DebugStepName,
+  pushDebugStepEvent,
+  pushDebugStepTimeout,
+} from '$lib/state/debug';
+import {
   gw,
   upsertSession,
   mergeSessions,
@@ -475,9 +481,9 @@ function handleEvent(evt: Record<string, unknown>) {
       break;
     }
     default: {
+      const evtName = evt.event as string | undefined;
       // Phase 25: bubble prompt.section.* mutations to a single window event
       // so /prompt subscribers can refetch usage without a per-event case.
-      const evtName = evt.event as string | undefined;
       if (
         typeof evtName === 'string' &&
         evtName.startsWith('prompt.section.') &&
@@ -487,8 +493,48 @@ function handleEvent(evt: Record<string, unknown>) {
           new CustomEvent('prompt.sections.changed', { detail: evt.payload }),
         );
       }
+      // Phase D-0c: debug.step.* (admin-only) — push to debug rune store
+      if (typeof evtName === 'string' && evtName.startsWith('debug.step.')) {
+        onDebugStepEvent(evtName, evt.payload);
+      }
       break;
     }
+  }
+}
+
+function onDebugStepEvent(eventName: string, payload: unknown) {
+  if (!payload || typeof payload !== 'object') return;
+  const stepFromName = eventName.slice('debug.step.'.length);
+  // Special: debug.step.timeout — auto-resume notification, not a gate fire
+  if (stepFromName === 'timeout') {
+    const p = payload as { sessionKey?: unknown; step?: unknown; ts?: unknown };
+    if (typeof p.sessionKey === 'string' && typeof p.step === 'string') {
+      pushDebugStepTimeout({
+        sessionKey: p.sessionKey,
+        step: p.step as DebugStepName,
+        ts: typeof p.ts === 'number' ? p.ts : Date.now(),
+      });
+    }
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent(eventName, { detail: payload }));
+    }
+    return;
+  }
+  // Step gate event: push into the debug store. Payload shape matches the
+  // gateway's DebugStepEvent type.
+  const p = payload as Partial<DebugStepEvent>;
+  if (typeof p.sessionKey === 'string' && typeof p.step === 'string') {
+    pushDebugStepEvent({
+      category: 'debug.step',
+      step: p.step as DebugStepName,
+      sessionKey: p.sessionKey,
+      agentId: typeof p.agentId === 'string' ? p.agentId : undefined,
+      state: (p.state as Record<string, unknown>) ?? {},
+      ts: typeof p.ts === 'number' ? p.ts : Date.now(),
+    });
+  }
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(eventName, { detail: payload }));
   }
 }
 
@@ -719,6 +765,26 @@ export async function fetchPromptPreview(agentId: string) {
 
 export async function fetchKGSnapshot(agentId: string) {
   return sendRequest('memory.snapshot', { agentId });
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Phase D-0c — debug stepped-build RPCs (admin-only)
+// ──────────────────────────────────────────────────────────────────────────
+
+export async function debugSetSteppedBuild(
+  sessionKey: string,
+  enabled: boolean,
+  pauseTimeoutMs?: number,
+) {
+  return sendRequest('debug.setSteppedBuild', { sessionKey, enabled, pauseTimeoutMs });
+}
+
+export async function debugStepContinue(sessionKey: string, fromStep?: string) {
+  return sendRequest('debug.stepContinue', { sessionKey, fromStep });
+}
+
+export async function debugSkipAll(sessionKey: string) {
+  return sendRequest('debug.skipAll', { sessionKey });
 }
 
 export function loadChatHistory(agentId: string) {

--- a/src/lib/state/debug/debug.svelte.ts
+++ b/src/lib/state/debug/debug.svelte.ts
@@ -1,0 +1,129 @@
+/**
+ * Phase D-0c — debug stepped-build state.
+ *
+ * Per-session ring buffer of debug.step.* events received via WS, plus the
+ * currently-paused step. Hub admin opts in by calling debug.setSteppedBuild,
+ * then clicks Continue/Skip-all/Cancel as gates fire.
+ */
+
+import type { Snippet } from 'svelte';
+
+export type DebugStepName =
+  | 'agent_resolved'
+  | 'eligible_pool_computed'
+  | 'pre_prompt_build_dispatched'
+  | 'pre_prompt_build_merged'
+  | 'llm_call_starting'
+  | 'section_assembly_started'
+  | 'prompt_assembled'
+  | 'pre_prompt_build_handler';
+
+export type DebugStepEvent = {
+  category: 'debug.step';
+  step: DebugStepName;
+  sessionKey: string;
+  agentId?: string;
+  state: Record<string, unknown>;
+  ts: number;
+};
+
+export const ALL_GATES: DebugStepName[] = [
+  'agent_resolved',
+  'eligible_pool_computed',
+  'pre_prompt_build_dispatched',
+  'pre_prompt_build_merged',
+  'llm_call_starting',
+  'section_assembly_started',
+  'prompt_assembled',
+  'pre_prompt_build_handler',
+];
+
+export const GATE_LABEL: Record<DebugStepName, string> = {
+  agent_resolved: 'Agent resolved',
+  eligible_pool_computed: 'Eligible pool computed',
+  pre_prompt_build_dispatched: 'pre_prompt_build dispatched',
+  pre_prompt_build_handler: 'pre_prompt_build handler',
+  pre_prompt_build_merged: 'pre_prompt_build merged',
+  section_assembly_started: 'Section assembly started',
+  prompt_assembled: 'Prompt assembled',
+  llm_call_starting: 'LLM call starting',
+};
+
+const MAX_EVENTS_PER_SESSION = 50;
+
+type SessionDebugState = {
+  events: DebugStepEvent[];
+  pausedStep: DebugStepName | null;
+  steppedBuildEnabled: boolean;
+  timeoutCount: number;
+  lastUpdatedAt: number;
+};
+
+function emptySession(): SessionDebugState {
+  return {
+    events: [],
+    pausedStep: null,
+    steppedBuildEnabled: false,
+    timeoutCount: 0,
+    lastUpdatedAt: 0,
+  };
+}
+
+export const debugState = $state({
+  sessions: {} as Record<string, SessionDebugState>,
+});
+
+export function getSessionDebug(sessionKey: string): SessionDebugState {
+  let session = debugState.sessions[sessionKey];
+  if (!session) {
+    session = emptySession();
+    debugState.sessions[sessionKey] = session;
+  }
+  return session;
+}
+
+export function pushDebugStepEvent(evt: DebugStepEvent) {
+  const session = getSessionDebug(evt.sessionKey);
+  session.events.push(evt);
+  if (session.events.length > MAX_EVENTS_PER_SESSION) {
+    session.events.splice(0, session.events.length - MAX_EVENTS_PER_SESSION);
+  }
+  // Latest event is the gate currently paused (gateway emits then awaits).
+  // Subsequent stepContinue + next gate event will overwrite this.
+  session.pausedStep = evt.step;
+  session.lastUpdatedAt = evt.ts;
+}
+
+export function pushDebugStepTimeout(payload: {
+  sessionKey: string;
+  step: DebugStepName;
+  ts: number;
+}) {
+  const session = getSessionDebug(payload.sessionKey);
+  session.timeoutCount += 1;
+  session.pausedStep = null;
+  session.lastUpdatedAt = payload.ts;
+}
+
+export function clearPausedStep(sessionKey: string) {
+  const session = debugState.sessions[sessionKey];
+  if (session) {
+    session.pausedStep = null;
+    session.lastUpdatedAt = Date.now();
+  }
+}
+
+export function setSessionSteppedBuildEnabled(sessionKey: string, enabled: boolean) {
+  const session = getSessionDebug(sessionKey);
+  session.steppedBuildEnabled = enabled;
+  if (!enabled) {
+    session.pausedStep = null;
+  }
+}
+
+export function clearSessionDebug(sessionKey: string) {
+  delete debugState.sessions[sessionKey];
+}
+
+// Re-export Snippet type for component imports
+export type { Snippet };

--- a/src/lib/state/debug/index.ts
+++ b/src/lib/state/debug/index.ts
@@ -1,0 +1,12 @@
+export {
+  ALL_GATES,
+  GATE_LABEL,
+  clearPausedStep,
+  clearSessionDebug,
+  debugState,
+  getSessionDebug,
+  pushDebugStepEvent,
+  pushDebugStepTimeout,
+  setSessionSteppedBuildEnabled,
+} from './debug.svelte';
+export type { DebugStepEvent, DebugStepName } from './debug.svelte';

--- a/src/routes/(app)/sessions/[sessionKey]/debug/+page.svelte
+++ b/src/routes/(app)/sessions/[sessionKey]/debug/+page.svelte
@@ -1,0 +1,250 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import StepView from '$lib/components/debug/StepView.svelte';
+  import StepStateView from '$lib/components/debug/StepStateView.svelte';
+  import {
+    debugSetSteppedBuild,
+    debugSkipAll,
+    debugStepContinue,
+  } from '$lib/services/gateway.svelte';
+  import {
+    type DebugStepName,
+    type DebugStepEvent,
+    debugState,
+    getSessionDebug,
+    setSessionSteppedBuildEnabled,
+  } from '$lib/state/debug';
+  import { conn } from '$lib/state/gateway/connection.svelte';
+
+  const sessionKey = $derived(decodeURIComponent(page.params.sessionKey ?? ''));
+
+  // Reactive read of the session's debug state via runed store
+  const session = $derived(sessionKey ? debugState.sessions[sessionKey] ?? getSessionDebug(sessionKey) : null);
+
+  let selectedStep = $state<DebugStepName | null>(null);
+  let busy = $state(false);
+  let error = $state<string | null>(null);
+
+  const selectedEvent = $derived.by((): DebugStepEvent | null => {
+    if (!session || !selectedStep) {
+      // Default to most recent event
+      return session?.events.at(-1) ?? null;
+    }
+    for (let i = session.events.length - 1; i >= 0; i -= 1) {
+      const e = session.events[i];
+      if (e?.step === selectedStep) return e;
+    }
+    return null;
+  });
+
+  async function handleToggle(enabled: boolean) {
+    if (!sessionKey || busy) return;
+    busy = true;
+    error = null;
+    try {
+      await debugSetSteppedBuild(sessionKey, enabled);
+      setSessionSteppedBuildEnabled(sessionKey, enabled);
+    } catch (e) {
+      error = `Failed to ${enabled ? 'enable' : 'disable'} stepping: ${e instanceof Error ? e.message : String(e)}`;
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function handleContinue(step: DebugStepName) {
+    if (!sessionKey) return;
+    error = null;
+    try {
+      await debugStepContinue(sessionKey, step);
+    } catch (e) {
+      error = `Continue failed: ${e instanceof Error ? e.message : String(e)}`;
+    }
+  }
+
+  async function handleSkipAll() {
+    if (!sessionKey) return;
+    error = null;
+    try {
+      await debugSkipAll(sessionKey);
+    } catch (e) {
+      error = `Skip all failed: ${e instanceof Error ? e.message : String(e)}`;
+    }
+  }
+
+  function handleSelect(step: DebugStepName) {
+    selectedStep = step;
+  }
+</script>
+
+<svelte:head>
+  <title>Debug · {sessionKey} · Minion Hub</title>
+</svelte:head>
+
+<div class="page">
+  <header>
+    <h1>Stepped build debug</h1>
+    <div class="meta">
+      <div>
+        Session: <code>{sessionKey}</code>
+      </div>
+      <div class="status">
+        Gateway:
+        <span class:on={conn.connected}>
+          {conn.connected ? 'connected' : conn.connecting ? 'connecting' : 'disconnected'}
+        </span>
+      </div>
+    </div>
+  </header>
+
+  {#if !sessionKey}
+    <p class="error">No sessionKey in URL.</p>
+  {:else}
+    <section class="controls">
+      <label class="toggle">
+        <input
+          type="checkbox"
+          checked={session?.steppedBuildEnabled ?? false}
+          disabled={busy || !conn.connected}
+          onchange={(e) => handleToggle((e.currentTarget as HTMLInputElement).checked)}
+        />
+        <span>Stepped build {session?.steppedBuildEnabled ? 'ON' : 'OFF'}</span>
+      </label>
+      <button
+        type="button"
+        class="skip-btn"
+        onclick={handleSkipAll}
+        disabled={!session?.pausedStep}
+      >
+        ⏭ Skip all gates this turn
+      </button>
+      {#if session && session.timeoutCount > 0}
+        <span class="timeout-badge">⚠ {session.timeoutCount} auto-resume(s)</span>
+      {/if}
+    </section>
+
+    {#if error}
+      <p class="error">{error}</p>
+    {/if}
+
+    <div class="grid">
+      <StepView
+        events={session?.events ?? []}
+        pausedStep={session?.pausedStep ?? null}
+        onContinue={handleContinue}
+        onSelect={handleSelect}
+      />
+      <StepStateView event={selectedEvent} />
+    </div>
+  {/if}
+</div>
+
+<style>
+  .page {
+    padding: 1.5rem;
+    max-width: 1400px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  h1 {
+    margin: 0;
+    font-size: 1.5rem;
+  }
+
+  .meta {
+    display: flex;
+    gap: 1.5rem;
+    color: var(--fg-muted, #888);
+    font-size: 0.9rem;
+  }
+
+  code {
+    font-family: var(--font-mono, monospace);
+    color: var(--fg, #ddd);
+  }
+
+  .status .on {
+    color: #4ade80;
+  }
+
+  .controls {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.75rem 1rem;
+    background: var(--bg-card, #141414);
+    border: 1px solid var(--bd, #2a2a2a);
+    border-radius: 8px;
+    flex-wrap: wrap;
+  }
+
+  .toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .toggle input {
+    width: 1.1rem;
+    height: 1.1rem;
+    cursor: pointer;
+  }
+
+  .skip-btn {
+    background: transparent;
+    border: 1px solid var(--bd, #2a2a2a);
+    border-radius: 4px;
+    padding: 0.4rem 0.85rem;
+    color: var(--fg, #ddd);
+    cursor: pointer;
+    font: inherit;
+  }
+
+  .skip-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .skip-btn:not(:disabled):hover {
+    background: var(--bg-hover, rgba(255, 255, 255, 0.04));
+  }
+
+  .timeout-badge {
+    margin-left: auto;
+    font-size: 0.8rem;
+    color: var(--warn, #ffb84d);
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: minmax(300px, 1fr) minmax(400px, 2fr);
+    gap: 1rem;
+  }
+
+  @media (max-width: 720px) {
+    .grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .error {
+    color: #f87171;
+    margin: 0;
+    padding: 0.75rem;
+    background: rgba(248, 113, 113, 0.1);
+    border: 1px solid rgba(248, 113, 113, 0.3);
+    border-radius: 4px;
+  }
+</style>


### PR DESCRIPTION
## Summary

Hub-side counterpart to gateway **D-0b** (minion-ai #104, merged at \`872d9c47\`). Admin opts in to stepping for a session, watches the build-pipeline gates fire in real time, inspects each gate's state, and releases via **Continue** or **Skip-all**. Pairs with the new \`debug.setSteppedBuild\` / \`debug.stepContinue\` / \`debug.skipAll\` admin RPCs.

## What ships

| Component | Purpose |
|---|---|
| \`src/lib/state/debug/\` | Per-session runed store with ring buffer (cap 50), \`pushDebugStepEvent\`, \`pushDebugStepTimeout\`, \`setSessionSteppedBuildEnabled\` |
| \`gateway.svelte.ts\` (modified) | \`onDebugStepEvent\` dispatcher in the WS default branch (prefix-matched \`debug.step.*\`); 3 RPC helpers |
| \`StepView.svelte\` | 8-gate pipeline list — status icons (paused/fired/pending), per-gate Continue button, clickable to select |
| \`StepStateView.svelte\` | JSON state inspector for the selected gate event |
| \`/sessions/[sessionKey]/debug/+page.svelte\` | Full viewer route — stepping toggle, Skip-all, timeout badge, error surface, gateway connection state |

## How it flows

1. Admin navigates to \`/sessions/<key>/debug\`
2. Toggles "Stepped build ON" → calls \`debug.setSteppedBuild\` RPC
3. Sends a message in that session through any channel
4. Gateway pauses at gate 1 (\`agent_resolved\`) → emits \`debug.step.agent_resolved\` → hub WS dispatcher pushes into rune store → component renders the gate as ⏸ paused with state inspector
5. Admin clicks **Continue** → \`debug.stepContinue\` RPC → gateway advances to gate 2
6. Repeat for 5 gates (or 8 once the deferred 3 are wired in pi/section assembly)
7. **Skip all** → \`debug.skipAll\` RPC → release current pause + fire-through remaining gates without pausing for the rest of the turn

## Constraints

- **Admin-only**: gateway side rejects non-admin RPCs and won't broadcast \`debug.step.*\` events to non-admin scopes (already enforced in #104). The hub UI shows the toggle to anyone but RPCs will fail without admin scope.
- **Connection-gated**: toggle disabled when WS isn't connected; error surface explains failures.
- **No leak across turns**: gateway calls \`resetSessionStepping\` at turn-start so prior \`skipAll\` doesn't carry forward. The hub follows the gateway's lead — \`pausedStep\` updates per event.

## Test plan

- [x] \`bun run check\` — zero net-new errors (159→156, all pre-existing are paraglide codegen)
- [ ] Manual: deploy gateway with #104 + this hub, navigate to \`/sessions/<live-key>/debug\`, toggle ON, send a message, verify gate timeline renders + Continue button advances pipeline
- [ ] Manual: Skip-all releases current + fires-through; reload page mid-pause to confirm reconnect doesn't lose state

## Follow-ups

- D-0a-4: real \`eligiblePool\` on the \`pre_prompt_build_dispatched\` gate so the state inspector shows actual skill names (currently \`[]\`)
- D-0c-2 (or later): wire the 3 deferred gates (\`section_assembly_started\`, \`prompt_assembled\`, \`pre_prompt_build_handler\`) — they're already in the union + broadcast allowlist
- Future: per-agent settings toggle (current toggle is per-session; agent-level would need an agent setting + auto-apply to all sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)