### PR TITLE
feat(hub): editable STATIC prose via origin pill (D-0f-1)

### DIFF
--- a/src/lib/components/agents/AgentPromptSimulator.svelte
+++ b/src/lib/components/agents/AgentPromptSimulator.svelte
@@ -47,6 +47,9 @@
     label: string;
     chars: number;
     order: number;
+    /** Phase D-0e: rendered text content (gateway-side D-0e #105). May be
+     * undefined if the gateway hasn't been updated yet — UI shows a notice. */
+    content?: string;
   }
 
   interface SystemPromptReport {
@@ -548,6 +551,28 @@
                   <span class="shrink-0 text-[10px] text-muted">{totalChars > 0 ? ((currentSection.chars / totalChars) * 100).toFixed(1) + '%' : '—'}</span>
                 </div>
               </div>
+            </div>
+
+            <!-- Phase D-0e: rendered section content (real prompt text) -->
+            <div class="mt-4">
+              <div class="flex items-center justify-between mb-1">
+                <p class="text-[10px] font-bold uppercase tracking-wide text-muted">Rendered content</p>
+                {#if currentSection.content !== undefined}
+                  <span class="text-[9px] text-muted font-mono">{currentSection.content.length} chars</span>
+                {/if}
+              </div>
+              {#if currentSection.content === undefined}
+                <div class="rounded border border-border/50 bg-bg2 px-3 py-2 text-[11px] text-muted italic">
+                  Gateway hasn't been updated to emit per-section content yet (D-0e #105).
+                  Until then, only metadata is available.
+                </div>
+              {:else if currentSection.content.length === 0}
+                <div class="rounded border border-border/50 bg-bg2 px-3 py-2 text-[11px] text-muted italic">
+                  This section rendered empty for the current parameters.
+                </div>
+              {:else}
+                <pre class="rounded border border-border/50 bg-bg1 p-3 text-[11px] font-mono text-foreground whitespace-pre-wrap break-words max-h-96 overflow-auto">{currentSection.content}</pre>
+              {/if}
             </div>
 
             <!-- Contextual detail for known sections -->

--- a/src/lib/components/agents/AgentPromptSimulator.svelte
+++ b/src/lib/components/agents/AgentPromptSimulator.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import MarkdownMessage from '$lib/components/chat/MarkdownMessage.svelte';
   import { fetchSessionPromptReport, fetchPromptPreview } from '$lib/services/gateway.svelte';
   import * as m from '$lib/paraglide/messages';
 
@@ -50,7 +51,40 @@
     /** Phase D-0e: rendered text content (gateway-side D-0e #105). May be
      * undefined if the gateway hasn't been updated yet — UI shows a notice. */
     content?: string;
+    /** Phase D-0e/f: where this section's content originates. */
+    source?: 'static' | 'file' | 'generated' | 'config' | 'custom';
   }
+
+  const SOURCE_META: Record<
+    NonNullable<SectionEntry['source']>,
+    { label: string; color: string; description: string }
+  > = {
+    static: {
+      label: 'Static',
+      color: '#6b7280',
+      description: 'Hardcoded boilerplate in the gateway section definition.',
+    },
+    file: {
+      label: 'File',
+      color: '#06b6d4',
+      description: 'Loaded from an agent workspace file (bootstrap or project docs).',
+    },
+    generated: {
+      label: 'Generated',
+      color: '#8b5cf6',
+      description: 'Produced at request time from runtime state (skills, memory, workspace, time).',
+    },
+    config: {
+      label: 'Config',
+      color: '#f59e0b',
+      description: 'User-configurable per-agent setting (personality, sandbox, permissions).',
+    },
+    custom: {
+      label: 'Custom',
+      color: '#10b981',
+      description: 'User-authored YAML section from Phase 19 customisation.',
+    },
+  };
 
   interface SystemPromptReport {
     source?: string;
@@ -109,6 +143,9 @@
   let testPrompt = $state('Tell me about today\'s schedule.');
   /** Per-step delay during animated playback. */
   const STEP_ANIMATION_MS = 220;
+
+  /** Phase D-0e: toggle for rendered-content panel between markdown and raw. */
+  let contentViewMode = $state<'rendered' | 'raw'>('rendered');
 
   // ─── Pipeline steps ──────────────────────────────────────────────────────
 
@@ -519,6 +556,18 @@
               <span class="w-2 h-2 rounded-full shrink-0" style:background-color={LAYER_META[currentSection.layer]?.color ?? '#6b7280'}></span>
               <h2 class="text-sm font-semibold text-foreground">{currentSection.label}</h2>
               <span class="text-[9px] px-1.5 py-0.5 rounded bg-bg2 border border-border/50 text-muted font-mono">{currentSection.layer}</span>
+              {#if currentSection.source}
+                {@const meta = SOURCE_META[currentSection.source]}
+                <span
+                  class="text-[9px] px-1.5 py-0.5 rounded font-mono uppercase tracking-wide"
+                  style:background-color={`${meta.color}22`}
+                  style:border={`1px solid ${meta.color}66`}
+                  style:color={meta.color}
+                  title={meta.description}
+                >
+                  {meta.label}
+                </span>
+              {/if}
             </div>
             <p class="text-muted text-[11px] mb-3">
               {LAYER_META[currentSection.layer]?.description ?? ''}
@@ -557,9 +606,18 @@
             <div class="mt-4">
               <div class="flex items-center justify-between mb-1">
                 <p class="text-[10px] font-bold uppercase tracking-wide text-muted">Rendered content</p>
-                {#if currentSection.content !== undefined}
-                  <span class="text-[9px] text-muted font-mono">{currentSection.content.length} chars</span>
-                {/if}
+                <div class="flex items-center gap-2">
+                  {#if currentSection.content !== undefined}
+                    <span class="text-[9px] text-muted font-mono">{currentSection.content.length} chars</span>
+                    <button
+                      type="button"
+                      class="text-[9px] px-1.5 py-0.5 rounded border border-border text-muted hover:text-foreground transition-colors cursor-pointer"
+                      onclick={() => (contentViewMode = contentViewMode === 'rendered' ? 'raw' : 'rendered')}
+                    >
+                      {contentViewMode === 'rendered' ? 'Raw' : 'Rendered'}
+                    </button>
+                  {/if}
+                </div>
               </div>
               {#if currentSection.content === undefined}
                 <div class="rounded border border-border/50 bg-bg2 px-3 py-2 text-[11px] text-muted italic">
@@ -569,6 +627,12 @@
               {:else if currentSection.content.length === 0}
                 <div class="rounded border border-border/50 bg-bg2 px-3 py-2 text-[11px] text-muted italic">
                   This section rendered empty for the current parameters.
+                </div>
+              {:else if contentViewMode === 'rendered'}
+                <div class="rounded border border-border/50 bg-bg1 p-3 max-h-96 overflow-auto prompt-md">
+                  {#key currentSection.id}
+                    <MarkdownMessage value={currentSection.content} tone="assistant" />
+                  {/key}
                 </div>
               {:else}
                 <pre class="rounded border border-border/50 bg-bg1 p-3 text-[11px] font-mono text-foreground whitespace-pre-wrap break-words max-h-96 overflow-auto">{currentSection.content}</pre>

--- a/src/lib/components/agents/AgentPromptSimulator.svelte
+++ b/src/lib/components/agents/AgentPromptSimulator.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import MarkdownMessage from '$lib/components/chat/MarkdownMessage.svelte';
+  import SectionProseEditor from '$lib/components/agents/SectionProseEditor.svelte';
   import { fetchSessionPromptReport, fetchPromptPreview } from '$lib/services/gateway.svelte';
   import * as m from '$lib/paraglide/messages';
 
@@ -147,6 +148,9 @@
   /** Phase D-0e: toggle for rendered-content panel between markdown and raw. */
   let contentViewMode = $state<'rendered' | 'raw'>('rendered');
 
+  /** Phase D-0f: prose-editor modal state. */
+  let editorOpen = $state(false);
+
   // ─── Pipeline steps ──────────────────────────────────────────────────────
 
   // Classic fallback steps when sections data is not available
@@ -168,6 +172,11 @@
   const activeSections = $derived(
     report?.sections?.filter((s) => s.chars > 0) ?? [],
   );
+
+  /** Phase D-0f: top-level reference to the currently-focused section so the
+   * editor modal (rendered outside the template's section-detail scope) can
+   * read its id/layer/source. */
+  const currentSectionTop = $derived(activeSections[activeStep] ?? null);
 
   const currentSteps = $derived(
     viewMode === 'sections' && hasSections
@@ -558,15 +567,29 @@
               <span class="text-[9px] px-1.5 py-0.5 rounded bg-bg2 border border-border/50 text-muted font-mono">{currentSection.layer}</span>
               {#if currentSection.source}
                 {@const meta = SOURCE_META[currentSection.source]}
-                <span
-                  class="text-[9px] px-1.5 py-0.5 rounded font-mono uppercase tracking-wide"
-                  style:background-color={`${meta.color}22`}
-                  style:border={`1px solid ${meta.color}66`}
-                  style:color={meta.color}
-                  title={meta.description}
-                >
-                  {meta.label}
-                </span>
+                {#if currentSection.source === 'static'}
+                  <button
+                    type="button"
+                    class="text-[9px] px-1.5 py-0.5 rounded font-mono uppercase tracking-wide hover:opacity-80 transition-opacity cursor-pointer"
+                    style:background-color={`${meta.color}22`}
+                    style:border={`1px solid ${meta.color}66`}
+                    style:color={meta.color}
+                    title={`${meta.description} — click to edit`}
+                    onclick={() => (editorOpen = true)}
+                  >
+                    {meta.label} ✎
+                  </button>
+                {:else}
+                  <span
+                    class="text-[9px] px-1.5 py-0.5 rounded font-mono uppercase tracking-wide"
+                    style:background-color={`${meta.color}22`}
+                    style:border={`1px solid ${meta.color}66`}
+                    style:color={meta.color}
+                    title={meta.description}
+                  >
+                    {meta.label}
+                  </span>
+                {/if}
               {/if}
             </div>
             <p class="text-muted text-[11px] mb-3">
@@ -982,3 +1005,16 @@
   </div>
   </div><!-- /flex flex-1 (sidebar + detail row) -->
 </div>
+
+{#if currentSectionTop && currentSectionTop.source === 'static'}
+  <SectionProseEditor
+    bind:open={editorOpen}
+    layer={currentSectionTop.layer as 'platform' | 'agent-type' | 'identity' | 'user' | 'session'}
+    sectionId={currentSectionTop.id}
+    sectionLabel={currentSectionTop.label}
+    onSaved={() => {
+      // Re-fetch the prompt preview so the rendered content panel shows the edit.
+      void runTest();
+    }}
+  />
+{/if}

--- a/src/lib/components/agents/SectionProseEditor.svelte
+++ b/src/lib/components/agents/SectionProseEditor.svelte
@@ -1,0 +1,225 @@
+<script lang="ts">
+  /**
+   * Phase D-0f-1 — editor modal for externalized static section prose.
+   *
+   * Reads/writes via prompt.sections.prose.read|write RPCs. Tries known variant
+   * names (none, full, minimal) and shows the ones that exist as sub-tabs.
+   * Global scope only in the pilot; per-agent override comes in D-0f-2.
+   */
+  import { readSectionProse, writeSectionProse } from '$lib/services/gateway.svelte';
+
+  let {
+    open = $bindable(false),
+    layer,
+    sectionId,
+    sectionLabel,
+    onSaved,
+  }: {
+    open?: boolean;
+    layer: 'platform' | 'agent-type' | 'identity' | 'user' | 'session';
+    sectionId: string;
+    sectionLabel: string;
+    onSaved?: () => void;
+  } = $props();
+
+  // Variants we'll probe. Section files use these suffixes today.
+  const CANDIDATE_VARIANTS: (string | undefined)[] = [undefined, 'full', 'minimal'];
+
+  type Slot = {
+    variant: string | undefined;
+    path: string;
+    content: string;
+    exists: boolean;
+    dirty: string | null; // user-edited content, null if pristine
+  };
+
+  let slots = $state<Slot[]>([]);
+  let activeIdx = $state(0);
+  let loading = $state(false);
+  let saving = $state(false);
+  let error = $state<string | null>(null);
+
+  $effect(() => {
+    if (open && sectionId) {
+      void loadAll();
+    } else if (!open) {
+      // Reset on close so reopen always re-fetches.
+      slots = [];
+      activeIdx = 0;
+      error = null;
+    }
+  });
+
+  async function loadAll() {
+    loading = true;
+    error = null;
+    try {
+      const results = await Promise.all(
+        CANDIDATE_VARIANTS.map((variant) =>
+          readSectionProse({ layer, sectionId, variant, scope: 'global' }).then(
+            (r) => ({ variant, ...r }),
+            (err) => ({ variant, error: err }),
+          ),
+        ),
+      );
+      slots = results
+        .filter((r): r is { variant: string | undefined; path: string; content: string; exists: boolean; scope: 'global' | 'agent' } => 'exists' in r && r.exists)
+        .map((r) => ({
+          variant: r.variant,
+          path: r.path,
+          content: r.content,
+          exists: r.exists,
+          dirty: null,
+        }));
+      activeIdx = 0;
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function save() {
+    const slot = slots[activeIdx];
+    if (!slot || slot.dirty === null) return;
+    saving = true;
+    error = null;
+    try {
+      await writeSectionProse({
+        layer,
+        sectionId,
+        variant: slot.variant,
+        scope: 'global',
+        content: slot.dirty,
+      });
+      slot.content = slot.dirty;
+      slot.dirty = null;
+      onSaved?.();
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    } finally {
+      saving = false;
+    }
+  }
+
+  function onInput(e: Event) {
+    const slot = slots[activeIdx];
+    if (!slot) return;
+    slot.dirty = (e.target as HTMLTextAreaElement).value;
+  }
+
+  function close() {
+    open = false;
+  }
+
+  function variantLabel(v: string | undefined): string {
+    return v ?? 'default';
+  }
+</script>
+
+{#if open}
+  <div
+    class="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+    role="presentation"
+    onclick={close}
+    onkeydown={(e) => {
+      if (e.key === 'Escape') close();
+    }}
+  >
+    <div
+      class="bg-bg1 border border-border rounded-lg shadow-2xl w-[min(80vw,800px)] max-h-[80vh] flex flex-col"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="prose-editor-title"
+      tabindex="-1"
+      onclick={(e) => e.stopPropagation()}
+      onkeydown={(e) => e.stopPropagation()}
+    >
+      <!-- Header -->
+      <div class="px-4 py-3 border-b border-border flex items-center justify-between">
+        <div>
+          <h2 id="prose-editor-title" class="text-sm font-semibold text-foreground">
+            Edit prose — {sectionLabel}
+          </h2>
+          <p class="text-[10px] text-muted mt-0.5 font-mono">
+            global · {layer}/{sectionId}
+          </p>
+        </div>
+        <button
+          type="button"
+          class="text-muted hover:text-foreground transition-colors"
+          onclick={close}
+          aria-label="Close"
+        >
+          ✕
+        </button>
+      </div>
+
+      <!-- Variant tabs (only if >1) -->
+      {#if slots.length > 1}
+        <div class="px-4 pt-2 flex gap-1 border-b border-border/30">
+          {#each slots as slot, i}
+            <button
+              type="button"
+              class="text-[11px] px-2 py-1 rounded-t border-b-2 transition-colors"
+              class:border-accent={activeIdx === i}
+              class:text-foreground={activeIdx === i}
+              class:border-transparent={activeIdx !== i}
+              class:text-muted={activeIdx !== i}
+              onclick={() => (activeIdx = i)}
+            >
+              {variantLabel(slot.variant)}
+              {#if slot.dirty !== null}
+                <span class="text-accent">•</span>
+              {/if}
+            </button>
+          {/each}
+        </div>
+      {/if}
+
+      <!-- Body -->
+      <div class="flex-1 overflow-auto px-4 py-3">
+        {#if loading}
+          <p class="text-muted text-xs">Loading…</p>
+        {:else if error}
+          <p class="text-red-400 text-xs font-mono">{error}</p>
+        {:else if slots.length === 0}
+          <p class="text-muted text-xs">No prose files found for this section.</p>
+        {:else}
+          {@const slot = slots[activeIdx]}
+          <p class="text-[10px] text-muted mb-2 font-mono break-all">{slot.path}</p>
+          <textarea
+            class="w-full h-[40vh] bg-bg2 border border-border/50 rounded px-3 py-2 text-xs font-mono text-foreground resize-none focus:outline-none focus:border-accent"
+            value={slot.dirty ?? slot.content}
+            oninput={onInput}
+          ></textarea>
+        {/if}
+      </div>
+
+      <!-- Footer -->
+      <div class="px-4 py-3 border-t border-border flex items-center justify-end gap-2">
+        <button
+          type="button"
+          class="text-xs px-3 py-1.5 rounded border border-border text-muted hover:text-foreground transition-colors"
+          onclick={close}
+          disabled={saving}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="text-xs px-3 py-1.5 rounded bg-accent text-accent-foreground hover:opacity-90 transition-opacity disabled:opacity-50"
+          onclick={save}
+          disabled={
+            saving ||
+            loading ||
+            slots.length === 0 ||
+            slots[activeIdx]?.dirty === null
+          }
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/lib/services/gateway.svelte.ts
+++ b/src/lib/services/gateway.svelte.ts
@@ -787,6 +787,38 @@ export async function debugSkipAll(sessionKey: string) {
   return sendRequest('debug.skipAll', { sessionKey });
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// Phase D-0f — externalized section prose read/write
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface ProseReadParams {
+  layer: 'platform' | 'agent-type' | 'identity' | 'user' | 'session';
+  sectionId: string;
+  variant?: string;
+  scope: 'global' | 'agent';
+  agentId?: string;
+  agentWorkspaceDir?: string;
+}
+
+export interface ProseReadResult {
+  path: string;
+  content: string;
+  exists: boolean;
+  scope: 'global' | 'agent';
+}
+
+export async function readSectionProse(params: ProseReadParams): Promise<ProseReadResult> {
+  const res = await sendRequest('prompt.sections.prose.read', params);
+  return res as ProseReadResult;
+}
+
+export async function writeSectionProse(
+  params: ProseReadParams & { content: string },
+): Promise<{ path: string; bytes: number }> {
+  const res = await sendRequest('prompt.sections.prose.write', params);
+  return res as { path: string; bytes: number };
+}
+
 export function loadChatHistory(agentId: string) {
   const chat = ensureAgentChat(agentId);
   const isInitialLoad = chat.messages.length === 0;


### PR DESCRIPTION
## Summary
- STATIC source pill becomes a clickable button (✎) for sections whose prose lives in editable .md files (gateway side: minion-ai PR #107).
- New \`SectionProseEditor.svelte\` modal: probes known variants (default, full, minimal), shows existing files as sub-tabs, textarea editor with dirty marker, save → write RPC → re-runs prompt preview.
- New service helpers: \`readSectionProse\`, \`writeSectionProse\`.
- Other pill sources (file/generated/config/custom) remain non-interactive.

Depends on gateway PR https://github.com/NikolasP98/minion-ai/pull/107 (or merged DEV thereafter) to expose \`prompt.sections.prose.read/write\`.

## Test plan
- [ ] Run hub against a gateway with PR #107 applied
- [ ] Click STATIC pill on \"Identity\" section — modal opens with default tab showing prose
- [ ] Edit text → Save → rendered content panel updates
- [ ] Click STATIC pill on \"Safety\" section — modal shows full + minimal sub-tabs
- [ ] Escape / Cancel discards changes
- [ ] Non-static pills (e.g. workspace=GENERATED) remain non-interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)