### PR TITLE
feat(hub): stepped playback in Prompt tab Test (Phase D-0d)

### DIFF
--- a/src/lib/components/agents/AgentPromptSimulator.svelte
+++ b/src/lib/components/agents/AgentPromptSimulator.svelte
@@ -96,6 +96,17 @@
   /** 'sections' = per-section view, 'classic' = old aggregated view */
   let viewMode = $state<'sections' | 'classic'>('sections');
 
+  // ─── Phase D-0d: stepped Test playback ─────────────────────────────────
+  // Per-step status during animated playback after Test is clicked.
+  // 'pending' = not yet reached, 'loading' = currently processing,
+  // 'ok' = completed with content, 'missing' = completed but section produced
+  // no content. When `stepStatus` is empty (default), legacy non-animated
+  // rendering is used; the animator sets entries during runTest.
+  let stepStatus = $state<Record<string, 'pending' | 'loading' | 'ok' | 'missing'>>({});
+  let testPrompt = $state('Tell me about today\'s schedule.');
+  /** Per-step delay during animated playback. */
+  const STEP_ANIMATION_MS = 220;
+
   // ─── Pipeline steps ──────────────────────────────────────────────────────
 
   // Classic fallback steps when sections data is not available
@@ -149,26 +160,76 @@
     }
   }
 
+  function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
   async function runTest() {
     testing = true;
     error = null;
     report = null;
+    stepStatus = {};
+    activeStep = 0;
     try {
+      // Phase D-0d: fetch the full prompt preview, then animate the pipeline
+      // sidebar one step at a time so each step renders as if it were its
+      // own mini-prompt to an LLM. The data is real; the stepping is a
+      // client-side playback. A real-events upgrade is a future enhancement.
       const res = (await fetchPromptPreview(agentId)) as SystemPromptReport | null;
       report = res;
-      // Switch to sections view if sections data is available
       if (res?.sections && res.sections.length > 0) {
         viewMode = 'sections';
+      }
+
+      // Capture step list AFTER report is set so currentSteps reflects sections.
+      // Use a microtask to let derived currentSteps recompute.
+      await sleep(0);
+      const stepsToPlay = currentSteps;
+      // Mark all pending up front so the sidebar shows an explicit playback queue.
+      const initialStatus: Record<string, 'pending' | 'loading' | 'ok' | 'missing'> = {};
+      for (const s of stepsToPlay) initialStatus[s.id] = 'pending';
+      stepStatus = initialStatus;
+
+      // Walk steps sequentially: pending → loading (active) → ok/missing.
+      for (let i = 0; i < stepsToPlay.length; i += 1) {
+        const step = stepsToPlay[i];
+        if (!step) continue;
+        activeStep = i;
+        stepStatus = { ...stepStatus, [step.id]: 'loading' };
+        await sleep(STEP_ANIMATION_MS);
+        const hasContent =
+          step.chars === undefined ? true : (step.chars ?? 0) > 0;
+        stepStatus = {
+          ...stepStatus,
+          [step.id]: hasContent ? 'ok' : 'missing',
+        };
       }
     } catch (e) {
       error = (e as Error).message ?? 'Failed to generate prompt preview';
     } finally {
       testing = false;
-      activeStep = 0;
     }
   }
 
   // ─── Helpers ──────────────────────────────────────────────────────────────
+
+  function stepIcon(stepId: string): string {
+    const status = stepStatus[stepId];
+    if (!status) return '';
+    if (status === 'pending') return '○';
+    if (status === 'loading') return '⏳';
+    if (status === 'ok') return '✓';
+    return '×';
+  }
+
+  function stepStatusClass(stepId: string): string {
+    const status = stepStatus[stepId];
+    if (status === 'loading') return 'text-accent animate-pulse';
+    if (status === 'ok') return 'text-emerald-400';
+    if (status === 'missing') return 'text-rose-400';
+    if (status === 'pending') return 'text-foreground/30';
+    return '';
+  }
 
   function fmtChars(n: number): string {
     if (n >= 1000) return `${(n / 1000).toFixed(1)}k chars`;
@@ -346,6 +407,11 @@
                   : 'border-l-2 border-transparent text-muted hover:text-foreground hover:bg-white/[0.03]'}"
                 onclick={() => (activeStep = stepIdx)}
               >
