### PR TITLE
fix(prompt-ui): backfill section content for legacy session reports

### DIFF
--- a/src/lib/components/agents/AgentPromptSimulator.svelte
+++ b/src/lib/components/agents/AgentPromptSimulator.svelte
@@ -202,6 +202,31 @@
       } | null;
       const first = res?.sessions?.[0];
       report = first?.contextWeight ?? null;
+      // Stored contextWeight reports captured before D-0e #105 don't carry
+      // per-section `content`. Backfill from a fresh prompt.preview so the
+      // viewer panel works for legacy sessions without forcing the operator
+      // to hit Test. Runtime stats (chars/order/tokens) stay from the stored
+      // report; only content/source are merged in by id.
+      if (report?.sections && report.sections.some((s) => s.content === undefined)) {
+        try {
+          const fresh = (await fetchPromptPreview(agentId)) as SystemPromptReport | null;
+          if (fresh?.sections) {
+            const freshById = new Map(fresh.sections.map((s) => [s.id, s]));
+            report = {
+              ...report,
+              sections: report.sections.map((s) => {
+                if (s.content !== undefined) return s;
+                const live = freshById.get(s.id);
+                return live
+                  ? { ...s, content: live.content, source: s.source ?? live.source }
+                  : s;
+              }),
+            };
+          }
+        } catch (e) {
+          console.warn('[prompt] content backfill failed:', e);
+        }
+      }
     } catch (e) {
       error = (e as Error).message ?? 'Failed to load prompt report';
     } finally {


### PR DESCRIPTION
## Summary
- Stored `sessions.usage.contextWeight` reports captured before D-0e #105 lack per-section `content`, so the Prompt tab's right panel shows the "Gateway hasn't been updated" empty state for legacy sessions even though the live gateway already emits content.
- Fix: in `AgentPromptSimulator.loadReport`, when any section lacks `content`, lazily call `prompt.preview` and merge `content`/`source` in by section id. Runtime stats from the stored report are untouched.

## Behaviour
| Case | Before | After |
|---|---|---|
| Session ran after D-0e | Content visible | Unchanged |
| Session ran before D-0e | "Gateway hasn't been updated" notice | Content backfilled from live render |
| Gateway truly missing content (very old prod build) | Same notice | Same notice (fresh call also returns no content → no-op) |

## Test plan
- [ ] Open agent → Prompt tab on a session that last ran before today
- [ ] Verify each section now shows rendered content + Raw/Rendered toggle
- [ ] Confirm chars/order/weight cards still match the stored values (no drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)