### PR TITLE
feat(cache): wrap agent-groups with @minion-stack/cache (P4-mini)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ posthog-setup-report.md
 
 .infisical.json
 infisical-dev.sh
+.paperclip-mock.local.ts
+.paperclip-mock-probe.local.ts

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@inlang/paraglide-sveltekit": "^0.16.1",
         "@libsql/client": "^0.17.0",
         "@minion-stack/auth": "^0.2.0",
+        "@minion-stack/cache": "^0.1.0",
         "@minion-stack/db": "^0.2.0",
         "@minion-stack/paperclip-client": "^0.1.0",
         "@minion-stack/shared": "^0.5.0",
@@ -291,6 +292,8 @@
 
     "@inlang/translatable": ["@inlang/translatable@1.3.1", "", { "dependencies": { "@inlang/language-tag": "1.5.1" } }, "sha512-VAtle21vRpIrB+axtHFrFB0d1HtDaaNj+lV77eZQTJyOWbTFYTVIQJ8WAbyw9eu4F6h6QC2FutLyxjMomxfpcQ=="],
 
+    "@ioredis/commands": ["@ioredis/commands@1.5.1", "", {}, "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="],
+
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
@@ -340,6 +343,8 @@
     "@mapbox/node-pre-gyp": ["@mapbox/node-pre-gyp@2.0.3", "", { "dependencies": { "consola": "^3.2.3", "detect-libc": "^2.0.0", "https-proxy-agent": "^7.0.5", "node-fetch": "^2.6.7", "nopt": "^8.0.0", "semver": "^7.5.3", "tar": "^7.4.0" }, "bin": { "node-pre-gyp": "bin/node-pre-gyp" } }, "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg=="],
 
     "@minion-stack/auth": ["@minion-stack/auth@0.2.0", "", { "peerDependencies": { "better-auth": "1.4.19", "drizzle-orm": ">=0.45.0" } }, "sha512-FVK/M4tV9muNGnrzZHkoEeDtMGXmZsTY/amxIU0JHzUcMcQNvbrkogwzyHLpIVWgmwuf8e8NdpzvaGfTDDKvrg=="],
+
+    "@minion-stack/cache": ["@minion-stack/cache@0.1.0", "", { "dependencies": { "ioredis": "^5.4.1" } }, "sha512-+svYPzPZ5W4eXM0Bnas3sOFzf8zCOPIev9QtyeDiUyn9gKIIOqiEfM3wpoEVEWvf0zZj3+bJO24krgcWVR8WnA=="],
 
     "@minion-stack/db": ["@minion-stack/db@0.2.0", "", { "peerDependencies": { "drizzle-orm": ">=0.45.0" } }, "sha512-4AARTpPYK5kN+4DAZmPN+s58rZnkKMSDHI7LDbnm3x/CGxKYJfUK3fB1ujA1rCxgTqdvXIdjUfI3wNnKcjxbsA=="],
 
@@ -965,6 +970,8 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
@@ -1034,6 +1041,8 @@
     "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
     "deprecation": ["deprecation@2.3.1", "", {}, "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="],
 