+                {#if stepStatus[section.id]}
+                  <span class={`shrink-0 w-3 text-center text-[11px] font-mono ${stepStatusClass(section.id)}`}>
+                    {stepIcon(section.id)}
+                  </span>
+                {/if}
                 <span class="flex-1 min-w-0 text-[11px] truncate">{section.label}</span>
                 <span class="shrink-0 text-[9px] text-foreground/30 font-mono">{section.chars > 0 ? fmtChars(section.chars) : ''}</span>
               </button>
@@ -372,6 +438,11 @@
               {i + 1}
             </span>
             <span class="text-[11px] font-medium truncate">{step.label}</span>
+            {#if stepStatus[step.id]}
+              <span class={`shrink-0 ml-auto text-[11px] font-mono ${stepStatusClass(step.id)}`}>
+                {stepIcon(step.id)}
+              </span>
+            {/if}
           </button>
         {/each}
       </div>
@@ -379,11 +450,24 @@
 
     <!-- Action buttons -->
     <div class="shrink-0 px-3 py-2 border-t border-border space-y-1.5">
+      <!-- Phase D-0d: editable test prompt fed into the stepped playback -->
+      <label class="block">
+        <span class="block text-[9px] font-bold uppercase tracking-widest text-muted mb-1">
+          Test prompt
+        </span>
+        <textarea
+          bind:value={testPrompt}
+          rows="2"
+          class="w-full text-[11px] px-2 py-1.5 rounded border border-border bg-bg1 text-foreground placeholder:text-foreground/30 focus:outline-none focus:border-accent/60 resize-none font-mono"
+          placeholder="Enter a sample message…"
+          disabled={testing}
+        ></textarea>
+      </label>
       <button
         type="button"
         class="w-full text-[10px] font-semibold px-2 py-1.5 rounded border border-accent/40 text-accent hover:bg-accent/10 transition-colors cursor-pointer disabled:opacity-40"
         onclick={runTest}
-        disabled={testing || loading}
+        disabled={testing || loading || !testPrompt.trim()}
       >
         {testing ? m.prompt_generating() : m.prompt_test()}
       </button>


### PR DESCRIPTION
## Summary

Per request: \"the prompt debug step sequence should be in the PROMPT tab in each agent detail. When the user clicks Test, a sample prompt is selected or inserted and each step in order is rendered. The user can view the load progress for each step and its outputs as if each were its own mini-prompt to an llm.\"

This PR makes the existing Prompt tab Test button feel sequential. The data is the real \`prompt.preview\` response (no gateway changes); the stepping is a 220ms-per-step client-side playback that walks the pipeline sidebar one step at a time.

## What ships

- **Editable test prompt textarea** above the Test button, prefilled with a sample. Test button disabled when empty.
- **Per-step status** in both views (sections + classic):
  - ○ pending (gray) — not yet reached
  - ⏳ loading (accent + pulse) — currently activating
  - ✓ ok (emerald) — completed with content
  - × missing (rose) — completed but section produced no content
- **Sequential animator** in \`runTest()\`: fetches the full report, then walks \`currentSteps\` updating \`stepStatus\` + \`activeStep\` so the right-pane content reveals as each step activates.

## Why client-side animation (not real per-step events)

Per discussion: ship the UX now, real-events upgrade is a clean follow-up. The component contract (status enum + per-step \`activeStep\` advance) stays the same when we eventually wire gateway-side measured timing.

## What this does NOT do (yet)

- The textarea content isn't yet sent to the gateway as a real test message — \`prompt.preview\` doesn't accept a per-call message override. When the gateway grows that param, a one-line change here passes \`testPrompt\` along.
- No real timing data — every step gets the same 220ms playback delay. Real per-section timing requires gateway instrumentation.
- No section-output diff between runs (e.g. \"this skill was added/removed since last test\"). Future enhancement.

## Test plan

- [x] \`bun run check\` clean (156 errors, all pre-existing paraglide codegen)
- [ ] Manual: open agent detail → Prompt tab → click Test → verify pipeline sidebar animates with each step transitioning ○→⏳→✓ in order
- [ ] Manual: edit the prompt textarea, click Test again, verify re-runs without stale state
- [ ] Manual: verify a missing/empty section shows the × marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)