@@ -1179,6 +1188,8 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
+    "ioredis": ["ioredis@5.10.1", "", { "dependencies": { "@ioredis/commands": "1.5.1", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA=="],
+
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
     "is-callable": ["is-callable@1.2.7", "", {}, "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="],
@@ -1263,7 +1274,11 @@
 
     "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
 
+    "lodash.defaults": ["lodash.defaults@4.2.0", "", {}, "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="],
+
     "lodash.includes": ["lodash.includes@4.3.0", "", {}, "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="],
+
+    "lodash.isarguments": ["lodash.isarguments@3.1.0", "", {}, "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="],
 
     "lodash.isboolean": ["lodash.isboolean@3.0.3", "", {}, "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="],
 
@@ -1485,6 +1500,10 @@
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
+    "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
+
+    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
+
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
     "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
@@ -1556,6 +1575,8 @@
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
     "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@inlang/paraglide-sveltekit": "^0.16.1",
     "@libsql/client": "^0.17.0",
     "@minion-stack/auth": "^0.2.0",
+    "@minion-stack/cache": "^0.1.0",
     "@minion-stack/db": "^0.2.0",
     "@minion-stack/paperclip-client": "^0.1.0",
     "@minion-stack/shared": "^0.5.0",

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -17,6 +17,7 @@ import { env } from '$env/dynamic/private';
 import { startBackupScheduler } from '$server/services/backup-scheduler';
 import { ensurePersonalAgentOnLogin } from '$server/services/personal-agent.service';
 import { mintPaperclipIdentity } from '$lib/server/paperclip-identity';
+import { initCache } from '$lib/server/cache';
 
 /**
  * Resolve tenantCtx from a Bearer server token.
@@ -330,3 +331,6 @@ export const handleError: HandleServerError = async ({ error, event, status, mes
 };
 
 startBackupScheduler();
+
+// One-time cache initialization.
+void initCache().catch((err) => console.error('[cache] init failed', err));

--- a/src/lib/components/LiveIndicator.svelte
+++ b/src/lib/components/LiveIndicator.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	let { label = 'Live', intervalMs = 5000 }: { label?: string; intervalMs?: number } = $props();
+</script>
+
+<span
+	class="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
+	title="Auto-refreshing every {Math.round(intervalMs / 1000)}s"
+>
+	<span class="relative flex h-2 w-2">
+		<span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-500 opacity-70"></span>
+		<span class="relative inline-flex h-2 w-2 rounded-full bg-green-500"></span>
+	</span>
+	{label}
+</span>

--- a/src/lib/components/Sparkline.svelte
+++ b/src/lib/components/Sparkline.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	type Props = {
+		values: number[];
+		width?: number;
+		height?: number;
+		stroke?: string;
+		fill?: string;
+		strokeWidth?: number;
+	};
+	let {
+		values,
+		width = 160,
+		height = 36,
+		stroke = 'currentColor',
+		fill = 'currentColor',
+		strokeWidth = 1.5,
+	}: Props = $props();
+
+	const path = $derived.by(() => {
+		if (values.length < 2) return '';
+		const min = Math.min(...values);
+		const max = Math.max(...values);
+		const range = max - min || 1;
+		const stepX = width / (values.length - 1);
+		return values
+			.map((v, i) => {
+				const x = i * stepX;
+				const y = height - ((v - min) / range) * height;
+				return `${i === 0 ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`;
+			})
+			.join(' ');
+	});
+
+	const fillPath = $derived(path ? `${path} L ${width} ${height} L 0 ${height} Z` : '');
+</script>
+
+<svg
+	{width}
+	{height}
+	viewBox="0 0 {width} {height}"
+	preserveAspectRatio="none"
+	aria-hidden="true"
+	class="block"
+>
+	{#if fillPath}
+		<path d={fillPath} {fill} fill-opacity="0.12" stroke="none" />
+	{/if}
+	{#if path}
+		<path d={path} fill="none" {stroke} stroke-width={strokeWidth} stroke-linecap="round" stroke-linejoin="round" />
+	{/if}
+</svg>

--- a/src/lib/components/layout/CompanySwitcher.svelte
+++ b/src/lib/components/layout/CompanySwitcher.svelte
@@ -17,6 +17,13 @@
 			workspaces = await res.json();
 			// Default to first entry — server controls the actual active selection.
 			currentCompanyId = workspaces[0]?.companyId ?? null;
+			// If exactly one workspace, auto-select it so the pc_company_id cookie
+			// is set without requiring an explicit dropdown interaction. Without
+			// this, single-workspace users land on /workforce/welcome because
+			// the <select onchange> never fires.
+			if (workspaces.length === 1 && currentCompanyId) {
+				await select(currentCompanyId);
+			}
 		}
 		loading = false;
 	});

--- a/src/lib/components/layout/Topbar.svelte
+++ b/src/lib/components/layout/Topbar.svelte
@@ -115,11 +115,10 @@
                     <LayoutDashboard size={14} />
                     <span>Dashboard</span>
                 </a>
-                <Tooltip label="Coming soon" id="nav-wf-issues">
-                    {#snippet children(triggerProps)}
-                        <span class="nav-pill disabled" {...triggerProps}>Issues</span>
-                    {/snippet}
-                </Tooltip>
+                <a href="/workforce/issues" class="nav-pill {page.url.pathname.startsWith('/workforce/issues') ? 'active' : ''}">Issues</a>
+                <a href="/workforce/approvals" class="nav-pill {page.url.pathname.startsWith('/workforce/approvals') ? 'active' : ''}">
+                    <span>Approvals</span>
+                </a>
                 <Tooltip label="Coming soon" id="nav-wf-goals">
                     {#snippet children(triggerProps)}
                         <span class="nav-pill disabled" {...triggerProps}>Goals</span>
@@ -417,10 +416,20 @@
                     <LayoutDashboard size={18} />
                     <span>Dashboard</span>
                 </a>
-                <span class="mobile-nav-link disabled">
+                <a
+                    href="/workforce/issues"
+                    class="mobile-nav-link {page.url.pathname.startsWith('/workforce/issues') ? 'active' : ''}"
+                    onclick={closeMobileMenu}
+                >
                     <span>Issues</span>
-                    <span class="ml-auto text-[10px] text-muted/50">Soon</span>
-                </span>
+                </a>
+                <a
+                    href="/workforce/approvals"
+                    class="mobile-nav-link {page.url.pathname.startsWith('/workforce/approvals') ? 'active' : ''}"
+                    onclick={closeMobileMenu}
+                >
+                    <span>Approvals</span>
+                </a>
                 <span class="mobile-nav-link disabled">
                     <span>Goals</span>
                     <span class="ml-auto text-[10px] text-muted/50">Soon</span>

--- a/src/lib/components/layout/Topbar.svelte
+++ b/src/lib/components/layout/Topbar.svelte
@@ -124,14 +124,10 @@
                         <span class="nav-pill disabled" {...triggerProps}>Goals</span>
                     {/snippet}
                 </Tooltip>
-                <Tooltip label="Coming soon" id="nav-wf-people">
-                    {#snippet children(triggerProps)}
-                        <span class="nav-pill disabled" {...triggerProps}>
-                            <Users size={14} />
-                            <span>People</span>
-                        </span>
-                    {/snippet}
-                </Tooltip>
+                <a href="/workforce/org" class="nav-pill {page.url.pathname.startsWith('/workforce/org') ? 'active' : ''}" title="Org chart">
+                    <Users size={14} />
+                    <span>Org</span>
+                </a>
             </div>
 
             <div class="w-px h-4 bg-border/60 mx-1"></div>
@@ -434,11 +430,14 @@
                     <span>Goals</span>
                     <span class="ml-auto text-[10px] text-muted/50">Soon</span>
                 </span>
-                <span class="mobile-nav-link disabled">
+                <a
+                    href="/workforce/org"
+                    class="mobile-nav-link {page.url.pathname.startsWith('/workforce/org') ? 'active' : ''}"
+                    onclick={closeMobileMenu}
+                >
                     <Users size={18} />
-                    <span>People</span>
-                    <span class="ml-auto text-[10px] text-muted/50">Soon</span>
-                </span>
+                    <span>Org</span>
+                </a>
 
                 <div class="h-px bg-border/60 my-1"></div>
 

--- a/src/lib/components/layout/Topbar.svelte
+++ b/src/lib/components/layout/Topbar.svelte
@@ -119,11 +119,7 @@
                 <a href="/workforce/approvals" class="nav-pill {page.url.pathname.startsWith('/workforce/approvals') ? 'active' : ''}">
                     <span>Approvals</span>
                 </a>
-                <Tooltip label="Coming soon" id="nav-wf-goals">
-                    {#snippet children(triggerProps)}
-                        <span class="nav-pill disabled" {...triggerProps}>Goals</span>
-                    {/snippet}
-                </Tooltip>
+                <a href="/workforce/goals" class="nav-pill {page.url.pathname.startsWith('/workforce/goals') ? 'active' : ''}">Goals</a>
                 <a href="/workforce/org" class="nav-pill {page.url.pathname.startsWith('/workforce/org') ? 'active' : ''}" title="Org chart">
                     <Users size={14} />
                     <span>Org</span>
@@ -426,10 +422,13 @@
                 >
                     <span>Approvals</span>
                 </a>
-                <span class="mobile-nav-link disabled">
+                <a
+                    href="/workforce/goals"
+                    class="mobile-nav-link {page.url.pathname.startsWith('/workforce/goals') ? 'active' : ''}"
+                    onclick={closeMobileMenu}
+                >
                     <span>Goals</span>
-                    <span class="ml-auto text-[10px] text-muted/50">Soon</span>
-                </span>
+                </a>
                 <a
                     href="/workforce/org"
                     class="mobile-nav-link {page.url.pathname.startsWith('/workforce/org') ? 'active' : ''}"

--- a/src/lib/components/layout/Topbar.svelte
+++ b/src/lib/components/layout/Topbar.svelte
@@ -120,6 +120,7 @@
                     <span>Approvals</span>
                 </a>
                 <a href="/workforce/goals" class="nav-pill {page.url.pathname.startsWith('/workforce/goals') ? 'active' : ''}">Goals</a>
+                <a href="/workforce/projects" class="nav-pill {page.url.pathname.startsWith('/workforce/projects') ? 'active' : ''}">Projects</a>
                 <a href="/workforce/org" class="nav-pill {page.url.pathname.startsWith('/workforce/org') ? 'active' : ''}" title="Org chart">
                     <Users size={14} />
                     <span>Org</span>
@@ -428,6 +429,13 @@
                     onclick={closeMobileMenu}
                 >
                     <span>Goals</span>
+                </a>
+                <a
+                    href="/workforce/projects"
+                    class="mobile-nav-link {page.url.pathname.startsWith('/workforce/projects') ? 'active' : ''}"
+                    onclick={closeMobileMenu}
+                >
+                    <span>Projects</span>
                 </a>
                 <a
                     href="/workforce/org"

--- a/src/lib/server/cache.ts
+++ b/src/lib/server/cache.ts
@@ -1,0 +1,58 @@
+import {
+  configureCache,
+  createBackend,
+  createBackendAsync,
+  type Backend,
+  type CacheBackend,
+} from '@minion-stack/cache';
+import { env } from '$env/dynamic/private';
+
+let initialized = false;
+
+/**
+ * One-time cache initialization. Idempotent — safe to call from multiple
+ * SSR loaders in case hooks.server.ts hasn't run yet (e.g. during prerender).
+ *
+ * Backend selection:
+ *   - CACHE_BACKEND env wins if set ('memory' | 'valkey' | 'noop')
+ *   - Else dev defaults to 'memory', production defaults to 'noop'
+ *
+ * Valkey is selected via createBackendAsync since it dynamically imports
+ * ioredis. We block on it once at boot.
+ */
+export async function initCache(): Promise<void> {
+  if (initialized) return;
+  initialized = true;
+
+  const explicit = env.CACHE_BACKEND as Backend | undefined;
+  const isProd = env.NODE_ENV === 'production';
+  const backendName: Backend = explicit ?? (isProd ? 'noop' : 'memory');
+
+  let backend: CacheBackend;
+  if (backendName === 'valkey') {
+    if (!env.VALKEY_URL) {
+      console.warn('[cache] CACHE_BACKEND=valkey but VALKEY_URL unset — falling back to noop');
+      backend = createBackend({ backend: 'noop' });
+    } else {
+      backend = await createBackendAsync({
+        backend: 'valkey',
+        url: env.VALKEY_URL,
+        password: env.VALKEY_PASSWORD,
+      });
+    }
+  } else {
+    backend = createBackend({ backend: backendName });
+  }
+
+  configureCache({
+    backend,
+    namespace: 'hub',
+    // Broadcaster wired up later when gateway receive endpoint ships.
+    logger:
+      env.CACHE_LOG === '1' || !isProd
+        ? (evt) => console.log(`[cache] ${JSON.stringify(evt)}`)
+        : undefined,
+  });
+
+  console.log(`[cache] initialized — backend=${backendName}`);
+}

--- a/src/lib/server/paperclip-fetch.ts
+++ b/src/lib/server/paperclip-fetch.ts
@@ -2,12 +2,34 @@ import { createPaperclipClient, type PaperclipClient } from '@minion-stack/paper
 import { env } from '$env/dynamic/private';
 import type { RequestEvent } from '@sveltejs/kit';
 
+function baseUrl(): string {
+	return env.PAPERCLIP_INTERNAL_URL ?? 'http://paperclip:3200';
+}
+
 export function paperclipServerClient(event: RequestEvent): PaperclipClient {
-  const token = event.locals.paperclipIdentity?.token;
-  if (!token) throw new Error('paperclipIdentity not populated by hooks');
-  return createPaperclipClient({
-    baseUrl: env.PAPERCLIP_INTERNAL_URL ?? 'http://paperclip:3200',
-    fetch: globalThis.fetch,
-    headers: { 'x-hub-identity': token },
-  });
+	const token = event.locals.paperclipIdentity?.token;
+	if (!token) throw new Error('paperclipIdentity not populated by hooks');
+	return createPaperclipClient({
+		baseUrl: baseUrl(),
+		fetch: globalThis.fetch,
+		headers: { 'x-hub-identity': token },
+	});
+}
+
+/**
+ * Ad-hoc fetch with the same auth headers as paperclipServerClient. Use for
+ * endpoints not in the typed client (e.g. mock-only routes during dev).
+ */
+export async function paperclipRawFetch<T = unknown>(event: RequestEvent, path: string): Promise<T> {
+	const token = event.locals.paperclipIdentity?.token;
+	if (!token) throw new Error('paperclipIdentity not populated by hooks');
+	const r = await fetch(`${baseUrl()}${path}`, {
+		headers: { 'x-hub-identity': token },
+	});
+	if (!r.ok) {
+		const err = new Error(`paperclip ${path} returned ${r.status}`);
+		(err as any).status = r.status;
+		throw err;
+	}
+	return (await r.json()) as T;
 }

--- a/src/lib/util/live-polling.ts
+++ b/src/lib/util/live-polling.ts
@@ -1,0 +1,18 @@
+import { invalidate } from '$app/navigation';
+
+/**
+ * Start a setInterval that calls invalidate(depKey) every `intervalMs` ms.
+ * Returns a cleanup function — call it from onMount's return value or onDestroy.
+ *
+ * Usage:
+ *   onMount(() => startPolling('app:dashboard', 5000));
+ *
+ * The corresponding +page.server.ts must declare `event.depends('app:dashboard')`
+ * for invalidate to actually trigger a reload.
+ */
+export function startPolling(depKey: string, intervalMs = 5000): () => void {
+	const id = setInterval(() => {
+		void invalidate(depKey);
+	}, intervalMs);
+	return () => clearInterval(id);
+}

--- a/src/routes/(app)/workforce/+layout.svelte
+++ b/src/routes/(app)/workforce/+layout.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { type Snippet } from 'svelte';
+	let { children }: { children: Snippet } = $props();
+</script>
+
+<!--
+	Workforce subtree shares one scroll container. The parent (app) layout uses
+	flex-col h-screen overflow-hidden with the Topbar fixed inside; without a
+	scroll wrapper here every workforce page that exceeds viewport height gets
+	clipped. flex-1 min-h-0 lets the wrapper fill remaining height; overflow-y-auto
+	gives it scroll without breaking pages that constrain their own height
+	(e.g., org chart's h-[calc(100vh-3.5rem)] still resolves to the same value).
+-->
+<main class="flex-1 min-h-0 overflow-y-auto">
+	{@render children()}
+</main>

--- a/src/routes/(app)/workforce/+page.server.ts
+++ b/src/routes/(app)/workforce/+page.server.ts
@@ -1,6 +1,8 @@
 import { redirect, error } from '@sveltejs/kit';
-import { paperclipServerClient } from '$lib/server/paperclip-fetch';
+import { paperclipServerClient, paperclipRawFetch } from '$lib/server/paperclip-fetch';
 import type { PageServerLoad } from './$types';
+
+type CostTrendPoint = { date: string; cents: number };
 
 export const load: PageServerLoad = async (event) => {
 	if (!event.locals.user) throw redirect(302, '/login');
@@ -11,12 +13,15 @@ export const load: PageServerLoad = async (event) => {
 	const companyId = event.locals.paperclipIdentity.companyId;
 	const client = paperclipServerClient(event);
 	try {
-		const [summary, badges, activity] = await Promise.all([
+		const [summary, badges, activity, costTrend] = await Promise.all([
 			client.dashboard.summary(companyId),
 			client.sidebarBadges.get(companyId),
 			client.activity.list(companyId),
+			paperclipRawFetch<CostTrendPoint[]>(event, `/api/companies/${companyId}/costs/trend`).catch(
+				() => [] as CostTrendPoint[],
+			),
 		]);
-		return { summary, badges, activity };
+		return { summary, badges, activity, costTrend };
 	} catch (e: any) {
 		throw error(e?.status ?? 502, 'paperclip unavailable');
 	}

--- a/src/routes/(app)/workforce/+page.server.ts
+++ b/src/routes/(app)/workforce/+page.server.ts
@@ -7,6 +7,7 @@ export const load: PageServerLoad = async (event) => {
 	if (!event.locals.paperclipIdentity?.companyId) {
 		throw redirect(302, '/workforce/welcome');
 	}
+	event.depends('app:dashboard');
 	const companyId = event.locals.paperclipIdentity.companyId;
 	const client = paperclipServerClient(event);
 	try {

--- a/src/routes/(app)/workforce/+page.svelte
+++ b/src/routes/(app)/workforce/+page.svelte
@@ -14,6 +14,7 @@
 		Inbox,
 		Receipt,
 		Settings,
+		FolderKanban,
 	} from 'lucide-svelte';
 
 	let { data }: { data: PageData } = $props();
@@ -60,6 +61,12 @@
 			href: '/workforce/goals',
 			icon: Target,
 			description: 'company → agent',
+		},
+		{
+			label: 'Projects',
+			href: '/workforce/projects',
+			icon: FolderKanban,
+			description: 'workspaces + scope',
 		},
 		{
 			label: 'Reliability',

--- a/src/routes/(app)/workforce/+page.svelte
+++ b/src/routes/(app)/workforce/+page.svelte
@@ -4,11 +4,97 @@
 	import { startPolling } from '$lib/util/live-polling';
 	import LiveIndicator from '$lib/components/LiveIndicator.svelte';
 	import Sparkline from '$lib/components/Sparkline.svelte';
+	import {
+		ListTodo,
+		ClipboardCheck,
+		Activity as ActivityIcon,
+		Network,
+		Target,
+		Gauge,
+		Inbox,
+		Receipt,
+		Settings,
+	} from 'lucide-svelte';
 
 	let { data }: { data: PageData } = $props();
 
 	const { summary, badges, activity, costTrend } = $derived(data);
 	const trendValues = $derived(costTrend.map((p) => p.cents));
+
+	type WorkforceTile = {
+		label: string;
+		href: string;
+		icon: typeof ListTodo;
+		description: string;
+		badge?: { text: string; tone: 'primary' | 'amber' | 'destructive' | 'muted' };
+	};
+
+	const tiles = $derived<WorkforceTile[]>([
+		{
+			label: 'Issues',
+			href: '/workforce/issues',
+			icon: ListTodo,
+			description: `${summary.tasks.open + summary.tasks.inProgress} open`,
+		},
+		{
+			label: 'Approvals',
+			href: '/workforce/approvals',
+			icon: ClipboardCheck,
+			description: 'pending decisions',
+			badge: badges.approvals > 0 ? { text: String(badges.approvals), tone: 'amber' } : undefined,
+		},
+		{
+			label: 'Activity',
+			href: '/workforce/activity',
+			icon: ActivityIcon,
+			description: 'recent events',
+		},
+		{
+			label: 'Org',
+			href: '/workforce/org',
+			icon: Network,
+			description: 'reporting tree',
+		},
+		{
+			label: 'Goals',
+			href: '/workforce/goals',
+			icon: Target,
+			description: 'company → agent',
+		},
+		{
+			label: 'Reliability',
+			href: '/workforce/reliability',
+			icon: Gauge,
+			description: 'activity heatmap',
+			badge: badges.failedRuns > 0 ? { text: String(badges.failedRuns), tone: 'destructive' } : undefined,
+		},
+		{
+			label: 'Inbox',
+			href: '/workforce/inbox',
+			icon: Inbox,
+			description: 'notifications',
+			badge: badges.inbox > 0 ? { text: String(badges.inbox), tone: 'primary' } : undefined,
+		},
+		{
+			label: 'Costs',
+			href: '/workforce/costs',
+			icon: Receipt,
+			description: `${summary.costs.monthUtilizationPercent.toFixed(0)}% of budget`,
+		},
+		{
+			label: 'Settings',
+			href: '/workforce/settings',
+			icon: Settings,
+			description: 'company + agents',
+		},
+	]);
+
+	const BADGE_TINT: Record<NonNullable<WorkforceTile['badge']>['tone'], string> = {
+		primary: 'bg-primary/10 text-primary',
+		amber: 'bg-amber-500/10 text-amber-600',
+		destructive: 'bg-destructive/10 text-destructive',
+		muted: 'bg-muted text-muted-foreground',
+	};
 
 	function formatCents(cents: number): string {
 		return `$${(cents / 100).toFixed(2)}`;
@@ -181,6 +267,42 @@
 			{/if}
 		</section>
 	{/if}
+
+	<!-- Workforce nav tiles (bento grid) -->
+	<section aria-label="Workforce navigation">
+		<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+			Explore workforce
+		</h2>
+		<ul class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+			{#each tiles as tile (tile.href)}
+				{@const Icon = tile.icon}
+				<li>
+					<a
+						href={tile.href}
+						class="group relative flex flex-col gap-2 rounded-lg border border-border bg-card p-4 transition-colors hover:bg-accent hover:border-foreground/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+						aria-label="{tile.label} — {tile.description}"
+					>
+						<div class="flex items-center justify-between gap-2">
+							<span class="inline-flex h-9 w-9 items-center justify-center rounded-md bg-muted text-muted-foreground group-hover:text-foreground transition-colors">
+								<Icon size={18} aria-hidden="true" />
+							</span>
+							{#if tile.badge}
+								<span
+									class="rounded-full px-2 py-0.5 text-xs font-medium tabular-nums {BADGE_TINT[tile.badge.tone]}"
+								>
+									{tile.badge.text}
+								</span>
+							{/if}
+						</div>
+						<div class="space-y-0.5 min-w-0">
+							<div class="text-sm font-medium text-foreground truncate">{tile.label}</div>
+							<div class="text-xs text-muted-foreground truncate">{tile.description}</div>
+						</div>
+					</a>
+				</li>
+			{/each}
+		</ul>
+	</section>
 
 	<!-- Activity feed -->
 	<section aria-label="Recent activity">

--- a/src/routes/(app)/workforce/+page.svelte
+++ b/src/routes/(app)/workforce/+page.svelte
@@ -3,10 +3,12 @@
 	import type { PageData } from './$types';
 	import { startPolling } from '$lib/util/live-polling';
 	import LiveIndicator from '$lib/components/LiveIndicator.svelte';
+	import Sparkline from '$lib/components/Sparkline.svelte';
 
 	let { data }: { data: PageData } = $props();
 
-	const { summary, badges, activity } = $derived(data);
+	const { summary, badges, activity, costTrend } = $derived(data);
+	const trendValues = $derived(costTrend.map((p) => p.cents));
 
 	function formatCents(cents: number): string {
 		return `$${(cents / 100).toFixed(2)}`;
@@ -121,8 +123,17 @@
 
 		<!-- Costs -->
 		<div class="rounded-lg border border-border bg-card p-4 space-y-2">
-			<h2 class="text-sm font-medium text-muted-foreground">Monthly spend</h2>
-			<div class="text-2xl font-semibold tabular-nums">{formatCents(summary.costs.monthSpendCents)}</div>
+			<div class="flex items-start justify-between gap-2">
+				<div class="space-y-1">
+					<h2 class="text-sm font-medium text-muted-foreground">Monthly spend</h2>
+					<div class="text-2xl font-semibold tabular-nums">{formatCents(summary.costs.monthSpendCents)}</div>
+				</div>
+				{#if trendValues.length > 1}
+					<div class="text-primary shrink-0 mt-1" title="Daily spend over the last 14 days">
+						<Sparkline values={trendValues} width={120} height={32} />
+					</div>
+				{/if}
+			</div>
 			<div class="text-xs text-muted-foreground">
 				of {formatCents(summary.costs.monthBudgetCents)} budget
 				({summary.costs.monthUtilizationPercent.toFixed(1)}%)

--- a/src/routes/(app)/workforce/+page.svelte
+++ b/src/routes/(app)/workforce/+page.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import type { PageData } from './$types';
+	import { startPolling } from '$lib/util/live-polling';
+	import LiveIndicator from '$lib/components/LiveIndicator.svelte';
 
 	let { data }: { data: PageData } = $props();
 
@@ -8,11 +11,16 @@
 	function formatCents(cents: number): string {
 		return `$${(cents / 100).toFixed(2)}`;
 	}
+
+	onMount(() => startPolling('app:dashboard', 5000));
 </script>
 
 <div class="p-6 space-y-6">
 	<div class="flex items-center justify-between">
-		<h1 class="text-2xl font-semibold">Dashboard</h1>
+		<div class="flex items-center gap-3">
+			<h1 class="text-2xl font-semibold">Dashboard</h1>
+			<LiveIndicator intervalMs={5000} />
+		</div>
 		{#if badges.approvals > 0 || badges.inbox > 0 || badges.failedRuns > 0 || badges.joinRequests > 0}
 			<div class="flex gap-2 text-xs">
 				{#if badges.inbox > 0}
@@ -46,35 +54,75 @@
 			<h2 class="text-sm font-medium text-muted-foreground">Agents</h2>
 			<div class="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
 				<span class="text-muted-foreground">Active</span>
-				<span class="font-medium">{summary.agents.active}</span>
+				<span class="font-medium tabular-nums">{summary.agents.active}</span>
 				<span class="text-muted-foreground">Running</span>
-				<span class="font-medium">{summary.agents.running}</span>
+				<span class="font-medium tabular-nums">{summary.agents.running}</span>
 				<span class="text-muted-foreground">Paused</span>
-				<span class="font-medium">{summary.agents.paused}</span>
+				<span class="font-medium tabular-nums">{summary.agents.paused}</span>
 				<span class="text-muted-foreground">Error</span>
-				<span class="font-medium text-destructive">{summary.agents.error}</span>
+				<span class="font-medium tabular-nums text-destructive">{summary.agents.error}</span>
 			</div>
 		</div>
 
-		<!-- Tasks -->
+		<!-- Tasks (clickable, drills into filtered issues) -->
 		<div class="rounded-lg border border-border bg-card p-4 space-y-2">
 			<h2 class="text-sm font-medium text-muted-foreground">Tasks</h2>
 			<div class="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
-				<span class="text-muted-foreground">Open</span>
-				<span class="font-medium">{summary.tasks.open}</span>
-				<span class="text-muted-foreground">In progress</span>
-				<span class="font-medium">{summary.tasks.inProgress}</span>
-				<span class="text-muted-foreground">Blocked</span>
-				<span class="font-medium text-amber-600">{summary.tasks.blocked}</span>
-				<span class="text-muted-foreground">Done</span>
-				<span class="font-medium text-green-600">{summary.tasks.done}</span>
+				<a
+					href="/workforce/issues?status=todo"
+					class="text-muted-foreground hover:text-foreground hover:underline underline-offset-2"
+				>
+					Open
+				</a>
+				<a
+					href="/workforce/issues?status=todo"
+					class="font-medium tabular-nums hover:underline underline-offset-2"
+				>
+					{summary.tasks.open}
+				</a>
+				<a
+					href="/workforce/issues?status=in_progress"
+					class="text-muted-foreground hover:text-foreground hover:underline underline-offset-2"
+				>
+					In progress
+				</a>
+				<a
+					href="/workforce/issues?status=in_progress"
+					class="font-medium tabular-nums hover:underline underline-offset-2"
+				>
+					{summary.tasks.inProgress}
+				</a>
+				<a
+					href="/workforce/issues?status=blocked"
+					class="text-muted-foreground hover:text-foreground hover:underline underline-offset-2"
+				>
+					Blocked
+				</a>
+				<a
+					href="/workforce/issues?status=blocked"
+					class="font-medium tabular-nums text-amber-600 hover:underline underline-offset-2"
+				>
+					{summary.tasks.blocked}
+				</a>
+				<a
+					href="/workforce/issues?status=done"
+					class="text-muted-foreground hover:text-foreground hover:underline underline-offset-2"
+				>
+					Done
+				</a>
+				<a
+					href="/workforce/issues?status=done"
+					class="font-medium tabular-nums text-green-600 hover:underline underline-offset-2"
+				>
+					{summary.tasks.done}
+				</a>
 			</div>
 		</div>
 
 		<!-- Costs -->
 		<div class="rounded-lg border border-border bg-card p-4 space-y-2">
 			<h2 class="text-sm font-medium text-muted-foreground">Monthly spend</h2>
-			<div class="text-2xl font-semibold">{formatCents(summary.costs.monthSpendCents)}</div>
+			<div class="text-2xl font-semibold tabular-nums">{formatCents(summary.costs.monthSpendCents)}</div>
 			<div class="text-xs text-muted-foreground">
 				of {formatCents(summary.costs.monthBudgetCents)} budget
 				({summary.costs.monthUtilizationPercent.toFixed(1)}%)
@@ -100,10 +148,13 @@
 				</div>
 			{/if}
 			{#if summary.pendingApprovals > 0}
-				<div class="rounded-lg border border-amber-300/30 bg-amber-500/5 px-4 py-2 text-sm">
+				<a
+					href="/workforce/approvals"
+					class="rounded-lg border border-amber-300/30 bg-amber-500/5 px-4 py-2 text-sm hover:bg-amber-500/10 transition-colors"
+				>
 					<span class="font-medium text-amber-600">{summary.pendingApprovals}</span>
 					<span class="text-muted-foreground ml-1">pending approval{summary.pendingApprovals !== 1 ? 's' : ''}</span>
-				</div>
+				</a>
 			{/if}
 			{#if summary.budgets.pausedAgents > 0}
 				<div class="rounded-lg border border-border bg-muted/50 px-4 py-2 text-sm">
@@ -122,12 +173,17 @@
 
 	<!-- Activity feed -->
 	<section aria-label="Recent activity">
-		<h2 class="text-lg font-semibold mb-2">Recent activity</h2>
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-semibold">Recent activity</h2>
+			<a href="/workforce/activity" class="text-xs text-muted-foreground hover:text-foreground hover:underline">
+				view all →
+			</a>
+		</div>
 		{#if activity.length === 0}
 			<p class="text-muted-foreground text-sm">No recent activity yet.</p>
 		{:else}
 			<ul class="divide-y divide-border rounded-lg border border-border bg-card">
-				{#each activity as item (item.id)}
+				{#each activity.slice(0, 8) as item (item.id)}
 					<li class="px-4 py-2 text-sm flex items-start gap-3">
 						<span class="shrink-0 mt-0.5 rounded px-1.5 py-0.5 text-xs font-medium bg-muted text-muted-foreground uppercase tracking-wide">
 							{item.actorType}
@@ -138,7 +194,6 @@
 								<span class="text-muted-foreground"> on {item.entityType}</span>
 							{/if}
 							{#if item.details !== null}
-								<!-- TODO Task 16 polish: format item.details into human-readable summary -->
 								<pre class="mt-1 text-xs text-muted-foreground whitespace-pre-wrap">{JSON.stringify(item.details)}</pre>
 							{/if}
 						</div>

--- a/src/routes/(app)/workforce/+page.svelte
+++ b/src/routes/(app)/workforce/+page.svelte
@@ -279,7 +279,7 @@
 				<li>
 					<a
 						href={tile.href}
-						class="group relative flex flex-col gap-2 rounded-lg border border-border bg-card p-4 transition-colors hover:bg-accent hover:border-foreground/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+						class="group relative flex flex-col gap-2 rounded-lg border border-border bg-card p-4 transition-colors hover:bg-muted hover:border-foreground/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
 						aria-label="{tile.label} — {tile.description}"
 					>
 						<div class="flex items-center justify-between gap-2">

--- a/src/routes/(app)/workforce/activity/+page.server.ts
+++ b/src/routes/(app)/workforce/activity/+page.server.ts
@@ -1,0 +1,18 @@
+import { redirect, error } from '@sveltejs/kit';
+import { paperclipServerClient } from '$lib/server/paperclip-fetch';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async (event) => {
+	if (!event.locals.user) throw redirect(302, '/login');
+	if (!event.locals.paperclipIdentity?.companyId) {
+		throw redirect(302, '/workforce/welcome');
+	}
+	const companyId = event.locals.paperclipIdentity.companyId;
+	const client = paperclipServerClient(event);
+	try {
+		const items = await client.activity.list(companyId);
+		return { items };
+	} catch (e: any) {
+		throw error(e?.status ?? 502, 'paperclip unavailable');
+	}
+};

--- a/src/routes/(app)/workforce/activity/+page.server.ts
+++ b/src/routes/(app)/workforce/activity/+page.server.ts
@@ -7,6 +7,7 @@ export const load: PageServerLoad = async (event) => {
 	if (!event.locals.paperclipIdentity?.companyId) {
 		throw redirect(302, '/workforce/welcome');
 	}
+	event.depends('app:activity');
 	const companyId = event.locals.paperclipIdentity.companyId;
 	const client = paperclipServerClient(event);
 	try {

--- a/src/routes/(app)/workforce/activity/+page.svelte
+++ b/src/routes/(app)/workforce/activity/+page.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import type { PageData } from './$types';
+	import { startPolling } from '$lib/util/live-polling';
+	import LiveIndicator from '$lib/components/LiveIndicator.svelte';
 
 	let { data }: { data: PageData } = $props();
 
 	const { items } = $derived(data);
+
+	onMount(() => startPolling('app:activity', 5000));
 
 	const ACTOR_COLORS: Record<string, string> = {
 		agent: 'bg-primary/10 text-primary',
@@ -27,8 +32,11 @@
 </script>
 
 <div class="p-6 space-y-6">
-	<div class="flex items-center justify-between">
-		<h1 class="text-2xl font-semibold">Activity</h1>
+	<div class="flex items-center justify-between flex-wrap gap-3">
+		<div class="flex items-center gap-3">
+			<h1 class="text-2xl font-semibold">Activity</h1>
+			<LiveIndicator intervalMs={5000} />
+		</div>
 		<span class="text-sm text-muted-foreground">{items.length} event{items.length !== 1 ? 's' : ''}</span>
 	</div>
 

--- a/src/routes/(app)/workforce/activity/+page.svelte
+++ b/src/routes/(app)/workforce/activity/+page.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	const { items } = $derived(data);
+
+	const ACTOR_COLORS: Record<string, string> = {
+		agent: 'bg-primary/10 text-primary',
+		user: 'bg-blue-500/10 text-blue-600',
+		system: 'bg-muted text-muted-foreground',
+	};
+
+	function actorBadgeClass(actorType: string): string {
+		return ACTOR_COLORS[actorType] ?? 'bg-muted text-muted-foreground';
+	}
+
+	function formatTimestamp(createdAt: Date | string): string {
+		const d = new Date(createdAt);
+		return d.toLocaleString([], {
+			month: 'short',
+			day: 'numeric',
+			hour: '2-digit',
+			minute: '2-digit',
+		});
+	}
+</script>
+
+<div class="p-6 space-y-6">
+	<div class="flex items-center justify-between">
+		<h1 class="text-2xl font-semibold">Activity</h1>
+		<span class="text-sm text-muted-foreground">{items.length} event{items.length !== 1 ? 's' : ''}</span>
+	</div>
+
+	{#if items.length === 0}
+		<div class="rounded-lg border border-border bg-card p-12 flex flex-col items-center justify-center text-center">
+			<p class="text-muted-foreground text-sm">No activity yet.</p>
+		</div>
+	{:else}
+		<ul class="divide-y divide-border rounded-lg border border-border bg-card">
+			{#each items as item (item.id)}
+				<li class="px-4 py-3 flex items-start gap-3">
+					<!-- Actor type badge -->
+					<span
+						class="shrink-0 mt-0.5 rounded px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide {actorBadgeClass(item.actorType)}"
+					>
+						{item.actorType}
+					</span>
+
+					<!-- Action + entity -->
+					<div class="min-w-0 flex-1 space-y-0.5">
+						<p class="text-sm">
+							<span class="font-medium">{item.action}</span>
+							{#if item.entityType}
+								<span class="text-muted-foreground"> on </span>
+								<span class="font-medium text-foreground/80">{item.entityType}</span>
+							{/if}
+							{#if item.entityId}
+								<span class="text-muted-foreground text-xs ml-1">#{item.entityId.slice(0, 8)}</span>
+							{/if}
+						</p>
+						{#if item.details !== null}
+							<!-- TODO polish: render details as human-readable summary -->
+							<pre class="text-xs text-muted-foreground whitespace-pre-wrap break-all">{JSON.stringify(item.details)}</pre>
+						{/if}
+					</div>
+
+					<!-- Timestamp -->
+					<time
+						class="shrink-0 text-xs text-muted-foreground whitespace-nowrap"
+						datetime={new Date(item.createdAt).toISOString()}
+					>
+						{formatTimestamp(item.createdAt)}
+					</time>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</div>

--- a/src/routes/(app)/workforce/agents/[id]/+page.server.ts
+++ b/src/routes/(app)/workforce/agents/[id]/+page.server.ts
@@ -1,0 +1,40 @@
+import { redirect, error } from '@sveltejs/kit';
+import { paperclipServerClient, paperclipRawFetch } from '$lib/server/paperclip-fetch';
+import type { PageServerLoad } from './$types';
+
+type DailyCost = { date: string; cents: number };
+type AgentRun = {
+	id: string;
+	agentId: string;
+	status: 'succeeded' | 'failed' | 'running' | 'cancelled';
+	startedAt: string;
+	endedAt: string | null;
+	durationMs: number | null;
+	source: string;
+	costCents: number;
+	tokens: { input: number; output: number };
+	issueId: string | null;
+};
+
+export const load: PageServerLoad = async (event) => {
+	if (!event.locals.user) throw redirect(302, '/login');
+	if (!event.locals.paperclipIdentity?.companyId) {
+		throw redirect(302, '/workforce/welcome');
+	}
+	event.depends('app:agent');
+	const companyId = event.locals.paperclipIdentity.companyId;
+	const agentId = event.params.id;
+	const client = paperclipServerClient(event);
+
+	try {
+		const [agent, costTrend, runs, issues] = await Promise.all([
+			client.agents.get(agentId, companyId),
+			paperclipRawFetch<DailyCost[]>(event, `/api/agents/${agentId}/cost-trend`).catch(() => [] as DailyCost[]),
+			paperclipRawFetch<AgentRun[]>(event, `/api/agents/${agentId}/runs`).catch(() => [] as AgentRun[]),
+			client.issues.list(companyId, { assigneeAgentId: agentId }),
+		]);
+		return { agent, costTrend, runs, issues };
+	} catch (e: any) {
+		throw error(e?.status ?? 502, e?.status === 404 ? 'agent not found' : 'paperclip unavailable');
+	}
+};

--- a/src/routes/(app)/workforce/agents/[id]/+page.svelte
+++ b/src/routes/(app)/workforce/agents/[id]/+page.svelte
@@ -208,7 +208,7 @@
 						<li>
 							<a
 								href="/workforce/issues/{issue.id}"
-								class="px-4 py-3 flex items-center gap-3 text-sm hover:bg-accent transition-colors"
+								class="px-4 py-3 flex items-center gap-3 text-sm hover:bg-muted transition-colors"
 							>
 								<span class="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium {ISSUE_STATUS_BADGE[issue.status] ?? 'bg-muted'}">
 									{issue.status}

--- a/src/routes/(app)/workforce/agents/[id]/+page.svelte
+++ b/src/routes/(app)/workforce/agents/[id]/+page.svelte
@@ -1,0 +1,243 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { PageData } from './$types';
+	import { startPolling } from '$lib/util/live-polling';
+	import LiveIndicator from '$lib/components/LiveIndicator.svelte';
+	import Sparkline from '$lib/components/Sparkline.svelte';
+
+	let { data }: { data: PageData } = $props();
+	const { agent, costTrend, runs, issues } = $derived(data);
+
+	const trendValues = $derived(costTrend.map((p) => p.cents));
+	const totalCostCents = $derived(trendValues.reduce((s, n) => s + n, 0));
+
+	const STATUS_DOT: Record<string, string> = {
+		active: '#10b981',
+		running: '#3b82f6',
+		paused: '#f59e0b',
+		error: '#ef4444',
+		idle: '#6b7280',
+		pending_approval: '#a855f7',
+		terminated: '#525252',
+	};
+
+	const STATUS_BADGE: Record<string, string> = {
+		active: 'bg-green-500/10 text-green-600',
+		running: 'bg-blue-500/10 text-blue-600',
+		paused: 'bg-amber-500/10 text-amber-600',
+		error: 'bg-destructive/10 text-destructive',
+		idle: 'bg-muted text-muted-foreground',
+		pending_approval: 'bg-purple-500/10 text-purple-600',
+		terminated: 'bg-muted text-muted-foreground/50',
+	};
+
+	const RUN_STATUS_BADGE: Record<string, string> = {
+		succeeded: 'bg-green-500/10 text-green-600',
+		failed: 'bg-destructive/10 text-destructive',
+		running: 'bg-blue-500/10 text-blue-600',
+		cancelled: 'bg-muted text-muted-foreground',
+	};
+
+	const ISSUE_STATUS_BADGE: Record<string, string> = {
+		in_progress: 'bg-blue-500/10 text-blue-600',
+		blocked: 'bg-amber-500/10 text-amber-600',
+		todo: 'bg-muted text-muted-foreground',
+		backlog: 'bg-muted text-muted-foreground',
+		in_review: 'bg-purple-500/10 text-purple-600',
+		done: 'bg-green-500/10 text-green-600',
+		cancelled: 'bg-muted text-muted-foreground/50',
+	};
+
+	function formatCents(cents: number): string {
+		return `$${(cents / 100).toFixed(2)}`;
+	}
+
+	function formatDuration(ms: number | null): string {
+		if (ms === null) return '—';
+		if (ms < 1000) return `${ms}ms`;
+		if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+		return `${Math.floor(ms / 60_000)}m ${Math.round((ms % 60_000) / 1000)}s`;
+	}
+
+	function relativeTime(iso: string | Date): string {
+		const diff = Date.now() - new Date(iso).getTime();
+		if (diff < 60_000) return 'just now';
+		if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+		if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+		return `${Math.floor(diff / 86_400_000)}d ago`;
+	}
+
+	function initials(name: string): string {
+		return name.split(' ').map((w) => w[0]).slice(0, 2).join('').toUpperCase();
+	}
+
+	onMount(() => startPolling('app:agent', 6000));
+</script>
+
+<div class="p-6 space-y-6 max-w-5xl">
+	<!-- Breadcrumb -->
+	<nav class="text-sm text-muted-foreground flex items-center gap-1">
+		<a href="/workforce/org" class="hover:text-foreground">Org</a>
+		<span>/</span>
+		<span class="text-foreground">{agent.name}</span>
+	</nav>
+
+	<!-- Header card -->
+	<header class="rounded-lg border border-border bg-card p-5 flex items-start gap-4">
+		<div class="relative shrink-0">
+			<div class="w-16 h-16 rounded-full bg-muted flex items-center justify-center text-xl font-semibold text-foreground/70">
+				{initials(agent.name)}
+			</div>
+			<span
+				class="absolute -bottom-0.5 -right-0.5 h-4 w-4 rounded-full border-2 border-card"
+				style="background:{STATUS_DOT[agent.status] ?? STATUS_DOT.idle}"
+				title={agent.status}
+			></span>
+		</div>
+		<div class="flex-1 min-w-0 space-y-1.5">
+			<div class="flex items-center gap-3 flex-wrap">
+				<h1 class="text-2xl font-semibold">{agent.name}</h1>
+				<span class="rounded px-1.5 py-0.5 text-xs font-medium {STATUS_BADGE[agent.status] ?? STATUS_BADGE.idle}">
+					{agent.status}
+				</span>
+				<LiveIndicator intervalMs={6000} />
+			</div>
+			<div class="text-sm text-muted-foreground">
+				{agent.title ?? agent.role}
+				· <span class="font-mono text-xs">{agent.adapterType}</span>
+				{#if agent.capabilities}
+					<div class="mt-1 text-foreground/80">{agent.capabilities}</div>
+				{/if}
+			</div>
+		</div>
+	</header>
+
+	<!-- 3-column KPI row: cost / runs / issues -->
+	<section class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+		<div class="rounded-lg border border-border bg-card p-4 space-y-2">
+			<div class="flex items-start justify-between gap-2">
+				<div class="space-y-1">
+					<h2 class="text-xs font-medium text-muted-foreground uppercase tracking-wider">Cost (14d)</h2>
+					<div class="text-2xl font-semibold tabular-nums">{formatCents(totalCostCents)}</div>
+				</div>
+				{#if trendValues.length > 1}
+					<div class="text-primary shrink-0 mt-1">
+						<Sparkline values={trendValues} width={100} height={32} />
+					</div>
+				{/if}
+			</div>
+			<div class="text-xs text-muted-foreground">
+				of {formatCents(agent.budgetMonthlyCents)} monthly budget
+			</div>
+		</div>
+
+		<div class="rounded-lg border border-border bg-card p-4 space-y-1">
+			<h2 class="text-xs font-medium text-muted-foreground uppercase tracking-wider">Recent runs</h2>
+			<div class="text-2xl font-semibold tabular-nums">{runs.length}</div>
+			<div class="text-xs text-muted-foreground">
+				{runs.filter((r) => r.status === 'succeeded').length} succeeded · {runs.filter((r) => r.status === 'failed').length} failed
+			</div>
+		</div>
+
+		<div class="rounded-lg border border-border bg-card p-4 space-y-1">
+			<h2 class="text-xs font-medium text-muted-foreground uppercase tracking-wider">Assigned issues</h2>
+			<div class="text-2xl font-semibold tabular-nums">{issues.length}</div>
+			<div class="text-xs text-muted-foreground">
+				{#if agent.lastHeartbeatAt}
+					Last heartbeat {relativeTime(agent.lastHeartbeatAt)}
+				{:else}
+					No heartbeat yet
+				{/if}
+			</div>
+		</div>
+	</section>
+
+	<!-- Two-column main: runs + issues -->
+	<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+		<!-- Recent runs timeline -->
+		<section>
+			<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+				Recent runs
+			</h2>
+			{#if runs.length === 0}
+				<div class="rounded-lg border border-border bg-card p-6 text-sm text-muted-foreground">
+					No recent runs.
+				</div>
+			{:else}
+				<ul class="rounded-lg border border-border bg-card divide-y divide-border">
+					{#each runs as run (run.id)}
+						<li class="px-4 py-3 text-sm flex items-center gap-3">
+							<span class="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium {RUN_STATUS_BADGE[run.status] ?? 'bg-muted'}">
+								{run.status}
+							</span>
+							<div class="flex-1 min-w-0">
+								<div class="font-mono text-xs text-muted-foreground truncate">{run.id}</div>
+								<div class="text-xs text-muted-foreground/80 mt-0.5">
+									{run.source} · {formatDuration(run.durationMs)} · {formatCents(run.costCents)}
+								</div>
+							</div>
+							{#if run.issueId}
+								<a href="/workforce/issues/{run.issueId}" class="shrink-0 font-mono text-xs text-primary hover:underline">
+									{run.issueId}
+								</a>
+							{/if}
+							<time
+								class="shrink-0 text-xs text-muted-foreground"
+								datetime={run.startedAt}
+							>
+								{relativeTime(run.startedAt)}
+							</time>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</section>
+
+		<!-- Assigned issues -->
+		<section>
+			<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+				Assigned issues
+			</h2>
+			{#if issues.length === 0}
+				<div class="rounded-lg border border-border bg-card p-6 text-sm text-muted-foreground">
+					No issues currently assigned.
+				</div>
+			{:else}
+				<ul class="rounded-lg border border-border bg-card divide-y divide-border">
+					{#each issues as issue (issue.id)}
+						<li>
+							<a
+								href="/workforce/issues/{issue.id}"
+								class="px-4 py-3 flex items-center gap-3 text-sm hover:bg-accent transition-colors"
+							>
+								<span class="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium {ISSUE_STATUS_BADGE[issue.status] ?? 'bg-muted'}">
+									{issue.status}
+								</span>
+								{#if issue.identifier}
+									<span class="shrink-0 text-xs font-mono text-muted-foreground">{issue.identifier}</span>
+								{/if}
+								<span class="flex-1 min-w-0 truncate font-medium">{issue.title}</span>
+							</a>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</section>
+	</div>
+
+	<!-- Pause reason banner -->
+	{#if agent.pauseReason}
+		<div class="rounded-lg border border-amber-300/30 bg-amber-500/5 px-4 py-3 text-sm">
+			<span class="font-medium text-amber-600">Paused</span>
+			<span class="text-muted-foreground ml-1">— reason: {agent.pauseReason}</span>
+			{#if agent.pausedAt}
+				<span class="text-muted-foreground ml-1">· {relativeTime(agent.pausedAt)}</span>
+			{/if}
+		</div>
+	{/if}
+
+	<!-- Metadata footer -->
+	<footer class="text-xs text-muted-foreground font-mono">
+		{agent.id}
+	</footer>
+</div>

--- a/src/routes/(app)/workforce/approvals/+page.server.ts
+++ b/src/routes/(app)/workforce/approvals/+page.server.ts
@@ -1,0 +1,18 @@
+import { redirect, error } from '@sveltejs/kit';
+import { paperclipServerClient } from '$lib/server/paperclip-fetch';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async (event) => {
+	if (!event.locals.user) throw redirect(302, '/login');
+	if (!event.locals.paperclipIdentity?.companyId) {
+		throw redirect(302, '/workforce/welcome');
+	}
+	const companyId = event.locals.paperclipIdentity.companyId;
+	const client = paperclipServerClient(event);
+	try {
+		const items = await client.approvals.list(companyId);
+		return { items };
+	} catch (e: any) {
+		throw error(e?.status ?? 502, 'paperclip unavailable');
+	}
+};

--- a/src/routes/(app)/workforce/approvals/+page.svelte
+++ b/src/routes/(app)/workforce/approvals/+page.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import type { ApprovalStatus } from '@minion-stack/paperclip-client';
+
+	let { data }: { data: PageData } = $props();
+
+	const { items } = $derived(data);
+
+	const STATUS_BADGE: Record<ApprovalStatus, string> = {
+		pending: 'bg-amber-500/10 text-amber-600',
+		revision_requested: 'bg-orange-500/10 text-orange-600',
+		resubmitted: 'bg-blue-500/10 text-blue-600',
+		approved: 'bg-green-500/10 text-green-600',
+		rejected: 'bg-destructive/10 text-destructive',
+		cancelled: 'bg-muted text-muted-foreground/50',
+	};
+
+	const STATUS_LABELS: Record<ApprovalStatus, string> = {
+		pending: 'Pending',
+		revision_requested: 'Revision',
+		resubmitted: 'Resubmitted',
+		approved: 'Approved',
+		rejected: 'Rejected',
+		cancelled: 'Cancelled',
+	};
+
+	// Sort newest first
+	const sorted = $derived([...items].sort(
+		(a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+	));
+
+	const pendingCount = $derived(
+		items.filter((a) => a.status === 'pending' || a.status === 'revision_requested').length
+	);
+
+	function formatDate(d: Date | string): string {
+		return new Date(d).toLocaleString([], {
+			month: 'short',
+			day: 'numeric',
+			hour: '2-digit',
+			minute: '2-digit',
+		});
+	}
+
+	function formatCents(payload: Record<string, unknown>): string | null {
+		const raw = payload.amountCents ?? payload.amount_cents;
+		if (typeof raw !== 'number') return null;
+		return `$${(raw / 100).toFixed(2)}`;
+	}
+
+	function extractDescription(payload: Record<string, unknown>): string | null {
+		const desc = payload.description ?? payload.reason ?? payload.summary;
+		return typeof desc === 'string' ? desc : null;
+	}
+</script>
+
+<div class="p-6 space-y-6">
+	<div class="flex items-center justify-between">
+		<h1 class="text-2xl font-semibold">Approvals</h1>
+		{#if pendingCount > 0}
+			<span class="rounded-full bg-amber-500/20 px-2.5 py-0.5 text-xs font-medium text-amber-600">
+				{pendingCount} pending
+			</span>
+		{/if}
+	</div>
+
+	{#if items.length === 0}
+		<div class="rounded-lg border border-border bg-card p-12 flex flex-col items-center justify-center text-center">
+			<p class="text-muted-foreground text-sm">No approvals yet.</p>
+		</div>
+	{:else}
+		<ul class="space-y-3">
+			{#each sorted as approval (approval.id)}
+				<li class="rounded-lg border border-border bg-card p-4 space-y-2">
+					<div class="flex items-start gap-3">
+						<!-- Status badge -->
+						<span
+							class="shrink-0 mt-0.5 rounded px-1.5 py-0.5 text-xs font-medium {STATUS_BADGE[approval.status]}"
+						>
+							{STATUS_LABELS[approval.status]}
+						</span>
+
+						<div class="min-w-0 flex-1 space-y-1">
+							<!-- Type + ID -->
+							<p class="text-sm font-medium">
+								{approval.type}
+								<span class="text-xs font-mono text-muted-foreground ml-1">#{approval.id.slice(0, 8)}</span>
+							</p>
+
+							<!-- Description from payload -->
+							{#if extractDescription(approval.payload)}
+								<p class="text-sm text-muted-foreground">{extractDescription(approval.payload)}</p>
+							{/if}
+
+							<!-- Amount if present in payload -->
+							{#if formatCents(approval.payload)}
+								<p class="text-sm font-semibold">{formatCents(approval.payload)}</p>
+							{/if}
+
+							<!-- Payload fallback for opaque types -->
+							{#if !extractDescription(approval.payload) && !formatCents(approval.payload) && Object.keys(approval.payload).length > 0}
+								<!-- TODO polish: render payload fields in a human-readable form per approval type -->
+								<pre class="text-xs text-muted-foreground whitespace-pre-wrap break-all">{JSON.stringify(approval.payload)}</pre>
+							{/if}
+						</div>
+
+						<!-- Requested at -->
+						<time
+							class="shrink-0 text-xs text-muted-foreground whitespace-nowrap"
+							datetime={new Date(approval.createdAt).toISOString()}
+						>
+							{formatDate(approval.createdAt)}
+						</time>
+					</div>
+
+					<!-- Requester info -->
+					<div class="flex items-center gap-2 text-xs text-muted-foreground pl-0">
+						{#if approval.requestedByAgentId}
+							<span>Agent: <span class="font-mono">{approval.requestedByAgentId.slice(0, 8)}…</span></span>
+						{:else if approval.requestedByUserId}
+							<span>User: <span class="font-mono">{approval.requestedByUserId.slice(0, 8)}…</span></span>
+						{:else}
+							<span>Requester unknown</span>
+						{/if}
+
+						{#if approval.decisionNote}
+							<span class="ml-2 text-muted-foreground/70">Note: {approval.decisionNote}</span>
+						{/if}
+					</div>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</div>

--- a/src/routes/(app)/workforce/costs/+page.server.ts
+++ b/src/routes/(app)/workforce/costs/+page.server.ts
@@ -1,0 +1,51 @@
+import { redirect, error } from '@sveltejs/kit';
+import { paperclipRawFetch } from '$lib/server/paperclip-fetch';
+import type { PageServerLoad } from './$types';
+
+export type CostKpis = {
+	todayCents: number;
+	last7Cents: number;
+	monthCents: number;
+	projectedMonthEndCents: number;
+	budgetCents: number;
+};
+
+export type CostByAgent = {
+	agentId: string;
+	agentName: string;
+	role: string;
+	status: string;
+	cents: number;
+	tokens: { input: number; output: number };
+};
+
+export type CostByProvider = {
+	provider: string;
+	model: string;
+	cents: number;
+	share: number;
+	requests: number;
+};
+
+type DailyCost = { date: string; cents: number };
+
+export const load: PageServerLoad = async (event) => {
+	if (!event.locals.user) throw redirect(302, '/login');
+	if (!event.locals.paperclipIdentity?.companyId) {
+		throw redirect(302, '/workforce/welcome');
+	}
+	event.depends('app:costs');
+	const companyId = event.locals.paperclipIdentity.companyId;
+
+	try {
+		const [kpis, byAgent, byProvider, trend] = await Promise.all([
+			paperclipRawFetch<CostKpis>(event, `/api/companies/${companyId}/costs/kpis`),
+			paperclipRawFetch<CostByAgent[]>(event, `/api/companies/${companyId}/costs/by-agent`),
+			paperclipRawFetch<CostByProvider[]>(event, `/api/companies/${companyId}/costs/by-provider`),
+			paperclipRawFetch<DailyCost[]>(event, `/api/companies/${companyId}/costs/trend`),
+		]);
+		return { kpis, byAgent, byProvider, trend };
+	} catch (e: any) {
+		throw error(e?.status ?? 502, 'paperclip unavailable');
+	}
+};

--- a/src/routes/(app)/workforce/costs/+page.svelte
+++ b/src/routes/(app)/workforce/costs/+page.svelte
@@ -152,7 +152,7 @@
 				{#each byAgent as row (row.agentId)}
 					<a
 						href="/workforce/agents/{row.agentId}"
-						class="block px-4 py-3 text-sm hover:bg-accent transition-colors"
+						class="block px-4 py-3 text-sm hover:bg-muted transition-colors"
 					>
 						<div class="flex items-center gap-2 mb-1.5">
 							<span

--- a/src/routes/(app)/workforce/costs/+page.svelte
+++ b/src/routes/(app)/workforce/costs/+page.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { PageData } from './$types';
+	import { startPolling } from '$lib/util/live-polling';
+	import LiveIndicator from '$lib/components/LiveIndicator.svelte';
+	import Sparkline from '$lib/components/Sparkline.svelte';
+
+	let { data }: { data: PageData } = $props();
+	const { kpis, byAgent, byProvider, trend } = $derived(data);
+
+	const trendValues = $derived(trend.map((p) => p.cents));
+	const utilization = $derived(
+		kpis.budgetCents > 0 ? Math.min(100, (kpis.monthCents / kpis.budgetCents) * 100) : 0,
+	);
+
+	const projectedUtilization = $derived(
+		kpis.budgetCents > 0 ? Math.min(100, (kpis.projectedMonthEndCents / kpis.budgetCents) * 100) : 0,
+	);
+
+	const maxAgentCents = $derived(Math.max(1, ...byAgent.map((r) => r.cents)));
+	const maxProviderCents = $derived(Math.max(1, ...byProvider.map((r) => r.cents)));
+
+	const PROVIDER_TINT: Record<string, string> = {
+		anthropic: 'bg-orange-500',
+		openai: 'bg-emerald-500',
+		google: 'bg-blue-500',
+	};
+
+	const STATUS_DOT: Record<string, string> = {
+		active: '#10b981',
+		running: '#3b82f6',
+		paused: '#f59e0b',
+		error: '#ef4444',
+		idle: '#6b7280',
+	};
+
+	function formatCents(cents: number): string {
+		return `$${(cents / 100).toFixed(2)}`;
+	}
+
+	function formatBig(cents: number): string {
+		const v = cents / 100;
+		if (v >= 100) return `$${v.toFixed(0)}`;
+		return `$${v.toFixed(2)}`;
+	}
+
+	onMount(() => startPolling('app:costs', 8000));
+</script>
+
+<div class="p-6 space-y-6 max-w-6xl">
+	<header class="flex items-center justify-between flex-wrap gap-3">
+		<div class="flex items-center gap-3">
+			<h1 class="text-2xl font-semibold">Costs</h1>
+			<LiveIndicator intervalMs={8000} />
+		</div>
+		<div class="text-xs text-muted-foreground">
+			Trailing 14 days · projected month-end {formatBig(kpis.projectedMonthEndCents)}
+		</div>
+	</header>
+
+	<!-- KPI row: today / last 7 / month / projected -->
+	<section class="grid grid-cols-2 sm:grid-cols-4 gap-4">
+		<div class="rounded-lg border border-border bg-card p-4 space-y-1">
+			<h2 class="text-xs font-medium text-muted-foreground uppercase tracking-wider">Today</h2>
+			<div class="text-2xl font-semibold tabular-nums">{formatCents(kpis.todayCents)}</div>
+		</div>
+		<div class="rounded-lg border border-border bg-card p-4 space-y-1">
+			<h2 class="text-xs font-medium text-muted-foreground uppercase tracking-wider">Last 7 days</h2>
+			<div class="text-2xl font-semibold tabular-nums">{formatBig(kpis.last7Cents)}</div>
+		</div>
+		<div class="rounded-lg border border-border bg-card p-4 space-y-1">
+			<h2 class="text-xs font-medium text-muted-foreground uppercase tracking-wider">This period</h2>
+			<div class="text-2xl font-semibold tabular-nums">{formatBig(kpis.monthCents)}</div>
+			<div class="text-xs text-muted-foreground">of {formatBig(kpis.budgetCents)} budget</div>
+		</div>
+		<div class="rounded-lg border border-border bg-card p-4 space-y-1">
+			<h2 class="text-xs font-medium text-muted-foreground uppercase tracking-wider">Projected EOM</h2>
+			<div class="text-2xl font-semibold tabular-nums">{formatBig(kpis.projectedMonthEndCents)}</div>
+			<div class="text-xs {projectedUtilization > 100 ? 'text-destructive' : 'text-muted-foreground'}">
+				{projectedUtilization.toFixed(0)}% of budget
+			</div>
+		</div>
+	</section>
+
+	<!-- Trend chart (large sparkline) -->
+	<section>
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+				Daily spend
+			</h2>
+			<div class="text-xs text-muted-foreground tabular-nums">
+				min {formatCents(Math.min(...trendValues))} · max {formatCents(Math.max(...trendValues))} · avg {formatCents(Math.round(trendValues.reduce((s, n) => s + n, 0) / trendValues.length))}
+			</div>
+		</div>
+		<div class="rounded-lg border border-border bg-card p-4 space-y-3">
+			<div class="text-primary">
+				<Sparkline values={trendValues} width={1000} height={120} strokeWidth={2} />
+			</div>
+			<!-- Date labels (every other day to reduce noise) -->
+			<div class="flex justify-between text-[10px] text-muted-foreground font-mono px-1">
+				{#each trend as p, i (p.date)}
+					{#if i === 0 || i === trend.length - 1 || i % 2 === 0}
+						<span>{p.date.slice(5)}</span>
+					{:else}
+						<span class="opacity-0">·</span>
+					{/if}
+				{/each}
+			</div>
+		</div>
+	</section>
+
+	<!-- Budget bar (large) -->
+	<section>
+		<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+			Budget pacing
+		</h2>
+		<div class="rounded-lg border border-border bg-card p-4 space-y-2">
+			<div class="relative h-6 rounded-md bg-muted overflow-hidden">
+				<!-- Current spend bar -->
+				<div
+					class="h-full bg-primary transition-all"
+					style="width: {utilization}%"
+					title="Current spend"
+				></div>
+				<!-- Projected overlay (lighter) -->
+				{#if projectedUtilization > utilization}
+					<div
+						class="absolute top-0 h-full bg-primary/30"
+						style="left: {utilization}%; width: {projectedUtilization - utilization}%"
+						title="Projected end-of-month"
+					></div>
+				{/if}
+			</div>
+			<div class="flex justify-between text-xs text-muted-foreground tabular-nums">
+				<span>{formatBig(kpis.monthCents)} <span class="text-muted-foreground/60">spent</span></span>
+				<span>
+					{formatBig(kpis.projectedMonthEndCents)} <span class="text-muted-foreground/60">projected</span>
+				</span>
+				<span>{formatBig(kpis.budgetCents)} <span class="text-muted-foreground/60">budget</span></span>
+			</div>
+		</div>
+	</section>
+
+	<!-- Two-column breakdowns -->
+	<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+		<!-- By agent (horizontal bars) -->
+		<section>
+			<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+				By agent <span class="font-medium normal-case tracking-normal text-xs">({byAgent.length})</span>
+			</h2>
+			<div class="rounded-lg border border-border bg-card divide-y divide-border">
+				{#each byAgent as row (row.agentId)}
+					<a
+						href="/workforce/agents/{row.agentId}"
+						class="block px-4 py-3 text-sm hover:bg-accent transition-colors"
+					>
+						<div class="flex items-center gap-2 mb-1.5">
+							<span
+								class="h-2 w-2 rounded-full shrink-0"
+								style="background:{STATUS_DOT[row.status] ?? '#6b7280'}"
+							></span>
+							<span class="font-medium truncate flex-1 min-w-0">{row.agentName}</span>
+							<span class="font-mono text-xs text-muted-foreground tabular-nums">{formatCents(row.cents)}</span>
+						</div>
+						<div class="relative h-1.5 rounded-full bg-muted overflow-hidden">
+							<div
+								class="absolute inset-y-0 left-0 bg-primary rounded-full transition-all"
+								style="width: {(row.cents / maxAgentCents) * 100}%"
+							></div>
+						</div>
+					</a>
+				{/each}
+			</div>
+		</section>
+
+		<!-- By provider/model (horizontal bars with tint per provider) -->
+		<section>
+			<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+				By provider / model
+			</h2>
+			<div class="rounded-lg border border-border bg-card divide-y divide-border">
+				{#each byProvider as row (row.model)}
+					<div class="px-4 py-3 text-sm">
+						<div class="flex items-center gap-2 mb-1.5 flex-wrap">
+							<span class="font-medium truncate">{row.provider}</span>
+							<span class="font-mono text-xs text-muted-foreground/80 truncate">{row.model}</span>
+							<span class="ml-auto font-mono text-xs text-muted-foreground tabular-nums">
+								{formatCents(row.cents)} <span class="text-muted-foreground/60">({(row.share * 100).toFixed(0)}%)</span>
+							</span>
+						</div>
+						<div class="relative h-1.5 rounded-full bg-muted overflow-hidden">
+							<div
+								class="absolute inset-y-0 left-0 {PROVIDER_TINT[row.provider] ?? 'bg-primary'} rounded-full transition-all"
+								style="width: {(row.cents / maxProviderCents) * 100}%"
+							></div>
+						</div>
+						<div class="text-[10px] text-muted-foreground/70 mt-1 font-mono">
+							{row.requests} requests
+						</div>
+					</div>
+				{/each}
+			</div>
+			<!-- Provider legend -->
+			<div class="mt-3 flex items-center gap-4 text-xs text-muted-foreground">
+				{#each Object.entries(PROVIDER_TINT) as [provider, cls] (provider)}
+					<span class="inline-flex items-center gap-1.5">
+						<span class="h-2 w-2 rounded-full {cls}"></span>
+						{provider}
+					</span>
+				{/each}
+			</div>
+		</section>
+	</div>
+</div>

--- a/src/routes/(app)/workforce/goals/+page.server.ts
+++ b/src/routes/(app)/workforce/goals/+page.server.ts
@@ -1,0 +1,24 @@
+import { redirect, error } from '@sveltejs/kit';
+import { paperclipServerClient } from '$lib/server/paperclip-fetch';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async (event) => {
+	if (!event.locals.user) throw redirect(302, '/login');
+	if (!event.locals.paperclipIdentity?.companyId) {
+		throw redirect(302, '/workforce/welcome');
+	}
+	event.depends('app:goals');
+	const companyId = event.locals.paperclipIdentity.companyId;
+	const client = paperclipServerClient(event);
+	try {
+		const [goals, agents] = await Promise.all([
+			client.goals.list(companyId),
+			client.agents.list(companyId),
+		]);
+		const agentNames: Record<string, string> = {};
+		for (const a of agents) agentNames[a.id] = a.name;
+		return { goals, agentNames };
+	} catch (e: any) {
+		throw error(e?.status ?? 502, 'paperclip unavailable');
+	}
+};

--- a/src/routes/(app)/workforce/goals/+page.svelte
+++ b/src/routes/(app)/workforce/goals/+page.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { PageData } from './$types';
+	import type { Goal, GoalStatus, GoalLevel } from '@minion-stack/paperclip-client';
+	import { startPolling } from '$lib/util/live-polling';
+	import LiveIndicator from '$lib/components/LiveIndicator.svelte';
+
+	let { data }: { data: PageData } = $props();
+	const { goals, agentNames } = $derived(data);
+
+	type GoalNode = Goal & { children: GoalNode[]; depth: number };
+
+	function buildForest(rows: Goal[]): GoalNode[] {
+		const byId = new Map<string, GoalNode>();
+		for (const g of rows) byId.set(g.id, { ...g, children: [], depth: 0 });
+		const roots: GoalNode[] = [];
+		for (const node of byId.values()) {
+			if (node.parentId && byId.has(node.parentId)) {
+				const parent = byId.get(node.parentId)!;
+				parent.children.push(node);
+			} else {
+				roots.push(node);
+			}
+		}
+		// Assign depths via DFS
+		const walk = (n: GoalNode, depth: number) => {
+			n.depth = depth;
+			for (const c of n.children) walk(c, depth + 1);
+		};
+		roots.forEach((r) => walk(r, 0));
+		return roots;
+	}
+
+	function flatten(roots: GoalNode[]): GoalNode[] {
+		const out: GoalNode[] = [];
+		const walk = (n: GoalNode) => {
+			out.push(n);
+			n.children.forEach(walk);
+		};
+		roots.forEach(walk);
+		return out;
+	}
+
+	const flat = $derived(flatten(buildForest(goals)));
+
+	const STATUS_BADGE: Record<GoalStatus, string> = {
+		planned: 'bg-muted text-muted-foreground',
+		active: 'bg-blue-500/10 text-blue-600',
+		achieved: 'bg-green-500/10 text-green-600',
+		cancelled: 'bg-muted text-muted-foreground/50',
+	};
+
+	const STATUS_LABELS: Record<GoalStatus, string> = {
+		planned: 'Planned',
+		active: 'Active',
+		achieved: 'Achieved',
+		cancelled: 'Cancelled',
+	};
+
+	const LEVEL_LABEL: Record<GoalLevel, string> = {
+		company: 'Company',
+		team: 'Team',
+		agent: 'Agent',
+		task: 'Task',
+	};
+
+	const LEVEL_TINT: Record<GoalLevel, string> = {
+		company: 'border-l-amber-500',
+		team: 'border-l-blue-500',
+		agent: 'border-l-purple-500',
+		task: 'border-l-gray-500',
+	};
+
+	function agentLabel(agentId: string | null): string {
+		if (!agentId) return '—';
+		return agentNames[agentId] ?? `${agentId.slice(0, 8)}…`;
+	}
+
+	// Quick aggregate per status for the header chips
+	const counts = $derived.by(() => {
+		const out: Record<GoalStatus, number> = { planned: 0, active: 0, achieved: 0, cancelled: 0 };
+		for (const g of goals) out[g.status] += 1;
+		return out;
+	});
+
+	onMount(() => startPolling('app:goals', 8000));
+</script>
+
+<div class="p-6 space-y-6 max-w-5xl">
+	<header class="flex items-center justify-between flex-wrap gap-3">
+		<div class="flex items-center gap-3">
+			<h1 class="text-2xl font-semibold">Goals</h1>
+			<LiveIndicator intervalMs={8000} />
+		</div>
+		<div class="flex flex-wrap gap-2 text-xs">
+			{#each (['active', 'planned', 'achieved', 'cancelled'] as GoalStatus[]) as s (s)}
+				{#if counts[s] > 0}
+					<span class="rounded-full px-2 py-0.5 font-medium {STATUS_BADGE[s]}">
+						{counts[s]} {STATUS_LABELS[s].toLowerCase()}
+					</span>
+				{/if}
+			{/each}
+		</div>
+	</header>
+
+	{#if goals.length === 0}
+		<div class="rounded-lg border border-border bg-card p-12 flex flex-col items-center justify-center text-center">
+			<p class="text-muted-foreground text-sm">No goals defined.</p>
+		</div>
+	{:else}
+		<ul class="space-y-2">
+			{#each flat as goal (goal.id)}
+				<li
+					class="relative rounded-lg border border-border border-l-4 bg-card px-4 py-3 text-sm flex flex-col gap-1.5 transition-colors hover:border-foreground/30 {LEVEL_TINT[goal.level]}"
+					style="margin-left: {goal.depth * 1.5}rem"
+				>
+					<div class="flex items-center gap-3 flex-wrap">
+						<span class="rounded px-1.5 py-0.5 text-[10px] font-medium {STATUS_BADGE[goal.status]}">
+							{STATUS_LABELS[goal.status]}
+						</span>
+						<span class="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
+							{LEVEL_LABEL[goal.level]}
+						</span>
+						<span class="font-medium flex-1 min-w-0 truncate">{goal.title}</span>
+						<span class="text-xs text-muted-foreground shrink-0">{agentLabel(goal.ownerAgentId)}</span>
+					</div>
+					{#if goal.description}
+						<p class="text-xs text-muted-foreground">{goal.description}</p>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</div>

--- a/src/routes/(app)/workforce/inbox/+page.server.ts
+++ b/src/routes/(app)/workforce/inbox/+page.server.ts
@@ -1,0 +1,38 @@
+import { redirect, error } from '@sveltejs/kit';
+import { paperclipServerClient, paperclipRawFetch } from '$lib/server/paperclip-fetch';
+import type { PageServerLoad } from './$types';
+
+export type InboxItem = {
+	id: string;
+	type: 'comment' | 'approval' | 'run_failed' | 'join_request' | 'mention' | 'goal_achieved' | 'paused';
+	title: string;
+	body: string | null;
+	actorAgentId: string | null;
+	actorUserId: string | null;
+	entityType: 'issue' | 'approval' | 'agent' | 'goal' | 'user' | null;
+	entityId: string | null;
+	href: string | null;
+	createdAt: string;
+	readAt: string | null;
+};
+
+export const load: PageServerLoad = async (event) => {
+	if (!event.locals.user) throw redirect(302, '/login');
+	if (!event.locals.paperclipIdentity?.companyId) {
+		throw redirect(302, '/workforce/welcome');
+	}
+	event.depends('app:inbox');
+	const companyId = event.locals.paperclipIdentity.companyId;
+	const client = paperclipServerClient(event);
+	try {
+		const [items, agents] = await Promise.all([
+			paperclipRawFetch<InboxItem[]>(event, `/api/companies/${companyId}/inbox`),
+			client.agents.list(companyId),
+		]);
+		const agentNames: Record<string, string> = {};
+		for (const a of agents) agentNames[a.id] = a.name;
+		return { items, agentNames };
+	} catch (e: any) {
+		throw error(e?.status ?? 502, 'paperclip unavailable');
+	}
+};

--- a/src/routes/(app)/workforce/inbox/+page.svelte
+++ b/src/routes/(app)/workforce/inbox/+page.svelte
@@ -126,7 +126,7 @@
 						<svelte:element
 							this={Tag}
 							href={item.href ?? undefined}
-							class="flex items-start gap-3 px-4 py-3 text-sm transition-colors {item.href ? 'hover:bg-accent' : ''} {!item.readAt ? 'bg-primary/5' : ''}"
+							class="relative flex items-start gap-3 px-4 py-3 text-sm text-foreground no-underline transition-colors {item.href ? 'hover:bg-accent hover:text-accent-foreground' : ''} {!item.readAt ? 'border-l-2 border-l-primary -ml-px' : ''}"
 						>
 							<!-- Type icon badge -->
 							<span
@@ -140,7 +140,7 @@
 							<!-- Body -->
 							<div class="flex-1 min-w-0 space-y-0.5">
 								<div class="flex items-center gap-2 flex-wrap">
-									<span class="font-medium truncate">{item.title}</span>
+									<span class="font-medium text-foreground truncate">{item.title}</span>
 									{#if !item.readAt}
 										<span class="shrink-0 h-1.5 w-1.5 rounded-full bg-primary" title="Unread"></span>
 									{/if}

--- a/src/routes/(app)/workforce/inbox/+page.svelte
+++ b/src/routes/(app)/workforce/inbox/+page.svelte
@@ -1,0 +1,173 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { PageData } from './$types';
+	import type { InboxItem } from './+page.server';
+	import { startPolling } from '$lib/util/live-polling';
+	import LiveIndicator from '$lib/components/LiveIndicator.svelte';
+
+	let { data }: { data: PageData } = $props();
+	const { items, agentNames } = $derived(data);
+
+	let filter = $state<'all' | 'unread'>('all');
+
+	const filtered = $derived.by(() => {
+		if (filter === 'unread') return items.filter((i) => !i.readAt);
+		return items;
+	});
+
+	const unreadCount = $derived(items.filter((i) => !i.readAt).length);
+
+	// Type → icon glyph + accent color
+	const TYPE_META: Record<InboxItem['type'], { icon: string; tint: string; label: string }> = {
+		comment: { icon: '💬', tint: 'bg-blue-500/10 text-blue-600 border-blue-500/30', label: 'Comment' },
+		mention: { icon: '@', tint: 'bg-purple-500/10 text-purple-600 border-purple-500/30', label: 'Mention' },
+		approval: { icon: '✓', tint: 'bg-amber-500/10 text-amber-600 border-amber-500/30', label: 'Approval' },
+		run_failed: { icon: '!', tint: 'bg-destructive/10 text-destructive border-destructive/30', label: 'Run failed' },
+		join_request: { icon: '+', tint: 'bg-blue-500/10 text-blue-600 border-blue-500/30', label: 'Join request' },
+		goal_achieved: { icon: '★', tint: 'bg-green-500/10 text-green-600 border-green-500/30', label: 'Goal achieved' },
+		paused: { icon: '⏸', tint: 'bg-muted text-muted-foreground border-border', label: 'Paused' },
+	};
+
+	function bucketLabel(iso: string): string {
+		const d = new Date(iso).getTime();
+		const now = Date.now();
+		const today = new Date();
+		today.setHours(0, 0, 0, 0);
+		const startOfToday = today.getTime();
+		const startOfYesterday = startOfToday - 86_400_000;
+		const startOfWeek = startOfToday - 6 * 86_400_000;
+		if (d >= startOfToday) return 'Today';
+		if (d >= startOfYesterday) return 'Yesterday';
+		if (d >= startOfWeek) return 'This week';
+		return 'Earlier';
+	}
+
+	const grouped = $derived.by(() => {
+		const buckets: Array<{ label: string; items: InboxItem[] }> = [];
+		const order = ['Today', 'Yesterday', 'This week', 'Earlier'];
+		const map = new Map<string, InboxItem[]>();
+		for (const item of filtered) {
+			const b = bucketLabel(item.createdAt);
+			if (!map.has(b)) map.set(b, []);
+			map.get(b)!.push(item);
+		}
+		for (const label of order) {
+			const list = map.get(label);
+			if (list && list.length > 0) buckets.push({ label, items: list });
+		}
+		return buckets;
+	});
+
+	function relativeTime(iso: string): string {
+		const diff = Date.now() - new Date(iso).getTime();
+		if (diff < 60_000) return 'just now';
+		if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+		if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+		return `${Math.floor(diff / 86_400_000)}d ago`;
+	}
+
+	function actorLabel(agentId: string | null, userId: string | null): string {
+		if (agentId) return agentNames[agentId] ?? `${agentId.slice(0, 8)}…`;
+		if (userId) return `user:${userId.slice(0, 6)}…`;
+		return 'system';
+	}
+
+	onMount(() => startPolling('app:inbox', 6000));
+</script>
+
+<div class="p-6 space-y-6 max-w-4xl">
+	<header class="flex items-center justify-between flex-wrap gap-3">
+		<div class="flex items-center gap-3">
+			<h1 class="text-2xl font-semibold">Inbox</h1>
+			<LiveIndicator intervalMs={6000} />
+			{#if unreadCount > 0}
+				<span class="rounded-full bg-primary/10 text-primary px-2 py-0.5 text-xs font-medium">
+					{unreadCount} unread
+				</span>
+			{/if}
+		</div>
+
+		<!-- Filter tabs -->
+		<div class="flex gap-1 rounded-lg border border-border bg-card p-1">
+			<button
+				type="button"
+				class="px-3 py-1 rounded text-xs font-medium transition-colors {filter === 'all' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'}"
+				onclick={() => (filter = 'all')}
+			>
+				All ({items.length})
+			</button>
+			<button
+				type="button"
+				class="px-3 py-1 rounded text-xs font-medium transition-colors {filter === 'unread' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'}"
+				onclick={() => (filter = 'unread')}
+			>
+				Unread ({unreadCount})
+			</button>
+		</div>
+	</header>
+
+	{#if filtered.length === 0}
+		<div class="rounded-lg border border-border bg-card p-12 flex flex-col items-center justify-center text-center">
+			<div class="text-3xl mb-2">📬</div>
+			<p class="text-muted-foreground text-sm">
+				{filter === 'unread' ? 'All caught up.' : 'No notifications.'}
+			</p>
+		</div>
+	{:else}
+		{#each grouped as bucket (bucket.label)}
+			<section class="space-y-2">
+				<h2 class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+					{bucket.label}
+				</h2>
+				<ul class="rounded-lg border border-border bg-card divide-y divide-border">
+					{#each bucket.items as item (item.id)}
+						{@const meta = TYPE_META[item.type]}
+						{@const Tag = item.href ? 'a' : 'div'}
+						<svelte:element
+							this={Tag}
+							href={item.href ?? undefined}
+							class="flex items-start gap-3 px-4 py-3 text-sm transition-colors {item.href ? 'hover:bg-accent' : ''} {!item.readAt ? 'bg-primary/5' : ''}"
+						>
+							<!-- Type icon badge -->
+							<span
+								class="shrink-0 mt-0.5 h-7 w-7 flex items-center justify-center rounded-md border text-sm font-medium {meta.tint}"
+								title={meta.label}
+								aria-label={meta.label}
+							>
+								{meta.icon}
+							</span>
+
+							<!-- Body -->
+							<div class="flex-1 min-w-0 space-y-0.5">
+								<div class="flex items-center gap-2 flex-wrap">
+									<span class="font-medium truncate">{item.title}</span>
+									{#if !item.readAt}
+										<span class="shrink-0 h-1.5 w-1.5 rounded-full bg-primary" title="Unread"></span>
+									{/if}
+								</div>
+								{#if item.body}
+									<p class="text-xs text-muted-foreground line-clamp-2">{item.body}</p>
+								{/if}
+								<div class="text-[10px] text-muted-foreground/70 flex items-center gap-1.5 pt-0.5">
+									<span>{actorLabel(item.actorAgentId, item.actorUserId)}</span>
+									{#if item.entityType}
+										<span aria-hidden="true">·</span>
+										<span class="font-mono">{item.entityType}</span>
+									{/if}
+								</div>
+							</div>
+
+							<!-- Timestamp -->
+							<time
+								class="shrink-0 text-xs text-muted-foreground whitespace-nowrap"
+								datetime={item.createdAt}
+							>
+								{relativeTime(item.createdAt)}
+							</time>
+						</svelte:element>
+					{/each}
+				</ul>
+			</section>
+		{/each}
+	{/if}
+</div>

--- a/src/routes/(app)/workforce/inbox/+page.svelte
+++ b/src/routes/(app)/workforce/inbox/+page.svelte
@@ -126,7 +126,7 @@
 						<svelte:element
 							this={Tag}
 							href={item.href ?? undefined}
-							class="relative flex items-start gap-3 px-4 py-3 text-sm text-foreground no-underline transition-colors {item.href ? 'hover:bg-accent hover:text-accent-foreground' : ''} {!item.readAt ? 'border-l-2 border-l-primary -ml-px' : ''}"
+							class="relative flex items-start gap-3 px-4 py-3 text-sm text-foreground no-underline transition-colors {item.href ? 'hover:bg-muted' : ''} {!item.readAt ? 'border-l-2 border-l-primary -ml-px' : ''}"
 						>
 							<!-- Type icon badge -->
 							<span

--- a/src/routes/(app)/workforce/issues/+page.server.ts
+++ b/src/routes/(app)/workforce/issues/+page.server.ts
@@ -1,0 +1,18 @@
+import { redirect, error } from '@sveltejs/kit';
+import { paperclipServerClient } from '$lib/server/paperclip-fetch';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async (event) => {
+	if (!event.locals.user) throw redirect(302, '/login');
+	if (!event.locals.paperclipIdentity?.companyId) {
+		throw redirect(302, '/workforce/welcome');
+	}
+	const companyId = event.locals.paperclipIdentity.companyId;
+	const client = paperclipServerClient(event);
+	try {
+		const items = await client.issues.list(companyId);
+		return { items };
+	} catch (e: any) {
+		throw error(e?.status ?? 502, 'paperclip unavailable');
+	}
+};

--- a/src/routes/(app)/workforce/issues/+page.server.ts
+++ b/src/routes/(app)/workforce/issues/+page.server.ts
@@ -7,11 +7,13 @@ export const load: PageServerLoad = async (event) => {
 	if (!event.locals.paperclipIdentity?.companyId) {
 		throw redirect(302, '/workforce/welcome');
 	}
+	event.depends('app:issues');
 	const companyId = event.locals.paperclipIdentity.companyId;
+	const status = event.url.searchParams.get('status') ?? undefined;
 	const client = paperclipServerClient(event);
 	try {
-		const items = await client.issues.list(companyId);
-		return { items };
+		const items = await client.issues.list(companyId, status ? { status } : undefined);
+		return { items, status: status ?? null };
 	} catch (e: any) {
 		throw error(e?.status ?? 502, 'paperclip unavailable');
 	}

--- a/src/routes/(app)/workforce/issues/+page.svelte
+++ b/src/routes/(app)/workforce/issues/+page.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import type { PageData } from './$types';
 	import type { IssueStatus } from '@minion-stack/paperclip-client';
+	import { startPolling } from '$lib/util/live-polling';
+	import LiveIndicator from '$lib/components/LiveIndicator.svelte';
 
 	let { data }: { data: PageData } = $props();
 
-	const { items } = $derived(data);
+	const { items, status } = $derived(data);
+
+	onMount(() => startPolling('app:issues', 5000));
 
 	const STATUS_ORDER: IssueStatus[] = ['in_progress', 'blocked', 'todo', 'backlog', 'in_review', 'done', 'cancelled'];
 
@@ -54,8 +59,21 @@
 </script>
 
 <div class="p-6 space-y-6">
-	<div class="flex items-center justify-between">
-		<h1 class="text-2xl font-semibold">Issues</h1>
+	<div class="flex items-center justify-between flex-wrap gap-3">
+		<div class="flex items-center gap-3 flex-wrap">
+			<h1 class="text-2xl font-semibold">Issues</h1>
+			<LiveIndicator intervalMs={5000} />
+			{#if status}
+				<a
+					href="/workforce/issues"
+					class="inline-flex items-center gap-1.5 rounded-full bg-primary/10 text-primary px-2.5 py-0.5 text-xs font-medium hover:bg-primary/15"
+					title="Clear filter"
+				>
+					status: {STATUS_LABELS[status as IssueStatus] ?? status}
+					<span aria-hidden="true">×</span>
+				</a>
+			{/if}
+		</div>
 		<span class="text-sm text-muted-foreground">{items.length} issue{items.length !== 1 ? 's' : ''}</span>
 	</div>
 

--- a/src/routes/(app)/workforce/issues/+page.svelte
+++ b/src/routes/(app)/workforce/issues/+page.svelte
@@ -93,7 +93,7 @@
 				<ul class="divide-y divide-border rounded-lg border border-border bg-card">
 					{#each group.issues as issue (issue.id)}
 						<li>
-							<a href="/workforce/issues/{issue.id}" class="px-4 py-2.5 flex items-center gap-3 text-sm hover:bg-accent transition-colors">
+							<a href="/workforce/issues/{issue.id}" class="px-4 py-2.5 flex items-center gap-3 text-sm hover:bg-muted transition-colors">
 								<!-- Status badge -->
 								<span
 									class="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium {STATUS_BADGE[issue.status]}"

--- a/src/routes/(app)/workforce/issues/+page.svelte
+++ b/src/routes/(app)/workforce/issues/+page.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import type { IssueStatus } from '@minion-stack/paperclip-client';
+
+	let { data }: { data: PageData } = $props();
+
+	const { items } = $derived(data);
+
+	const STATUS_ORDER: IssueStatus[] = ['in_progress', 'blocked', 'todo', 'backlog', 'in_review', 'done', 'cancelled'];
+
+	const STATUS_LABELS: Record<IssueStatus, string> = {
+		in_progress: 'In Progress',
+		blocked: 'Blocked',
+		todo: 'To Do',
+		backlog: 'Backlog',
+		in_review: 'In Review',
+		done: 'Done',
+		cancelled: 'Cancelled',
+	};
+
+	const STATUS_BADGE: Record<IssueStatus, string> = {
+		in_progress: 'bg-blue-500/10 text-blue-600',
+		blocked: 'bg-amber-500/10 text-amber-600',
+		todo: 'bg-muted text-muted-foreground',
+		backlog: 'bg-muted text-muted-foreground',
+		in_review: 'bg-purple-500/10 text-purple-600',
+		done: 'bg-green-500/10 text-green-600',
+		cancelled: 'bg-muted text-muted-foreground/50',
+	};
+
+	const PRIORITY_BADGE: Record<string, string> = {
+		critical: 'text-red-500',
+		high: 'text-orange-500',
+		medium: 'text-yellow-600',
+		low: 'text-muted-foreground',
+	};
+
+	// Group issues by status in display order; skip empty groups
+	const grouped = $derived(() => {
+		const map = new Map<IssueStatus, typeof items>();
+		for (const s of STATUS_ORDER) map.set(s, []);
+		for (const issue of items) {
+			const bucket = map.get(issue.status);
+			if (bucket) bucket.push(issue);
+		}
+		return STATUS_ORDER
+			.map((s) => ({ status: s, issues: map.get(s) ?? [] }))
+			.filter((g) => g.issues.length > 0);
+	});
+
+	function formatDate(d: Date | string): string {
+		return new Date(d).toLocaleDateString([], { month: 'short', day: 'numeric' });
+	}
+</script>
+
+<div class="p-6 space-y-6">
+	<div class="flex items-center justify-between">
+		<h1 class="text-2xl font-semibold">Issues</h1>
+		<span class="text-sm text-muted-foreground">{items.length} issue{items.length !== 1 ? 's' : ''}</span>
+	</div>
+
+	{#if items.length === 0}
+		<div class="rounded-lg border border-border bg-card p-12 flex flex-col items-center justify-center text-center">
+			<p class="text-muted-foreground text-sm">No issues found.</p>
+		</div>
+	{:else}
+		{#each grouped() as group (group.status)}
+			<section aria-label={STATUS_LABELS[group.status]}>
+				<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2 flex items-center gap-2">
+					{STATUS_LABELS[group.status]}
+					<span class="text-xs font-medium text-muted-foreground/60 normal-case tracking-normal">
+						{group.issues.length}
+					</span>
+				</h2>
+				<ul class="divide-y divide-border rounded-lg border border-border bg-card">
+					{#each group.issues as issue (issue.id)}
+						<li class="px-4 py-2.5 flex items-center gap-3 text-sm">
+							<!-- Status badge -->
+							<span
+								class="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium {STATUS_BADGE[issue.status]}"
+							>
+								{STATUS_LABELS[issue.status]}
+							</span>
+
+							<!-- Identifier -->
+							{#if issue.identifier}
+								<span class="shrink-0 text-xs font-mono text-muted-foreground">
+									{issue.identifier}
+								</span>
+							{/if}
+
+							<!-- Title -->
+							<span class="flex-1 min-w-0 truncate font-medium">{issue.title}</span>
+
+							<!-- Priority -->
+							{#if issue.priority}
+								<span class="shrink-0 text-xs font-medium {PRIORITY_BADGE[issue.priority] ?? 'text-muted-foreground'}">
+									{issue.priority}
+								</span>
+							{/if}
+
+							<!-- Assignee -->
+							{#if issue.assigneeAgentId}
+								<span class="shrink-0 text-xs text-muted-foreground truncate max-w-[8rem]" title={issue.assigneeAgentId}>
+									{issue.assigneeAgentId.slice(0, 8)}…
+								</span>
+							{/if}
+
+							<!-- Created at -->
+							<time
+								class="shrink-0 text-xs text-muted-foreground whitespace-nowrap"
+								datetime={new Date(issue.createdAt).toISOString()}
+							>
+								{formatDate(issue.createdAt)}
+							</time>
+						</li>
+					{/each}
+				</ul>
+			</section>
+		{/each}
+	{/if}
+</div>

--- a/src/routes/(app)/workforce/issues/+page.svelte
+++ b/src/routes/(app)/workforce/issues/+page.svelte
@@ -74,23 +74,24 @@
 				</h2>
 				<ul class="divide-y divide-border rounded-lg border border-border bg-card">
 					{#each group.issues as issue (issue.id)}
-						<li class="px-4 py-2.5 flex items-center gap-3 text-sm">
-							<!-- Status badge -->
-							<span
-								class="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium {STATUS_BADGE[issue.status]}"
-							>
-								{STATUS_LABELS[issue.status]}
-							</span>
-
-							<!-- Identifier -->
-							{#if issue.identifier}
-								<span class="shrink-0 text-xs font-mono text-muted-foreground">
-									{issue.identifier}
+						<li>
+							<a href="/workforce/issues/{issue.id}" class="px-4 py-2.5 flex items-center gap-3 text-sm hover:bg-accent transition-colors">
+								<!-- Status badge -->
+								<span
+									class="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium {STATUS_BADGE[issue.status]}"
+								>
+									{STATUS_LABELS[issue.status]}
 								</span>
-							{/if}
 
-							<!-- Title -->
-							<span class="flex-1 min-w-0 truncate font-medium">{issue.title}</span>
+								<!-- Identifier -->
+								{#if issue.identifier}
+									<span class="shrink-0 text-xs font-mono text-muted-foreground">
+										{issue.identifier}
+									</span>
+								{/if}
+
+								<!-- Title -->
+								<span class="flex-1 min-w-0 truncate font-medium">{issue.title}</span>
 
 							<!-- Priority -->
 							{#if issue.priority}
@@ -106,13 +107,14 @@
 								</span>
 							{/if}
 
-							<!-- Created at -->
-							<time
-								class="shrink-0 text-xs text-muted-foreground whitespace-nowrap"
-								datetime={new Date(issue.createdAt).toISOString()}
-							>
-								{formatDate(issue.createdAt)}
-							</time>
+								<!-- Created at -->
+								<time
+									class="shrink-0 text-xs text-muted-foreground whitespace-nowrap"
+									datetime={new Date(issue.createdAt).toISOString()}
+								>
+									{formatDate(issue.createdAt)}
+								</time>
+							</a>
 						</li>
 					{/each}
 				</ul>

--- a/src/routes/(app)/workforce/issues/[id]/+page.server.ts
+++ b/src/routes/(app)/workforce/issues/[id]/+page.server.ts
@@ -1,0 +1,32 @@
+import { redirect, error } from '@sveltejs/kit';
+import { paperclipServerClient } from '$lib/server/paperclip-fetch';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async (event) => {
+	if (!event.locals.user) throw redirect(302, '/login');
+	if (!event.locals.paperclipIdentity?.companyId) {
+		throw redirect(302, '/workforce/welcome');
+	}
+	const companyId = event.locals.paperclipIdentity.companyId;
+	const issueId = event.params.id;
+	const client = paperclipServerClient(event);
+
+	try {
+		const [issue, comments, documents, workProducts, approvals, children, agents] = await Promise.all([
+			client.issues.get(issueId),
+			client.issues.listComments(issueId),
+			client.issues.listDocuments(issueId),
+			client.issues.listWorkProducts(issueId),
+			client.issues.listApprovals(issueId),
+			client.issues.list(companyId, { parentId: issueId }),
+			client.agents.list(companyId),
+		]);
+
+		const agentNames: Record<string, string> = {};
+		for (const a of agents) agentNames[a.id] = a.name;
+
+		return { issue, comments, documents, workProducts, approvals, children, agentNames };
+	} catch (e: any) {
+		throw error(e?.status ?? 502, e?.status === 404 ? 'issue not found' : 'paperclip unavailable');
+	}
+};

--- a/src/routes/(app)/workforce/issues/[id]/+page.svelte
+++ b/src/routes/(app)/workforce/issues/[id]/+page.svelte
@@ -1,0 +1,269 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import type { IssueStatus } from '@minion-stack/paperclip-client';
+
+	let { data }: { data: PageData } = $props();
+	const { issue, comments, documents, workProducts, approvals, children, agentNames } = $derived(data);
+
+	const STATUS_LABELS: Record<IssueStatus, string> = {
+		in_progress: 'In Progress',
+		blocked: 'Blocked',
+		todo: 'To Do',
+		backlog: 'Backlog',
+		in_review: 'In Review',
+		done: 'Done',
+		cancelled: 'Cancelled',
+	};
+
+	const STATUS_BADGE: Record<IssueStatus, string> = {
+		in_progress: 'bg-blue-500/10 text-blue-600',
+		blocked: 'bg-amber-500/10 text-amber-600',
+		todo: 'bg-muted text-muted-foreground',
+		backlog: 'bg-muted text-muted-foreground',
+		in_review: 'bg-purple-500/10 text-purple-600',
+		done: 'bg-green-500/10 text-green-600',
+		cancelled: 'bg-muted text-muted-foreground/50',
+	};
+
+	const PRIORITY_BADGE: Record<string, string> = {
+		critical: 'text-red-500',
+		high: 'text-orange-500',
+		medium: 'text-yellow-600',
+		low: 'text-muted-foreground',
+	};
+
+	function actorLabel(agentId: string | null, userId: string | null): string {
+		if (agentId) return agentNames[agentId] ?? `${agentId.slice(0, 8)}…`;
+		if (userId) return `user:${userId.slice(0, 6)}…`;
+		return 'unknown';
+	}
+
+	function formatDate(d: Date | string | null): string {
+		if (!d) return '—';
+		return new Date(d).toLocaleString([], {
+			month: 'short',
+			day: 'numeric',
+			hour: 'numeric',
+			minute: '2-digit',
+		});
+	}
+
+	const ancestors = $derived(issue.ancestors ?? []);
+</script>
+
+<div class="p-6 space-y-6 max-w-5xl">
+	<!-- Breadcrumb -->
+	<nav class="text-sm text-muted-foreground flex flex-wrap items-center gap-1">
+		<a href="/workforce/issues" class="hover:text-foreground">Issues</a>
+		{#each ancestors as a (a.id)}
+			<span>/</span>
+			<a href="/workforce/issues/{a.id}" class="hover:text-foreground truncate max-w-[16rem]">
+				{#if a.identifier}<span class="font-mono text-xs">{a.identifier}</span>{/if}
+				{a.title}
+			</a>
+		{/each}
+		<span>/</span>
+		<span class="text-foreground truncate">
+			{#if issue.identifier}<span class="font-mono text-xs">{issue.identifier}</span>{/if}
+		</span>
+	</nav>
+
+	<!-- Header -->
+	<header class="space-y-3">
+		<div class="flex items-start gap-3">
+			<span class="rounded px-2 py-0.5 text-xs font-medium {STATUS_BADGE[issue.status]}">
+				{STATUS_LABELS[issue.status]}
+			</span>
+			{#if issue.identifier}
+				<span class="text-xs font-mono text-muted-foreground pt-1">{issue.identifier}</span>
+			{/if}
+			<span class="text-xs font-medium pt-1 {PRIORITY_BADGE[issue.priority] ?? 'text-muted-foreground'}">
+				{issue.priority}
+			</span>
+		</div>
+		<h1 class="text-2xl font-semibold leading-tight">{issue.title}</h1>
+		{#if issue.description}
+			<p class="text-sm text-foreground/80 whitespace-pre-wrap leading-relaxed">{issue.description}</p>
+		{/if}
+	</header>
+
+	<!-- Two-column layout: main content + properties sidebar -->
+	<div class="grid grid-cols-1 lg:grid-cols-[1fr_18rem] gap-6">
+		<div class="space-y-6 min-w-0">
+			<!-- Sub-issues -->
+			<section>
+				<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+					Sub-issues <span class="font-medium normal-case tracking-normal text-xs">({children.length})</span>
+				</h2>
+				{#if children.length === 0}
+					<div class="rounded-lg border border-border bg-card p-4 text-sm text-muted-foreground">
+						No sub-issues.
+					</div>
+				{:else}
+					<ul class="divide-y divide-border rounded-lg border border-border bg-card">
+						{#each children as child (child.id)}
+							<li class="px-4 py-2.5 flex items-center gap-3 text-sm">
+								<span class="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium {STATUS_BADGE[child.status]}">
+									{STATUS_LABELS[child.status]}
+								</span>
+								{#if child.identifier}
+									<span class="shrink-0 text-xs font-mono text-muted-foreground">{child.identifier}</span>
+								{/if}
+								<a class="flex-1 min-w-0 truncate font-medium hover:underline" href="/workforce/issues/{child.id}">
+									{child.title}
+								</a>
+								<span class="shrink-0 text-xs {PRIORITY_BADGE[child.priority] ?? 'text-muted-foreground'}">
+									{child.priority}
+								</span>
+								{#if child.assigneeAgentId}
+									<span class="shrink-0 text-xs text-muted-foreground truncate max-w-[10rem]">
+										{actorLabel(child.assigneeAgentId, child.assigneeUserId)}
+									</span>
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</section>
+
+			<!-- Documents -->
+			<section>
+				<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+					Documents <span class="font-medium normal-case tracking-normal text-xs">({documents.length})</span>
+				</h2>
+				{#if documents.length === 0}
+					<div class="rounded-lg border border-border bg-card p-4 text-sm text-muted-foreground">
+						No documents.
+					</div>
+				{:else}
+					<ul class="divide-y divide-border rounded-lg border border-border bg-card">
+						{#each documents as doc (doc.id)}
+							<li class="px-4 py-2.5 text-sm flex items-center gap-3">
+								<span class="font-mono text-xs text-muted-foreground shrink-0">{doc.key}</span>
+								<span class="flex-1 min-w-0 truncate font-medium">{doc.title ?? doc.key}</span>
+								<span class="shrink-0 text-xs text-muted-foreground">rev {doc.latestRevisionNumber}</span>
+								<time class="shrink-0 text-xs text-muted-foreground" datetime={new Date(doc.updatedAt).toISOString()}>
+									{formatDate(doc.updatedAt)}
+								</time>
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</section>
+
+			<!-- Work products -->
+			<section>
+				<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+					Work products <span class="font-medium normal-case tracking-normal text-xs">({workProducts.length})</span>
+				</h2>
+				{#if workProducts.length === 0}
+					<div class="rounded-lg border border-border bg-card p-4 text-sm text-muted-foreground">
+						No work products yet.
+					</div>
+				{:else}
+					<ul class="divide-y divide-border rounded-lg border border-border bg-card">
+						{#each workProducts as wp (wp.id)}
+							<li class="px-4 py-3 text-sm space-y-1">
+								<div class="flex items-center gap-2">
+									<span class="font-medium">{wp.title}</span>
+									<span class="rounded bg-muted px-1.5 py-0.5 text-xs">{wp.type}</span>
+									<span class="text-xs text-muted-foreground">{wp.status}</span>
+								</div>
+								{#if wp.summary}
+									<p class="text-xs text-muted-foreground">{wp.summary}</p>
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</section>
+
+			<!-- Linked approvals -->
+			{#if approvals.length > 0}
+				<section>
+					<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+						Linked approvals
+					</h2>
+					<ul class="divide-y divide-border rounded-lg border border-border bg-card">
+						{#each approvals as a (a.id)}
+							<li class="px-4 py-3 text-sm space-y-1">
+								<div class="flex items-center gap-2">
+									<span class="font-mono text-xs text-muted-foreground">{a.id}</span>
+									<span class="rounded bg-muted px-1.5 py-0.5 text-xs">{a.type}</span>
+									<span class="text-xs">{a.status}</span>
+								</div>
+								{#if a.payload && typeof a.payload === 'object' && 'description' in a.payload}
+									<p class="text-xs text-muted-foreground">{(a.payload as any).description}</p>
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				</section>
+			{/if}
+
+			<!-- Comments -->
+			<section>
+				<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+					Comments <span class="font-medium normal-case tracking-normal text-xs">({comments.length})</span>
+				</h2>
+				{#if comments.length === 0}
+					<div class="rounded-lg border border-border bg-card p-4 text-sm text-muted-foreground">
+						No comments.
+					</div>
+				{:else}
+					<ul class="space-y-3">
+						{#each comments as c (c.id)}
+							<li class="rounded-lg border border-border bg-card px-4 py-3 text-sm space-y-1.5">
+								<div class="flex items-center gap-2 text-xs text-muted-foreground">
+									<span class="font-medium text-foreground">{actorLabel(c.authorAgentId, c.authorUserId)}</span>
+									<time datetime={new Date(c.createdAt).toISOString()}>{formatDate(c.createdAt)}</time>
+								</div>
+								<p class="whitespace-pre-wrap leading-relaxed">{c.body}</p>
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</section>
+		</div>
+
+		<!-- Properties sidebar -->
+		<aside class="space-y-4">
+			<div class="rounded-lg border border-border bg-card p-4 space-y-3 text-sm">
+				<div>
+					<div class="text-xs uppercase tracking-wider text-muted-foreground mb-0.5">Assignee</div>
+					<div>{actorLabel(issue.assigneeAgentId, issue.assigneeUserId)}</div>
+				</div>
+				<div>
+					<div class="text-xs uppercase tracking-wider text-muted-foreground mb-0.5">Created by</div>
+					<div>{actorLabel(issue.createdByAgentId, issue.createdByUserId)}</div>
+				</div>
+				<div>
+					<div class="text-xs uppercase tracking-wider text-muted-foreground mb-0.5">Created</div>
+					<div>{formatDate(issue.createdAt)}</div>
+				</div>
+				<div>
+					<div class="text-xs uppercase tracking-wider text-muted-foreground mb-0.5">Updated</div>
+					<div>{formatDate(issue.updatedAt)}</div>
+				</div>
+				{#if issue.startedAt}
+					<div>
+						<div class="text-xs uppercase tracking-wider text-muted-foreground mb-0.5">Started</div>
+						<div>{formatDate(issue.startedAt)}</div>
+					</div>
+				{/if}
+				{#if issue.completedAt}
+					<div>
+						<div class="text-xs uppercase tracking-wider text-muted-foreground mb-0.5">Completed</div>
+						<div>{formatDate(issue.completedAt)}</div>
+					</div>
+				{/if}
+				{#if issue.executionRunId}
+					<div>
+						<div class="text-xs uppercase tracking-wider text-muted-foreground mb-0.5">Run</div>
+						<div class="font-mono text-xs">{issue.executionRunId}</div>
+					</div>
+				{/if}
+			</div>
+		</aside>
+	</div>
+</div>

--- a/src/routes/(app)/workforce/org/+page.server.ts
+++ b/src/routes/(app)/workforce/org/+page.server.ts
@@ -1,0 +1,22 @@
+import { redirect, error } from '@sveltejs/kit';
+import { paperclipServerClient } from '$lib/server/paperclip-fetch';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async (event) => {
+	if (!event.locals.user) throw redirect(302, '/login');
+	if (!event.locals.paperclipIdentity?.companyId) {
+		throw redirect(302, '/workforce/welcome');
+	}
+	event.depends('app:org');
+	const companyId = event.locals.paperclipIdentity.companyId;
+	const client = paperclipServerClient(event);
+	try {
+		const [tree, agents] = await Promise.all([
+			client.agents.org(companyId),
+			client.agents.list(companyId),
+		]);
+		return { tree, agents };
+	} catch (e: any) {
+		throw error(e?.status ?? 502, 'paperclip unavailable');
+	}
+};

--- a/src/routes/(app)/workforce/org/+page.svelte
+++ b/src/routes/(app)/workforce/org/+page.svelte
@@ -227,7 +227,7 @@
 		<!-- Zoom controls -->
 		<div class="absolute top-3 right-3 z-10 flex flex-col gap-1">
 			<button
-				class="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-sm hover:bg-accent transition-colors"
+				class="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-sm hover:bg-muted transition-colors"
 				onclick={zoomIn}
 				aria-label="Zoom in"
 				type="button"
@@ -235,7 +235,7 @@
 				+
 			</button>
 			<button
-				class="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-sm hover:bg-accent transition-colors"
+				class="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-sm hover:bg-muted transition-colors"
 				onclick={zoomOut}
 				aria-label="Zoom out"
 				type="button"
@@ -243,7 +243,7 @@
 				−
 			</button>
 			<button
-				class="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-[10px] hover:bg-accent transition-colors"
+				class="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-[10px] hover:bg-muted transition-colors"
 				onclick={fitToScreen}
 				title="Fit to screen"
 				aria-label="Fit chart to screen"

--- a/src/routes/(app)/workforce/org/+page.svelte
+++ b/src/routes/(app)/workforce/org/+page.svelte
@@ -1,0 +1,331 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { PageData } from './$types';
+	type OrgNode = { id: string; name: string; role: string; status: string; reports: OrgNode[] };
+	import { startPolling } from '$lib/util/live-polling';
+	import LiveIndicator from '$lib/components/LiveIndicator.svelte';
+
+	let { data }: { data: PageData } = $props();
+	const { tree, agents } = $derived(data);
+
+	const CARD_W = 220;
+	const CARD_H = 96;
+	const GAP_X = 36;
+	const GAP_Y = 72;
+	const PADDING = 48;
+
+	type LayoutNode = {
+		id: string;
+		name: string;
+		role: string;
+		status: string;
+		x: number;
+		y: number;
+		children: LayoutNode[];
+	};
+
+	function subtreeWidth(node: OrgNode): number {
+		if (node.reports.length === 0) return CARD_W;
+		const childrenW = node.reports.reduce((s: number, c: OrgNode) => s + subtreeWidth(c), 0);
+		const gaps = (node.reports.length - 1) * GAP_X;
+		return Math.max(CARD_W, childrenW + gaps);
+	}
+
+	function layoutTree(node: OrgNode, x: number, y: number): LayoutNode {
+		const totalW = subtreeWidth(node);
+		const layoutChildren: LayoutNode[] = [];
+		if (node.reports.length > 0) {
+			const childrenW = node.reports.reduce((s: number, c: OrgNode) => s + subtreeWidth(c), 0);
+			const gaps = (node.reports.length - 1) * GAP_X;
+			let cx = x + (totalW - childrenW - gaps) / 2;
+			for (const child of node.reports) {
+				const cw = subtreeWidth(child);
+				layoutChildren.push(layoutTree(child, cx, y + CARD_H + GAP_Y));
+				cx += cw + GAP_X;
+			}
+		}
+		return {
+			id: node.id,
+			name: node.name,
+			role: node.role,
+			status: node.status,
+			x: x + (totalW - CARD_W) / 2,
+			y,
+			children: layoutChildren,
+		};
+	}
+
+	function layoutForest(roots: OrgNode[]): LayoutNode[] {
+		let x = PADDING;
+		const y = PADDING;
+		const result: LayoutNode[] = [];
+		for (const root of roots) {
+			const w = subtreeWidth(root);
+			result.push(layoutTree(root, x, y));
+			x += w + GAP_X;
+		}
+		return result;
+	}
+
+	function flatten(nodes: LayoutNode[]): LayoutNode[] {
+		const out: LayoutNode[] = [];
+		const walk = (n: LayoutNode) => {
+			out.push(n);
+			n.children.forEach(walk);
+		};
+		nodes.forEach(walk);
+		return out;
+	}
+
+	function collectEdges(nodes: LayoutNode[]): Array<{ p: LayoutNode; c: LayoutNode }> {
+		const edges: Array<{ p: LayoutNode; c: LayoutNode }> = [];
+		const walk = (n: LayoutNode) => {
+			for (const c of n.children) {
+				edges.push({ p: n, c });
+				walk(c);
+			}
+		};
+		nodes.forEach(walk);
+		return edges;
+	}
+
+	const layout = $derived(layoutForest(tree));
+	const allNodes = $derived(flatten(layout));
+	const edges = $derived(collectEdges(layout));
+	const agentMap = $derived(new Map(agents.map((a) => [a.id, a])));
+
+	const bounds = $derived.by(() => {
+		if (allNodes.length === 0) return { w: 800, h: 600 };
+		let maxX = 0;
+		let maxY = 0;
+		for (const n of allNodes) {
+			if (n.x + CARD_W > maxX) maxX = n.x + CARD_W;
+			if (n.y + CARD_H > maxY) maxY = n.y + CARD_H;
+		}
+		return { w: maxX + PADDING, h: maxY + PADDING };
+	});
+
+	// Pan & zoom
+	let container: HTMLDivElement;
+	let pan = $state({ x: 0, y: 0 });
+	let zoom = $state(1);
+	let dragging = $state(false);
+	let dragStart = { x: 0, y: 0, panX: 0, panY: 0 };
+	let initialized = false;
+
+	function fitToScreen() {
+		if (!container) return;
+		const cW = container.clientWidth;
+		const cH = container.clientHeight;
+		const fitZoom = Math.min((cW - 40) / bounds.w, (cH - 40) / bounds.h, 1);
+		const chartW = bounds.w * fitZoom;
+		const chartH = bounds.h * fitZoom;
+		zoom = fitZoom;
+		pan = { x: (cW - chartW) / 2, y: (cH - chartH) / 2 };
+	}
+
+	function zoomIn() {
+		applyZoom(zoom * 1.2);
+	}
+	function zoomOut() {
+		applyZoom(zoom * 0.8);
+	}
+	function applyZoom(target: number) {
+		const next = Math.max(0.2, Math.min(2, target));
+		if (!container) {
+			zoom = next;
+			return;
+		}
+		const cx = container.clientWidth / 2;
+		const cy = container.clientHeight / 2;
+		const scale = next / zoom;
+		pan = { x: cx - scale * (cx - pan.x), y: cy - scale * (cy - pan.y) };
+		zoom = next;
+	}
+
+	function onMouseDown(e: MouseEvent) {
+		dragging = true;
+		dragStart = { x: e.clientX, y: e.clientY, panX: pan.x, panY: pan.y };
+	}
+	function onMouseMove(e: MouseEvent) {
+		if (!dragging) return;
+		pan = {
+			x: dragStart.panX + (e.clientX - dragStart.x),
+			y: dragStart.panY + (e.clientY - dragStart.y),
+		};
+	}
+	function onMouseUp() {
+		dragging = false;
+	}
+	function onWheel(e: WheelEvent) {
+		e.preventDefault();
+		if (!container) return;
+		const rect = container.getBoundingClientRect();
+		const mx = e.clientX - rect.left;
+		const my = e.clientY - rect.top;
+		const factor = e.deltaY < 0 ? 1.1 : 0.9;
+		const next = Math.max(0.2, Math.min(2, zoom * factor));
+		const scale = next / zoom;
+		pan = { x: mx - scale * (mx - pan.x), y: my - scale * (my - pan.y) };
+		zoom = next;
+	}
+
+	onMount(() => {
+		const stop = startPolling('app:org', 8000);
+		// Fit on first paint
+		requestAnimationFrame(() => {
+			if (!initialized) {
+				fitToScreen();
+				initialized = true;
+			}
+		});
+		return stop;
+	});
+
+	const STATUS_DOT: Record<string, string> = {
+		active: '#10b981',
+		running: '#3b82f6',
+		paused: '#f59e0b',
+		error: '#ef4444',
+		idle: '#6b7280',
+	};
+
+	function dotColor(status: string): string {
+		return STATUS_DOT[status] ?? '#6b7280';
+	}
+
+	function roleLabel(role: string): string {
+		return role.charAt(0).toUpperCase() + role.slice(1).replaceAll('_', ' ');
+	}
+</script>
+
+<div class="flex flex-col h-[calc(100vh-3.5rem)] p-6 gap-3">
+	<header class="flex items-center justify-between flex-wrap gap-3">
+		<div class="flex items-center gap-3">
+			<h1 class="text-2xl font-semibold">Org chart</h1>
+			<LiveIndicator intervalMs={8000} />
+		</div>
+		<div class="text-xs text-muted-foreground">
+			{allNodes.length} agent{allNodes.length !== 1 ? 's' : ''} · drag to pan · scroll to zoom
+		</div>
+	</header>
+
+	<div
+		bind:this={container}
+		role="application"
+		aria-label="Organisation chart canvas"
+		tabindex="-1"
+		class="relative flex-1 min-h-0 overflow-hidden rounded-lg border border-border bg-muted/20"
+		class:cursor-grab={!dragging}
+		class:cursor-grabbing={dragging}
+		onmousedown={onMouseDown}
+		onmousemove={onMouseMove}
+		onmouseup={onMouseUp}
+		onmouseleave={onMouseUp}
+		onwheel={onWheel}
+	>
+		<!-- Zoom controls -->
+		<div class="absolute top-3 right-3 z-10 flex flex-col gap-1">
+			<button
+				class="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-sm hover:bg-accent transition-colors"
+				onclick={zoomIn}
+				aria-label="Zoom in"
+				type="button"
+			>
+				+
+			</button>
+			<button
+				class="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-sm hover:bg-accent transition-colors"
+				onclick={zoomOut}
+				aria-label="Zoom out"
+				type="button"
+			>
+				−
+			</button>
+			<button
+				class="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-[10px] hover:bg-accent transition-colors"
+				onclick={fitToScreen}
+				title="Fit to screen"
+				aria-label="Fit chart to screen"
+				type="button"
+			>
+				Fit
+			</button>
+		</div>
+
+		<!-- Zoom % readout -->
+		<div class="absolute bottom-3 right-3 z-10 text-xs text-muted-foreground bg-background/80 backdrop-blur rounded px-2 py-1 font-mono">
+			{Math.round(zoom * 100)}%
+		</div>
+
+		<!-- Edges (SVG) -->
+		<svg class="absolute inset-0 pointer-events-none w-full h-full">
+			<g transform="translate({pan.x}, {pan.y}) scale({zoom})">
+				{#each edges as edge (`${edge.p.id}-${edge.c.id}`)}
+					{@const x1 = edge.p.x + CARD_W / 2}
+					{@const y1 = edge.p.y + CARD_H}
+					{@const x2 = edge.c.x + CARD_W / 2}
+					{@const y2 = edge.c.y}
+					{@const midY = (y1 + y2) / 2}
+					<path
+						d={`M ${x1} ${y1} L ${x1} ${midY} L ${x2} ${midY} L ${x2} ${y2}`}
+						fill="none"
+						stroke="var(--color-border, #2a2a2a)"
+						stroke-width="1.5"
+					/>
+				{/each}
+			</g>
+		</svg>
+
+		<!-- Cards -->
+		<div
+			class="absolute inset-0"
+			style="transform: translate({pan.x}px, {pan.y}px) scale({zoom}); transform-origin: 0 0;"
+		>
+			{#each allNodes as node (node.id)}
+				{@const a = agentMap.get(node.id)}
+				<a
+					href="/workforce/agents/{node.id}"
+					class="absolute bg-card border border-border rounded-lg shadow-sm hover:shadow-md hover:border-foreground/30 transition-[box-shadow,border-color] duration-150 select-none flex"
+					style="left: {node.x}px; top: {node.y}px; width: {CARD_W}px; min-height: {CARD_H}px;"
+				>
+					<div class="flex items-center px-4 py-3 gap-3 w-full">
+						<div class="relative shrink-0">
+							<div class="w-10 h-10 rounded-full bg-muted flex items-center justify-center text-sm font-semibold text-foreground/70">
+								{node.name.split(' ').map((w) => w[0]).slice(0, 2).join('')}
+							</div>
+							<span
+								class="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-card"
+								style="background:{dotColor(node.status)}"
+								title={node.status}
+							></span>
+						</div>
+						<div class="flex flex-col items-start min-w-0 flex-1">
+							<span class="text-sm font-semibold text-foreground leading-tight truncate w-full">
+								{node.name}
+							</span>
+							<span class="text-[11px] text-muted-foreground leading-tight mt-0.5">
+								{a?.title ?? roleLabel(node.role)}
+							</span>
+							{#if a?.adapterType}
+								<span class="text-[10px] text-muted-foreground/60 font-mono leading-tight mt-1">
+									{a.adapterType}
+								</span>
+							{/if}
+						</div>
+					</div>
+				</a>
+			{/each}
+		</div>
+	</div>
+
+	<!-- Status legend -->
+	<footer class="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+		{#each Object.entries(STATUS_DOT) as [status, color] (status)}
+			<span class="inline-flex items-center gap-1.5">
+				<span class="h-2 w-2 rounded-full" style="background:{color}"></span>
+				{status}
+			</span>
+		{/each}
+	</footer>
+</div>

--- a/src/routes/(app)/workforce/projects/+page.server.ts
+++ b/src/routes/(app)/workforce/projects/+page.server.ts
@@ -1,0 +1,24 @@
+import { redirect, error } from '@sveltejs/kit';
+import { paperclipServerClient } from '$lib/server/paperclip-fetch';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async (event) => {
+	if (!event.locals.user) throw redirect(302, '/login');
+	if (!event.locals.paperclipIdentity?.companyId) {
+		throw redirect(302, '/workforce/welcome');
+	}
+	event.depends('app:projects');
+	const companyId = event.locals.paperclipIdentity.companyId;
+	const client = paperclipServerClient(event);
+	try {
+		const [projects, agents] = await Promise.all([
+			client.projects.list(companyId),
+			client.agents.list(companyId),
+		]);
+		const agentNames: Record<string, string> = {};
+		for (const a of agents) agentNames[a.id] = a.name;
+		return { projects, agentNames };
+	} catch (e: any) {
+		throw error(e?.status ?? 502, 'paperclip unavailable');
+	}
+};

--- a/src/routes/(app)/workforce/projects/+page.svelte
+++ b/src/routes/(app)/workforce/projects/+page.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { PageData } from './$types';
+	import type { ProjectStatus } from '@minion-stack/paperclip-client';
+	import { startPolling } from '$lib/util/live-polling';
+	import LiveIndicator from '$lib/components/LiveIndicator.svelte';
+
+	let { data }: { data: PageData } = $props();
+	const { projects, agentNames } = $derived(data);
+
+	const STATUS_BADGE: Record<ProjectStatus, string> = {
+		backlog: 'bg-muted text-muted-foreground',
+		planned: 'bg-muted text-muted-foreground',
+		in_progress: 'bg-blue-500/10 text-blue-600',
+		completed: 'bg-green-500/10 text-green-600',
+		cancelled: 'bg-muted text-muted-foreground/50',
+	};
+
+	const STATUS_LABEL: Record<ProjectStatus, string> = {
+		backlog: 'Backlog',
+		planned: 'Planned',
+		in_progress: 'In Progress',
+		completed: 'Completed',
+		cancelled: 'Cancelled',
+	};
+
+	function agentLabel(id: string | null): string {
+		if (!id) return '—';
+		return agentNames[id] ?? `${id.slice(0, 8)}…`;
+	}
+
+	function daysUntil(iso: string | null): string {
+		if (!iso) return '';
+		const diff = new Date(iso).getTime() - Date.now();
+		const days = Math.round(diff / (1000 * 60 * 60 * 24));
+		if (days < 0) return `${Math.abs(days)}d overdue`;
+		if (days === 0) return 'today';
+		if (days === 1) return 'tomorrow';
+		return `${days}d`;
+	}
+
+	const counts = $derived.by(() => {
+		const out: Record<ProjectStatus, number> = {
+			backlog: 0, planned: 0, in_progress: 0, completed: 0, cancelled: 0,
+		};
+		for (const p of projects) out[p.status] = (out[p.status] ?? 0) + 1;
+		return out;
+	});
+
+	onMount(() => startPolling('app:projects', 8000));
+</script>
+
+<div class="p-6 space-y-6 max-w-5xl">
+	<header class="flex items-center justify-between flex-wrap gap-3">
+		<div class="flex items-center gap-3">
+			<h1 class="text-2xl font-semibold">Projects</h1>
+			<LiveIndicator intervalMs={8000} />
+		</div>
+		<div class="flex flex-wrap gap-2 text-xs">
+			{#each (['in_progress', 'planned', 'completed', 'backlog', 'cancelled'] as ProjectStatus[]) as s (s)}
+				{#if counts[s] > 0}
+					<span class="rounded-full px-2 py-0.5 font-medium {STATUS_BADGE[s]}">
+						{counts[s]} {STATUS_LABEL[s].toLowerCase()}
+					</span>
+				{/if}
+			{/each}
+		</div>
+	</header>
+
+	{#if projects.length === 0}
+		<div class="rounded-lg border border-border bg-card p-12 text-center">
+			<p class="text-muted-foreground text-sm">No projects yet.</p>
+		</div>
+	{:else}
+		<ul class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+			{#each projects as p (p.id)}
+				<li>
+					<a
+						href="/workforce/projects/{p.id}"
+						class="relative block rounded-lg border border-border bg-card p-4 text-foreground no-underline transition-colors hover:bg-muted overflow-hidden"
+					>
+						<!-- Color stripe -->
+						{#if p.color}
+							<span
+								class="absolute left-0 top-0 bottom-0 w-1"
+								style="background:{p.color}"
+								aria-hidden="true"
+							></span>
+						{/if}
+
+						<div class="pl-2 space-y-2">
+							<div class="flex items-start justify-between gap-2 flex-wrap">
+								<span class="rounded px-1.5 py-0.5 text-[10px] font-medium {STATUS_BADGE[p.status]}">
+									{STATUS_LABEL[p.status]}
+								</span>
+								{#if p.targetDate}
+									<span class="text-[10px] text-muted-foreground font-mono">
+										target {p.targetDate} <span class="text-muted-foreground/60">· {daysUntil(p.targetDate)}</span>
+									</span>
+								{/if}
+							</div>
+
+							<div class="space-y-1">
+								<h2 class="text-base font-semibold leading-tight">{p.name}</h2>
+								{#if p.description}
+									<p class="text-xs text-muted-foreground line-clamp-2">{p.description}</p>
+								{/if}
+							</div>
+
+							<div class="flex items-center gap-3 flex-wrap text-[11px] text-muted-foreground pt-1">
+								<span title="Lead agent">
+									<span class="text-muted-foreground/60">lead</span> {agentLabel(p.leadAgentId)}
+								</span>
+								{#if p.goals.length > 0}
+									<span>
+										<span class="text-muted-foreground/60">goal</span> {p.goals[0].title}
+									</span>
+								{/if}
+								{#if p.workspaces.length > 0}
+									<span class="font-mono">
+										{p.workspaces.length} workspace{p.workspaces.length !== 1 ? 's' : ''}
+									</span>
+								{/if}
+							</div>
+						</div>
+					</a>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</div>

--- a/src/routes/(app)/workforce/projects/[id]/+page.server.ts
+++ b/src/routes/(app)/workforce/projects/[id]/+page.server.ts
@@ -1,0 +1,27 @@
+import { redirect, error } from '@sveltejs/kit';
+import { paperclipServerClient } from '$lib/server/paperclip-fetch';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async (event) => {
+	if (!event.locals.user) throw redirect(302, '/login');
+	if (!event.locals.paperclipIdentity?.companyId) {
+		throw redirect(302, '/workforce/welcome');
+	}
+	event.depends('app:project');
+	const companyId = event.locals.paperclipIdentity.companyId;
+	const projectId = event.params.id;
+	const client = paperclipServerClient(event);
+
+	try {
+		const [project, issues, agents] = await Promise.all([
+			client.projects.get(projectId, companyId),
+			client.issues.list(companyId, { projectId }),
+			client.agents.list(companyId),
+		]);
+		const agentNames: Record<string, string> = {};
+		for (const a of agents) agentNames[a.id] = a.name;
+		return { project, issues, agentNames };
+	} catch (e: any) {
+		throw error(e?.status ?? 502, e?.status === 404 ? 'project not found' : 'paperclip unavailable');
+	}
+};

--- a/src/routes/(app)/workforce/projects/[id]/+page.svelte
+++ b/src/routes/(app)/workforce/projects/[id]/+page.svelte
@@ -1,0 +1,207 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { PageData } from './$types';
+	import type { ProjectStatus } from '@minion-stack/paperclip-client';
+	import { startPolling } from '$lib/util/live-polling';
+	import LiveIndicator from '$lib/components/LiveIndicator.svelte';
+
+	let { data }: { data: PageData } = $props();
+	const { project, issues, agentNames } = $derived(data);
+
+	const STATUS_BADGE: Record<ProjectStatus, string> = {
+		backlog: 'bg-muted text-muted-foreground',
+		planned: 'bg-muted text-muted-foreground',
+		in_progress: 'bg-blue-500/10 text-blue-600',
+		completed: 'bg-green-500/10 text-green-600',
+		cancelled: 'bg-muted text-muted-foreground/50',
+	};
+
+	const STATUS_LABEL: Record<ProjectStatus, string> = {
+		backlog: 'Backlog',
+		planned: 'Planned',
+		in_progress: 'In Progress',
+		completed: 'Completed',
+		cancelled: 'Cancelled',
+	};
+
+	const ISSUE_STATUS_BADGE: Record<string, string> = {
+		in_progress: 'bg-blue-500/10 text-blue-600',
+		blocked: 'bg-amber-500/10 text-amber-600',
+		todo: 'bg-muted text-muted-foreground',
+		backlog: 'bg-muted text-muted-foreground',
+		in_review: 'bg-purple-500/10 text-purple-600',
+		done: 'bg-green-500/10 text-green-600',
+		cancelled: 'bg-muted text-muted-foreground/50',
+	};
+
+	function agentLabel(id: string | null): string {
+		if (!id) return '—';
+		return agentNames[id] ?? `${id.slice(0, 8)}…`;
+	}
+
+	function formatDate(d: Date | string | null): string {
+		if (!d) return '—';
+		return new Date(d).toLocaleDateString([], { year: 'numeric', month: 'short', day: 'numeric' });
+	}
+
+	function daysUntil(iso: string | null): string {
+		if (!iso) return '';
+		const diff = new Date(iso).getTime() - Date.now();
+		const days = Math.round(diff / (1000 * 60 * 60 * 24));
+		if (days < 0) return `${Math.abs(days)}d overdue`;
+		if (days === 0) return 'today';
+		return `in ${days}d`;
+	}
+
+	onMount(() => startPolling('app:project', 6000));
+</script>
+
+<div class="p-6 space-y-6 max-w-5xl">
+	<!-- Breadcrumb -->
+	<nav class="text-sm text-muted-foreground flex items-center gap-1">
+		<a href="/workforce/projects" class="hover:text-foreground">Projects</a>
+		<span>/</span>
+		<span class="text-foreground truncate">{project.name}</span>
+	</nav>
+
+	<!-- Header -->
+	<header class="rounded-lg border border-border bg-card p-5 relative overflow-hidden">
+		{#if project.color}
+			<span
+				class="absolute left-0 top-0 bottom-0 w-1.5"
+				style="background:{project.color}"
+				aria-hidden="true"
+			></span>
+		{/if}
+		<div class="pl-3 space-y-3">
+			<div class="flex items-center gap-3 flex-wrap">
+				<span class="rounded px-1.5 py-0.5 text-xs font-medium {STATUS_BADGE[project.status]}">
+					{STATUS_LABEL[project.status]}
+				</span>
+				<span class="text-[10px] font-mono text-muted-foreground">{project.urlKey}</span>
+				<LiveIndicator intervalMs={6000} />
+			</div>
+			<h1 class="text-2xl font-semibold">{project.name}</h1>
+			{#if project.description}
+				<p class="text-sm text-muted-foreground leading-relaxed">{project.description}</p>
+			{/if}
+		</div>
+	</header>
+
+	<!-- KPI row -->
+	<section class="grid grid-cols-2 sm:grid-cols-4 gap-4">
+		<div class="rounded-lg border border-border bg-card p-4 space-y-1">
+			<h2 class="text-xs font-medium text-muted-foreground uppercase tracking-wider">Lead</h2>
+			<div class="text-sm font-medium truncate">{agentLabel(project.leadAgentId)}</div>
+		</div>
+		<div class="rounded-lg border border-border bg-card p-4 space-y-1">
+			<h2 class="text-xs font-medium text-muted-foreground uppercase tracking-wider">Target</h2>
+			<div class="text-sm font-medium tabular-nums">{project.targetDate ?? '—'}</div>
+			{#if project.targetDate}
+				<div class="text-[10px] text-muted-foreground">{daysUntil(project.targetDate)}</div>
+			{/if}
+		</div>
+		<div class="rounded-lg border border-border bg-card p-4 space-y-1">
+			<h2 class="text-xs font-medium text-muted-foreground uppercase tracking-wider">Workspaces</h2>
+			<div class="text-2xl font-semibold tabular-nums">{project.workspaces.length}</div>
+		</div>
+		<div class="rounded-lg border border-border bg-card p-4 space-y-1">
+			<h2 class="text-xs font-medium text-muted-foreground uppercase tracking-wider">Issues</h2>
+			<div class="text-2xl font-semibold tabular-nums">{issues.length}</div>
+		</div>
+	</section>
+
+	<!-- Linked goals -->
+	{#if project.goals.length > 0}
+		<section>
+			<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+				Linked goals
+			</h2>
+			<ul class="rounded-lg border border-border bg-card divide-y divide-border">
+				{#each project.goals as goal (goal.id)}
+					<li>
+						<a
+							href="/workforce/goals"
+							class="block px-4 py-3 text-sm text-foreground no-underline hover:bg-muted transition-colors"
+						>
+							{goal.title}
+						</a>
+					</li>
+				{/each}
+			</ul>
+		</section>
+	{/if}
+
+	<!-- Workspaces -->
+	<section>
+		<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+			Workspaces ({project.workspaces.length})
+		</h2>
+		{#if project.workspaces.length === 0}
+			<div class="rounded-lg border border-border bg-card p-6 text-sm text-muted-foreground">
+				No workspaces configured.
+			</div>
+		{:else}
+			<ul class="rounded-lg border border-border bg-card divide-y divide-border">
+				{#each project.workspaces as ws (ws.id)}
+					<li class="px-4 py-3 text-sm space-y-1">
+						<div class="flex items-center gap-2 flex-wrap">
+							<span class="font-medium">{ws.name}</span>
+							{#if ws.isPrimary}
+								<span class="rounded px-1.5 py-0.5 text-[10px] font-medium bg-primary/10 text-primary">primary</span>
+							{/if}
+							<span class="font-mono text-[10px] text-muted-foreground/70">{ws.sourceType}</span>
+						</div>
+						{#if ws.repoUrl}
+							<div class="font-mono text-xs text-muted-foreground truncate">{ws.repoUrl} · {ws.repoRef ?? 'main'}</div>
+						{:else if ws.cwd}
+							<div class="font-mono text-xs text-muted-foreground truncate">{ws.cwd}</div>
+						{/if}
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</section>
+
+	<!-- Linked issues -->
+	<section>
+		<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+			Issues ({issues.length})
+		</h2>
+		{#if issues.length === 0}
+			<div class="rounded-lg border border-border bg-card p-6 text-sm text-muted-foreground">
+				No issues linked to this project.
+			</div>
+		{:else}
+			<ul class="rounded-lg border border-border bg-card divide-y divide-border">
+				{#each issues as issue (issue.id)}
+					<li>
+						<a
+							href="/workforce/issues/{issue.id}"
+							class="flex items-center gap-3 px-4 py-2.5 text-sm text-foreground no-underline hover:bg-muted transition-colors"
+						>
+							<span class="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium {ISSUE_STATUS_BADGE[issue.status]}">
+								{issue.status}
+							</span>
+							{#if issue.identifier}
+								<span class="shrink-0 text-xs font-mono text-muted-foreground">{issue.identifier}</span>
+							{/if}
+							<span class="flex-1 min-w-0 truncate font-medium">{issue.title}</span>
+							{#if issue.assigneeAgentId}
+								<span class="shrink-0 text-xs text-muted-foreground truncate max-w-[10rem]">
+									{agentLabel(issue.assigneeAgentId)}
+								</span>
+							{/if}
+						</a>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</section>
+
+	<!-- Metadata footer -->
+	<footer class="text-xs text-muted-foreground space-y-0.5 pt-2">
+		<div><span class="font-mono">{project.id}</span></div>
+		<div>created {formatDate(project.createdAt)} · updated {formatDate(project.updatedAt)}</div>
+	</footer>
+</div>

--- a/src/routes/(app)/workforce/reliability/+page.server.ts
+++ b/src/routes/(app)/workforce/reliability/+page.server.ts
@@ -1,0 +1,37 @@
+import { redirect, error } from '@sveltejs/kit';
+import { paperclipServerClient, paperclipRawFetch } from '$lib/server/paperclip-fetch';
+import type { PageServerLoad } from './$types';
+
+type HeatmapAgent = { id: string; name: string; status: string };
+type Heatmap = {
+	agents: HeatmapAgent[];
+	cells: Record<string, number[]>;
+	hourLabels: number[];
+};
+
+export const load: PageServerLoad = async (event) => {
+	if (!event.locals.user) throw redirect(302, '/login');
+	if (!event.locals.paperclipIdentity?.companyId) {
+		throw redirect(302, '/workforce/welcome');
+	}
+	event.depends('app:reliability');
+	const companyId = event.locals.paperclipIdentity.companyId;
+	const client = paperclipServerClient(event);
+
+	try {
+		const [heatmap, runs, agents] = await Promise.all([
+			paperclipRawFetch<Heatmap>(event, `/api/companies/${companyId}/reliability/heatmap`),
+			// Pull a few agents' runs for the "recent failures" section
+			Promise.all(
+				['19153064-8faf-45d6-9b0c-112de6d368e9', 'a2b3c4d5-0000-0000-0000-111122223333'].map((id) =>
+					paperclipRawFetch<any[]>(event, `/api/agents/${id}/runs`).catch(() => [] as any[]),
+				),
+			),
+			client.agents.list(companyId),
+		]);
+		const allRuns = runs.flat();
+		return { heatmap, recentRuns: allRuns, agents };
+	} catch (e: any) {
+		throw error(e?.status ?? 502, 'paperclip unavailable');
+	}
+};

--- a/src/routes/(app)/workforce/reliability/+page.svelte
+++ b/src/routes/(app)/workforce/reliability/+page.svelte
@@ -1,0 +1,243 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { PageData } from './$types';
+	import { startPolling } from '$lib/util/live-polling';
+	import LiveIndicator from '$lib/components/LiveIndicator.svelte';
+
+	let { data }: { data: PageData } = $props();
+	const { heatmap, recentRuns, agents } = $derived(data);
+
+	// Max cell value drives intensity scaling
+	const maxCell = $derived.by(() => {
+		let m = 0;
+		for (const row of Object.values(heatmap.cells)) {
+			for (const v of row) if (v > m) m = v;
+		}
+		return Math.max(1, m);
+	});
+
+	function intensity(cell: number): number {
+		return cell / maxCell;
+	}
+
+	// Map intensity to background color (transparent to oklch primary)
+	function cellStyle(cell: number): string {
+		if (cell === 0) return 'background-color: rgba(255,255,255,0.02)';
+		const op = 0.12 + intensity(cell) * 0.78;
+		return `background-color: rgba(59,130,246,${op.toFixed(3)})`;
+	}
+
+	function cellTextColor(cell: number): string {
+		if (cell === 0) return 'text-muted-foreground/30';
+		if (intensity(cell) > 0.55) return 'text-white';
+		return 'text-foreground/80';
+	}
+
+	const STATUS_DOT: Record<string, string> = {
+		active: '#10b981',
+		running: '#3b82f6',
+		paused: '#f59e0b',
+		error: '#ef4444',
+		idle: '#6b7280',
+		pending_approval: '#a855f7',
+		terminated: '#525252',
+	};
+
+	const RUN_STATUS_BADGE: Record<string, string> = {
+		succeeded: 'bg-green-500/10 text-green-600',
+		failed: 'bg-destructive/10 text-destructive',
+		running: 'bg-blue-500/10 text-blue-600',
+		cancelled: 'bg-muted text-muted-foreground',
+	};
+
+	// Per-agent totals (right column)
+	const agentTotals = $derived.by(() => {
+		const out: Record<string, number> = {};
+		for (const [aid, row] of Object.entries(heatmap.cells)) {
+			out[aid] = row.reduce((s: number, v: number) => s + v, 0);
+		}
+		return out;
+	});
+
+	// Per-hour totals (bottom row)
+	const hourTotals = $derived.by(() => {
+		const out: number[] = new Array(24).fill(0);
+		for (const row of Object.values(heatmap.cells)) {
+			for (let h = 0; h < 24; h++) out[h] += row[h];
+		}
+		return out;
+	});
+
+	const grandTotal = $derived(Object.values(agentTotals).reduce((s: number, v: number) => s + v, 0));
+
+	// Failures from recent runs (across queried agents)
+	const failedRuns = $derived(recentRuns.filter((r: any) => r.status === 'failed'));
+	const runningRuns = $derived(recentRuns.filter((r: any) => r.status === 'running'));
+
+	function formatDuration(ms: number | null): string {
+		if (ms === null) return '—';
+		if (ms < 1000) return `${ms}ms`;
+		if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+		return `${Math.floor(ms / 60_000)}m`;
+	}
+
+	function relativeTime(iso: string | Date): string {
+		const diff = Date.now() - new Date(iso).getTime();
+		if (diff < 60_000) return 'just now';
+		if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+		if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+		return `${Math.floor(diff / 86_400_000)}d ago`;
+	}
+
+	function agentName(id: string): string {
+		return agents.find((a) => a.id === id)?.name ?? id.slice(0, 8);
+	}
+
+	onMount(() => startPolling('app:reliability', 8000));
+</script>
+
+<div class="p-6 space-y-6 max-w-6xl">
+	<header class="flex items-center justify-between flex-wrap gap-3">
+		<div class="flex items-center gap-3">
+			<h1 class="text-2xl font-semibold">Reliability</h1>
+			<LiveIndicator intervalMs={8000} />
+		</div>
+		<div class="text-xs text-muted-foreground">
+			{grandTotal} events across {heatmap.agents.length} agents · last 24 hours
+		</div>
+	</header>
+
+	<!-- Heatmap -->
+	<section>
+		<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+			Activity heatmap <span class="font-normal normal-case tracking-normal text-xs text-muted-foreground/60">(agent × hour-of-day)</span>
+		</h2>
+		<div class="rounded-lg border border-border bg-card p-4 overflow-x-auto">
+			<table class="w-full text-xs border-separate" style="border-spacing: 2px">
+				<thead>
+					<tr>
+						<th class="text-left text-muted-foreground font-medium pr-3 sticky left-0 bg-card">Agent</th>
+						{#each heatmap.hourLabels as h (h)}
+							<th class="text-center text-muted-foreground/60 font-mono font-normal w-7">
+								{#if h % 3 === 0}{h.toString().padStart(2, '0')}{/if}
+							</th>
+						{/each}
+						<th class="text-right text-muted-foreground font-medium pl-3">Σ</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each heatmap.agents as agent (agent.id)}
+						<tr>
+							<td class="pr-3 sticky left-0 bg-card whitespace-nowrap">
+								<a href="/workforce/agents/{agent.id}" class="inline-flex items-center gap-1.5 hover:underline">
+									<span
+										class="h-2 w-2 rounded-full shrink-0"
+										style="background:{STATUS_DOT[agent.status] ?? '#6b7280'}"
+									></span>
+									<span class="font-medium">{agent.name}</span>
+								</a>
+							</td>
+							{#each heatmap.cells[agent.id] as cell, h (h)}
+								<td
+									class="h-7 w-7 rounded text-center align-middle font-mono tabular-nums text-[10px] {cellTextColor(cell)}"
+									style={cellStyle(cell)}
+									title="{agent.name} · {h.toString().padStart(2, '0')}:00 · {cell} event{cell !== 1 ? 's' : ''}"
+								>
+									{#if cell > 0}{cell}{/if}
+								</td>
+							{/each}
+							<td class="pl-3 text-right font-mono tabular-nums font-medium">{agentTotals[agent.id]}</td>
+						</tr>
+					{/each}
+					<tr>
+						<td class="pr-3 sticky left-0 bg-card text-muted-foreground font-medium">Σ</td>
+						{#each hourTotals as t, h (h)}
+							<td class="text-center text-muted-foreground/70 font-mono tabular-nums text-[10px] pt-1">
+								{t > 0 ? t : ''}
+							</td>
+						{/each}
+						<td class="pl-3 text-right font-mono tabular-nums font-semibold">{grandTotal}</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+
+		<!-- Color scale legend -->
+		<div class="mt-3 flex items-center gap-3 text-xs text-muted-foreground">
+			<span>Less</span>
+			<div class="flex gap-1">
+				{#each [0, 0.2, 0.4, 0.6, 0.8, 1] as t (t)}
+					<span
+						class="h-3 w-6 rounded"
+						style="background-color: rgba(59,130,246,{t === 0 ? 0.02 : (0.12 + t * 0.78).toFixed(3)})"
+					></span>
+				{/each}
+			</div>
+			<span>More</span>
+			<span class="ml-auto">Peak hour: {hourTotals.indexOf(Math.max(...hourTotals)).toString().padStart(2, '0')}:00</span>
+		</div>
+	</section>
+
+	<!-- Recent failures + running -->
+	<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+		<section>
+			<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+				Recent failures <span class="font-medium normal-case tracking-normal text-xs">({failedRuns.length})</span>
+			</h2>
+			{#if failedRuns.length === 0}
+				<div class="rounded-lg border border-border bg-card p-6 text-sm text-muted-foreground">
+					No recent failures.
+				</div>
+			{:else}
+				<ul class="rounded-lg border border-border bg-card divide-y divide-border">
+					{#each failedRuns as run (run.id)}
+						<li class="px-4 py-3 text-sm flex items-center gap-3">
+							<span class="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium {RUN_STATUS_BADGE.failed}">
+								failed
+							</span>
+							<div class="flex-1 min-w-0">
+								<a href="/workforce/agents/{run.agentId}" class="font-medium hover:underline truncate block">
+									{agentName(run.agentId)}
+								</a>
+								<div class="text-xs text-muted-foreground font-mono">{run.id} · {formatDuration(run.durationMs)}</div>
+							</div>
+							<time class="shrink-0 text-xs text-muted-foreground" datetime={run.startedAt}>
+								{relativeTime(run.startedAt)}
+							</time>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</section>
+
+		<section>
+			<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+				In flight <span class="font-medium normal-case tracking-normal text-xs">({runningRuns.length})</span>
+			</h2>
+			{#if runningRuns.length === 0}
+				<div class="rounded-lg border border-border bg-card p-6 text-sm text-muted-foreground">
+					No runs currently in flight.
+				</div>
+			{:else}
+				<ul class="rounded-lg border border-border bg-card divide-y divide-border">
+					{#each runningRuns as run (run.id)}
+						<li class="px-4 py-3 text-sm flex items-center gap-3">
+							<span class="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium {RUN_STATUS_BADGE.running}">
+								running
+							</span>
+							<div class="flex-1 min-w-0">
+								<a href="/workforce/agents/{run.agentId}" class="font-medium hover:underline truncate block">
+									{agentName(run.agentId)}
+								</a>
+								<div class="text-xs text-muted-foreground font-mono">{run.id} · {run.source}</div>
+							</div>
+							<time class="shrink-0 text-xs text-muted-foreground" datetime={run.startedAt}>
+								started {relativeTime(run.startedAt)}
+							</time>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</section>
+	</div>
+</div>

--- a/src/routes/(app)/workforce/settings/+page.server.ts
+++ b/src/routes/(app)/workforce/settings/+page.server.ts
@@ -1,0 +1,21 @@
+import { redirect, error } from '@sveltejs/kit';
+import { paperclipServerClient } from '$lib/server/paperclip-fetch';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async (event) => {
+	if (!event.locals.user) throw redirect(302, '/login');
+	if (!event.locals.paperclipIdentity?.companyId) {
+		throw redirect(302, '/workforce/welcome');
+	}
+	const companyId = event.locals.paperclipIdentity.companyId;
+	const client = paperclipServerClient(event);
+	try {
+		const [company, agents] = await Promise.all([
+			client.companies.get(companyId),
+			client.agents.list(companyId),
+		]);
+		return { company, agentCount: agents.length };
+	} catch (e: any) {
+		throw error(e?.status ?? 502, 'paperclip unavailable');
+	}
+};

--- a/src/routes/(app)/workforce/settings/+page.svelte
+++ b/src/routes/(app)/workforce/settings/+page.svelte
@@ -33,7 +33,7 @@
 		<a href="/workforce/settings" class="rounded-md border border-border bg-card px-3 py-1.5 font-medium">
 			General
 		</a>
-		<a href="/workforce/settings/agents" class="rounded-md border border-border bg-card px-3 py-1.5 hover:bg-accent transition-colors">
+		<a href="/workforce/settings/agents" class="rounded-md border border-border bg-card px-3 py-1.5 hover:bg-muted transition-colors">
 			Agents
 			<span class="ml-1 text-xs text-muted-foreground">{agentCount}</span>
 		</a>

--- a/src/routes/(app)/workforce/settings/+page.svelte
+++ b/src/routes/(app)/workforce/settings/+page.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+	const { company, agentCount } = $derived(data);
+
+	function dollars(cents: number): string {
+		return `$${(cents / 100).toLocaleString('en-US', { minimumFractionDigits: 2 })}`;
+	}
+
+	function formatDate(d: Date | string | null): string {
+		if (!d) return '—';
+		return new Date(d).toLocaleDateString([], { year: 'numeric', month: 'short', day: 'numeric' });
+	}
+
+	const utilization = $derived(
+		company.budgetMonthlyCents > 0
+			? Math.round((company.spentMonthlyCents / company.budgetMonthlyCents) * 100)
+			: 0,
+	);
+</script>
+
+<div class="p-6 space-y-6 max-w-5xl">
+	<header>
+		<h1 class="text-2xl font-semibold">Workforce settings</h1>
+		<p class="text-sm text-muted-foreground mt-1">
+			Company-scoped settings for <span class="font-medium text-foreground">{company.name}</span>.
+		</p>
+	</header>
+
+	<!-- Sub-page nav -->
+	<nav class="flex flex-wrap gap-2 text-sm">
+		<a href="/workforce/settings" class="rounded-md border border-border bg-card px-3 py-1.5 font-medium">
+			General
+		</a>
+		<a href="/workforce/settings/agents" class="rounded-md border border-border bg-card px-3 py-1.5 hover:bg-accent transition-colors">
+			Agents
+			<span class="ml-1 text-xs text-muted-foreground">{agentCount}</span>
+		</a>
+	</nav>
+
+	<!-- General info card -->
+	<section>
+		<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+			Company info
+		</h2>
+		<div class="rounded-lg border border-border bg-card divide-y divide-border text-sm">
+			<div class="px-4 py-3 grid grid-cols-[10rem_1fr] gap-3">
+				<span class="text-muted-foreground">Name</span>
+				<span class="font-medium">{company.name}</span>
+			</div>
+			{#if company.description}
+				<div class="px-4 py-3 grid grid-cols-[10rem_1fr] gap-3">
+					<span class="text-muted-foreground">Description</span>
+					<span>{company.description}</span>
+				</div>
+			{/if}
+			<div class="px-4 py-3 grid grid-cols-[10rem_1fr] gap-3">
+				<span class="text-muted-foreground">Status</span>
+				<span class="font-medium">{company.status}</span>
+			</div>
+			<div class="px-4 py-3 grid grid-cols-[10rem_1fr] gap-3">
+				<span class="text-muted-foreground">Issue prefix</span>
+				<span class="font-mono text-xs">{company.issuePrefix}-{company.issueCounter}</span>
+			</div>
+			<div class="px-4 py-3 grid grid-cols-[10rem_1fr] gap-3 items-center">
+				<span class="text-muted-foreground">Brand color</span>
+				{#if company.brandColor}
+					<span class="flex items-center gap-2">
+						<span
+							class="inline-block size-4 rounded border border-border"
+							style="background:{company.brandColor}"
+						></span>
+						<span class="font-mono text-xs">{company.brandColor}</span>
+					</span>
+				{:else}
+					<span class="text-muted-foreground">—</span>
+				{/if}
+			</div>
+		</div>
+	</section>
+
+	<!-- Budget -->
+	<section>
+		<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+			Budget
+		</h2>
+		<div class="rounded-lg border border-border bg-card p-4 space-y-3">
+			<div class="flex items-baseline justify-between text-sm">
+				<span class="text-muted-foreground">This month</span>
+				<span class="font-medium">
+					{dollars(company.spentMonthlyCents)} <span class="text-muted-foreground">/ {dollars(company.budgetMonthlyCents)}</span>
+				</span>
+			</div>
+			<div class="h-2 rounded-full bg-muted overflow-hidden">
+				<div
+					class="h-full bg-primary"
+					style="width: {Math.min(100, utilization)}%"
+				></div>
+			</div>
+			<div class="text-xs text-muted-foreground">{utilization}% utilization</div>
+		</div>
+	</section>
+
+	<!-- Policies -->
+	<section>
+		<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+			Policies
+		</h2>
+		<div class="rounded-lg border border-border bg-card divide-y divide-border text-sm">
+			<div class="px-4 py-3 grid grid-cols-[1fr_auto] gap-3">
+				<div>
+					<div class="font-medium">Board approval required for new agents</div>
+					<div class="text-xs text-muted-foreground mt-0.5">
+						When enabled, hiring a new agent requires explicit board sign-off before it can run.
+					</div>
+				</div>
+				<span class="text-xs font-medium px-2 py-1 rounded-md self-start {company.requireBoardApprovalForNewAgents ? 'bg-green-500/10 text-green-600' : 'bg-muted text-muted-foreground'}">
+					{company.requireBoardApprovalForNewAgents ? 'On' : 'Off'}
+				</span>
+			</div>
+			<div class="px-4 py-3 grid grid-cols-[1fr_auto] gap-3">
+				<div>
+					<div class="font-medium">Feedback data sharing</div>
+					<div class="text-xs text-muted-foreground mt-0.5">
+						{#if company.feedbackDataSharingEnabled}
+							Sharing anonymized feedback traces with Paperclip Labs.
+							{#if company.feedbackDataSharingConsentAt}
+								Consented {formatDate(company.feedbackDataSharingConsentAt)}
+								{#if company.feedbackDataSharingTermsVersion}
+									(terms v{company.feedbackDataSharingTermsVersion}).
+								{/if}
+							{/if}
+						{:else}
+							Disabled — no feedback data leaves this company.
+						{/if}
+					</div>
+				</div>
+				<span class="text-xs font-medium px-2 py-1 rounded-md self-start {company.feedbackDataSharingEnabled ? 'bg-green-500/10 text-green-600' : 'bg-muted text-muted-foreground'}">
+					{company.feedbackDataSharingEnabled ? 'On' : 'Off'}
+				</span>
+			</div>
+		</div>
+	</section>
+
+	<!-- Metadata -->
+	<section>
+		<h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+			Metadata
+		</h2>
+		<div class="rounded-lg border border-border bg-card divide-y divide-border text-sm">
+			<div class="px-4 py-3 grid grid-cols-[10rem_1fr] gap-3">
+				<span class="text-muted-foreground">Company ID</span>
+				<span class="font-mono text-xs">{company.id}</span>
+			</div>
+			<div class="px-4 py-3 grid grid-cols-[10rem_1fr] gap-3">
+				<span class="text-muted-foreground">Created</span>
+				<span>{formatDate(company.createdAt)}</span>
+			</div>
+			<div class="px-4 py-3 grid grid-cols-[10rem_1fr] gap-3">
+				<span class="text-muted-foreground">Updated</span>
+				<span>{formatDate(company.updatedAt)}</span>
+			</div>
+		</div>
+	</section>
+</div>

--- a/src/routes/(app)/workforce/settings/agents/+page.server.ts
+++ b/src/routes/(app)/workforce/settings/agents/+page.server.ts
@@ -1,0 +1,18 @@
+import { redirect, error } from '@sveltejs/kit';
+import { paperclipServerClient } from '$lib/server/paperclip-fetch';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async (event) => {
+	if (!event.locals.user) throw redirect(302, '/login');
+	if (!event.locals.paperclipIdentity?.companyId) {
+		throw redirect(302, '/workforce/welcome');
+	}
+	const companyId = event.locals.paperclipIdentity.companyId;
+	const client = paperclipServerClient(event);
+	try {
+		const agents = await client.agents.list(companyId);
+		return { agents };
+	} catch (e: any) {
+		throw error(e?.status ?? 502, 'paperclip unavailable');
+	}
+};

--- a/src/routes/(app)/workforce/settings/agents/+page.svelte
+++ b/src/routes/(app)/workforce/settings/agents/+page.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+	const { agents } = $derived(data);
+
+	function formatDate(d: Date | string): string {
+		return new Date(d).toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' });
+	}
+</script>
+
+<div class="p-6 space-y-6 max-w-5xl">
+	<header>
+		<h1 class="text-2xl font-semibold">Agents</h1>
+		<p class="text-sm text-muted-foreground mt-1">
+			Workforce roster ({agents.length} agent{agents.length !== 1 ? 's' : ''}).
+		</p>
+	</header>
+
+	<nav class="flex flex-wrap gap-2 text-sm">
+		<a href="/workforce/settings" class="rounded-md border border-border bg-card px-3 py-1.5 hover:bg-accent transition-colors">
+			General
+		</a>
+		<a href="/workforce/settings/agents" class="rounded-md border border-border bg-card px-3 py-1.5 font-medium">
+			Agents
+			<span class="ml-1 text-xs text-muted-foreground">{agents.length}</span>
+		</a>
+	</nav>
+
+	{#if agents.length === 0}
+		<div class="rounded-lg border border-border bg-card p-12 flex flex-col items-center justify-center text-center">
+			<p class="text-muted-foreground text-sm">No agents hired yet.</p>
+		</div>
+	{:else}
+		<ul class="divide-y divide-border rounded-lg border border-border bg-card">
+			{#each agents as agent (agent.id)}
+				<li class="px-4 py-3 flex items-center gap-3 text-sm">
+					<div class="flex-1 min-w-0">
+						<div class="font-medium truncate">{agent.name}</div>
+						<div class="text-xs text-muted-foreground truncate">
+							{#if (agent as any).role}{(agent as any).role} · {/if}
+							{(agent as any).adapter ?? 'unknown adapter'}
+							{#if (agent as any).model} · <span class="font-mono">{(agent as any).model}</span>{/if}
+						</div>
+					</div>
+					<span class="shrink-0 text-xs text-muted-foreground">{(agent as any).status ?? '—'}</span>
+					<time
+						class="shrink-0 text-xs text-muted-foreground whitespace-nowrap"
+						datetime={new Date(agent.createdAt).toISOString()}
+					>
+						hired {formatDate(agent.createdAt)}
+					</time>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</div>

--- a/src/routes/(app)/workforce/settings/agents/+page.svelte
+++ b/src/routes/(app)/workforce/settings/agents/+page.svelte
@@ -18,7 +18,7 @@
 	</header>
 
 	<nav class="flex flex-wrap gap-2 text-sm">
-		<a href="/workforce/settings" class="rounded-md border border-border bg-card px-3 py-1.5 hover:bg-accent transition-colors">
+		<a href="/workforce/settings" class="rounded-md border border-border bg-card px-3 py-1.5 hover:bg-muted transition-colors">
 			General
 		</a>
 		<a href="/workforce/settings/agents" class="rounded-md border border-border bg-card px-3 py-1.5 font-medium">

--- a/src/server/services/agent-group.service.ts
+++ b/src/server/services/agent-group.service.ts
@@ -1,33 +1,43 @@
 import { eq, and, asc } from 'drizzle-orm';
 import { agentGroups, agentGroupMembers } from '@minion-stack/db/schema';
+import { cached, invalidateTags, keys, tags } from '@minion-stack/cache';
 import { newId, nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 
 export async function listGroups(ctx: TenantContext, userId: string) {
-  const groups = await ctx.db
-    .select()
-    .from(agentGroups)
-    .where(and(eq(agentGroups.userId, userId), eq(agentGroups.tenantId, ctx.tenantId)))
-    .orderBy(asc(agentGroups.sortOrder));
+  return cached(
+    keys.hub('agent-groups', { t: ctx.tenantId, u: userId }),
+    {
+      ttl: '10m',
+      swr: '60s',
+      tags: [...tags.tenantDomain(ctx.tenantId, 'agent-groups'), ...tags.user(userId)],
+    },
+    async () => {
+      const groups = await ctx.db
+        .select()
+        .from(agentGroups)
+        .where(and(eq(agentGroups.userId, userId), eq(agentGroups.tenantId, ctx.tenantId)))
+        .orderBy(asc(agentGroups.sortOrder));
 
-  const groupIds = groups.map((g) => g.id);
-  let members: { groupId: string; agentId: string; sortOrder: number | null }[] = [];
-  if (groupIds.length > 0) {
-    members = await ctx.db
-      .select()
-      .from(agentGroupMembers)
-      .orderBy(asc(agentGroupMembers.sortOrder));
-    // Filter to only members of these groups
-    const groupIdSet = new Set(groupIds);
-    members = members.filter((m) => groupIdSet.has(m.groupId));
-  }
+      const groupIds = groups.map((g) => g.id);
+      let members: { groupId: string; agentId: string; sortOrder: number | null }[] = [];
+      if (groupIds.length > 0) {
+        members = await ctx.db
+          .select()
+          .from(agentGroupMembers)
+          .orderBy(asc(agentGroupMembers.sortOrder));
+        const groupIdSet = new Set(groupIds);
+        members = members.filter((m) => groupIdSet.has(m.groupId));
+      }
 
-  return groups.map((g) => ({
-    id: g.id,
-    name: g.name,
-    sortOrder: g.sortOrder ?? 0,
-    memberAgentIds: members.filter((m) => m.groupId === g.id).map((m) => m.agentId),
-  }));
+      return groups.map((g) => ({
+        id: g.id,
+        name: g.name,
+        sortOrder: g.sortOrder ?? 0,
+        memberAgentIds: members.filter((m) => m.groupId === g.id).map((m) => m.agentId),
+      }));
+    },
+  );
 }
 
 export async function createGroup(ctx: TenantContext, userId: string, name: string) {
@@ -41,6 +51,10 @@ export async function createGroup(ctx: TenantContext, userId: string, name: stri
     sortOrder: 0,
     createdAt: now,
   });
+  await invalidateTags([
+    ...tags.tenantDomain(ctx.tenantId, 'agent-groups'),
+    ...tags.user(userId),
+  ]);
   return { id, name, sortOrder: 0, memberAgentIds: [] as string[] };
 }
 
@@ -65,6 +79,11 @@ export async function updateGroup(
         eq(agentGroups.tenantId, ctx.tenantId),
       ),
     );
+  await invalidateTags([
+    ...tags.tenantDomain(ctx.tenantId, 'agent-groups'),
+    ...tags.user(userId),
+    ...tags.entity('group', groupId),
+  ]);
 }
 
 export async function deleteGroup(ctx: TenantContext, userId: string, groupId: string) {
@@ -77,6 +96,11 @@ export async function deleteGroup(ctx: TenantContext, userId: string, groupId: s
         eq(agentGroups.tenantId, ctx.tenantId),
       ),
     );
+  await invalidateTags([
+    ...tags.tenantDomain(ctx.tenantId, 'agent-groups'),
+    ...tags.user(userId),
+    ...tags.entity('group', groupId),
+  ]);
 }
 
 export async function setGroupMembers(
@@ -101,15 +125,21 @@ export async function setGroupMembers(
 
   await ctx.db.delete(agentGroupMembers).where(eq(agentGroupMembers.groupId, groupId));
 
-  if (agentIds.length === 0) return;
+  if (agentIds.length > 0) {
+    await ctx.db.insert(agentGroupMembers).values(
+      agentIds.map((agentId, i) => ({
+        groupId,
+        agentId,
+        sortOrder: i,
+      })),
+    );
+  }
 
-  await ctx.db.insert(agentGroupMembers).values(
-    agentIds.map((agentId, i) => ({
-      groupId,
-      agentId,
-      sortOrder: i,
-    })),
-  );
+  await invalidateTags([
+    ...tags.tenantDomain(ctx.tenantId, 'agent-groups'),
+    ...tags.user(userId),
+    ...tags.entity('group', groupId),
+  ]);
 }
 
 export async function addAgentToGroup(
@@ -122,6 +152,11 @@ export async function addAgentToGroup(
     .insert(agentGroupMembers)
     .values({ groupId, agentId, sortOrder: 0 })
     .onConflictDoNothing();
+  await invalidateTags([
+    ...tags.tenantDomain(ctx.tenantId, 'agent-groups'),
+    ...tags.user(userId),
+    ...tags.entity('group', groupId),
+  ]);
 }
 
 export async function removeAgentFromGroup(
@@ -133,6 +168,11 @@ export async function removeAgentFromGroup(
   await ctx.db
     .delete(agentGroupMembers)
     .where(and(eq(agentGroupMembers.groupId, groupId), eq(agentGroupMembers.agentId, agentId)));
+  await invalidateTags([
+    ...tags.tenantDomain(ctx.tenantId, 'agent-groups'),
+    ...tags.user(userId),
+    ...tags.entity('group', groupId),
+  ]);
 }
 
 export async function moveAgentToGroup(


### PR DESCRIPTION
## Summary

- Wraps `listGroups` in `agent-group.service.ts` with `cached()` from `@minion-stack/cache`
- Adds `invalidateTags(...)` to all 6 mutation paths (`createGroup`, `updateGroup`, `deleteGroup`, `setGroupMembers`, `addAgentToGroup`, `removeAgentFromGroup`)
- New `src/lib/server/cache.ts` with env-driven backend selection (memory in dev, noop in prod, valkey if `CACHE_BACKEND=valkey + VALKEY_URL`)
- `initCache()` fire-and-forget from `hooks.server.ts`

## Test plan

- [ ] `bun run dev` → dashboard → AgentSidebar mounts → terminal shows `[cache] miss` then `[cache] set` then `[cache] hit` on revisit
- [ ] Create/rename/delete a group → terminal shows `[cache] invalidate`
- [ ] Subsequent fetch shows `[cache] miss` (fresh load)

This is the base layer for stacked PRs:
- `feat/cache-p5-p6` extends to sessions, agents, files, reliability
- `feat/cache-browser-store` (P7) adds the browser-side store + WS invalidation listener

🤖 Generated with [Claude Code](https://claude.com/claude-code)