### PR TITLE
feat(cache): wrap remaining hub services (sessions/agents/files/reliability)

### DIFF
--- a/src/server/services/agent.service.ts
+++ b/src/server/services/agent.service.ts
@@ -1,5 +1,6 @@
 import { eq, and } from 'drizzle-orm';
 import { agents, userAgents } from '@minion-stack/db/schema';
+import { cached, invalidateTags, keys, tags } from '@minion-stack/cache';
 import { nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 
@@ -42,15 +43,27 @@ export async function upsertAgents(ctx: TenantContext, serverId: string, items: 
         },
       });
   }
+
+  await invalidateTags(tags.tenantDomain(ctx.tenantId, 'agents'));
 }
 
 export async function listAgents(ctx: TenantContext, serverId: string) {
-  const rows = await ctx.db
-    .select({ rawJson: agents.rawJson })
-    .from(agents)
-    .where(and(eq(agents.serverId, serverId), eq(agents.tenantId, ctx.tenantId)));
+  return cached(
+    keys.hub('agents', { t: ctx.tenantId, d: { serverId } }),
+    {
+      ttl: '30m',
+      swr: '5m',
+      tags: tags.tenantDomain(ctx.tenantId, 'agents'),
+    },
+    async () => {
+      const rows = await ctx.db
+        .select({ rawJson: agents.rawJson })
+        .from(agents)
+        .where(and(eq(agents.serverId, serverId), eq(agents.tenantId, ctx.tenantId)));
 
-  return rows.map((r) => JSON.parse(r.rawJson));
+      return rows.map((r) => JSON.parse(r.rawJson));
+    },
+  );
 }
 
 export async function listAgentsForUser(
@@ -61,18 +74,28 @@ export async function listAgentsForUser(
 ) {
   if (userRole === 'admin') return listAgents(ctx, serverId);
 
-  const rows = await ctx.db
-    .select({ rawJson: agents.rawJson })
-    .from(agents)
-    .innerJoin(
-      userAgents,
-      and(
-        eq(userAgents.agentId, agents.id),
-        eq(userAgents.serverId, agents.serverId),
-        eq(userAgents.userId, userId),
-      ),
-    )
-    .where(and(eq(agents.serverId, serverId), eq(agents.tenantId, ctx.tenantId)));
+  return cached(
+    keys.hub('agents', { t: ctx.tenantId, u: userId, d: { serverId } }),
+    {
+      ttl: '30m',
+      swr: '5m',
+      tags: [...tags.tenantDomain(ctx.tenantId, 'agents'), ...tags.user(userId)],
+    },
+    async () => {
+      const rows = await ctx.db
+        .select({ rawJson: agents.rawJson })
+        .from(agents)
+        .innerJoin(
+          userAgents,
+          and(
+            eq(userAgents.agentId, agents.id),
+            eq(userAgents.serverId, agents.serverId),
+            eq(userAgents.userId, userId),
+          ),
+        )
+        .where(and(eq(agents.serverId, serverId), eq(agents.tenantId, ctx.tenantId)));
 
-  return rows.map((r) => JSON.parse(r.rawJson));
+      return rows.map((r) => JSON.parse(r.rawJson));
+    },
+  );
 }

--- a/src/server/services/credential-health.service.ts
+++ b/src/server/services/credential-health.service.ts
@@ -1,5 +1,6 @@
 import { eq, and, desc, gte, lte } from 'drizzle-orm';
 import { credentialHealthSnapshots } from '@minion-stack/db/schema';
+import { cached, keys, tags } from '@minion-stack/cache';
 import { nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 
@@ -32,16 +33,29 @@ export async function listCredentialHealthSnapshots(
     limit?: number;
   } = {},
 ) {
-  const conditions = [eq(credentialHealthSnapshots.tenantId, ctx.tenantId)];
+  return cached(
+    keys.hub('credential-health', {
+      t: ctx.tenantId,
+      d: { s: filters.serverId, f: filters.from, to: filters.to, l: filters.limit },
+    }),
+    {
+      ttl: '30s',
+      tags: tags.tenantDomain(ctx.tenantId, 'reliability'),
+    },
+    async () => {
+      const conditions = [eq(credentialHealthSnapshots.tenantId, ctx.tenantId)];
 
-  if (filters.serverId) conditions.push(eq(credentialHealthSnapshots.serverId, filters.serverId));
-  if (filters.from) conditions.push(gte(credentialHealthSnapshots.capturedAt, filters.from));
-  if (filters.to) conditions.push(lte(credentialHealthSnapshots.capturedAt, filters.to));
+      if (filters.serverId)
+        conditions.push(eq(credentialHealthSnapshots.serverId, filters.serverId));
+      if (filters.from) conditions.push(gte(credentialHealthSnapshots.capturedAt, filters.from));
+      if (filters.to) conditions.push(lte(credentialHealthSnapshots.capturedAt, filters.to));
 
-  return ctx.db
-    .select()
-    .from(credentialHealthSnapshots)
-    .where(and(...conditions))
-    .orderBy(desc(credentialHealthSnapshots.capturedAt))
-    .limit(filters.limit ?? 100);
+      return ctx.db
+        .select()
+        .from(credentialHealthSnapshots)
+        .where(and(...conditions))
+        .orderBy(desc(credentialHealthSnapshots.capturedAt))
+        .limit(filters.limit ?? 100);
+    },
+  );
 }

--- a/src/server/services/file.service.ts
+++ b/src/server/services/file.service.ts
@@ -1,5 +1,6 @@
 import { eq, and, desc } from 'drizzle-orm';
 import { files } from '@minion-stack/db/schema';
+import { cached, invalidateTags, keys, tags } from '@minion-stack/cache';
 import { newId, nowMs } from '$server/db/utils';
 import { uploadToB2, getSignedDownloadUrl, deleteFromB2 } from '$server/storage/b2';
 import type { TenantContext } from './base';
@@ -31,6 +32,7 @@ export async function uploadFile(ctx: TenantContext, input: FileUploadInput) {
     createdAt: nowMs(),
   });
 
+  await invalidateTags(tags.tenantDomain(ctx.tenantId, 'files'));
   return id;
 }
 
@@ -58,19 +60,33 @@ export async function deleteFile(ctx: TenantContext, id: string) {
 
   await deleteFromB2(file.b2FileKey);
   await ctx.db.delete(files).where(eq(files.id, id));
+  await invalidateTags([
+    ...tags.tenantDomain(ctx.tenantId, 'files'),
+    ...tags.entity('file', id),
+  ]);
 }
 
 export async function listFiles(ctx: TenantContext, category?: string) {
-  let query = ctx.db
-    .select()
-    .from(files)
-    .where(eq(files.tenantId, ctx.tenantId))
-    .orderBy(desc(files.createdAt))
-    .$dynamic();
+  return cached(
+    keys.hub('files', { t: ctx.tenantId, d: { category: category ?? null } }),
+    {
+      ttl: '5m',
+      swr: '30s',
+      tags: tags.tenantDomain(ctx.tenantId, 'files'),
+    },
+    async () => {
+      let query = ctx.db
+        .select()
+        .from(files)
+        .where(eq(files.tenantId, ctx.tenantId))
+        .orderBy(desc(files.createdAt))
+        .$dynamic();
 
-  if (category) {
-    query = query.where(and(eq(files.tenantId, ctx.tenantId), eq(files.category, category)));
-  }
+      if (category) {
+        query = query.where(and(eq(files.tenantId, ctx.tenantId), eq(files.category, category)));
+      }
 
-  return query.limit(200);
+      return query.limit(200);
+    },
+  );
 }

--- a/src/server/services/session.service.ts
+++ b/src/server/services/session.service.ts
@@ -1,5 +1,6 @@
 import { eq, and, desc } from 'drizzle-orm';
 import { sessions } from '@minion-stack/db/schema';
+import { cached, invalidateTags, keys, tags } from '@minion-stack/cache';
 import { newId, nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 
@@ -43,28 +44,52 @@ export async function upsertSession(ctx: TenantContext, input: SessionInput) {
       },
     });
 
+  await invalidateTags([
+    ...tags.tenantDomain(ctx.tenantId, 'sessions'),
+    ...tags.entity('session', id),
+  ]);
+
   return id;
 }
 
 export async function listSessions(ctx: TenantContext, serverId: string) {
-  return ctx.db
-    .select()
-    .from(sessions)
-    .where(and(eq(sessions.serverId, serverId), eq(sessions.tenantId, ctx.tenantId)))
-    .orderBy(desc(sessions.updatedAt));
+  return cached(
+    keys.hub('sessions', { t: ctx.tenantId, d: { serverId } }),
+    {
+      ttl: '2m',
+      swr: '30s',
+      tags: tags.tenantDomain(ctx.tenantId, 'sessions'),
+    },
+    () =>
+      ctx.db
+        .select()
+        .from(sessions)
+        .where(and(eq(sessions.serverId, serverId), eq(sessions.tenantId, ctx.tenantId)))
+        .orderBy(desc(sessions.updatedAt)),
+  );
 }
 
 export async function listSessionsByServer(ctx: TenantContext, serverId: string, agentId?: string) {
-  const conditions = [
-    eq(sessions.serverId, serverId),
-    eq(sessions.tenantId, ctx.tenantId),
-    ...(agentId ? [eq(sessions.agentId, agentId)] : []),
-  ];
-  return ctx.db
-    .select()
-    .from(sessions)
-    .where(and(...conditions))
-    .orderBy(desc(sessions.updatedAt));
+  return cached(
+    keys.hub('sessions', { t: ctx.tenantId, d: { agentId: agentId ?? '', serverId } }),
+    {
+      ttl: '2m',
+      swr: '30s',
+      tags: tags.tenantDomain(ctx.tenantId, 'sessions'),
+    },
+    () => {
+      const conditions = [
+        eq(sessions.serverId, serverId),
+        eq(sessions.tenantId, ctx.tenantId),
+        ...(agentId ? [eq(sessions.agentId, agentId)] : []),
+      ];
+      return ctx.db
+        .select()
+        .from(sessions)
+        .where(and(...conditions))
+        .orderBy(desc(sessions.updatedAt));
+    },
+  );
 }
 
 export async function getSession(ctx: TenantContext, id: string) {

--- a/src/server/services/skill-stats.service.ts
+++ b/src/server/services/skill-stats.service.ts
@@ -1,5 +1,6 @@
 import { eq, and, desc, gte, lte, sql } from 'drizzle-orm';
 import { skillExecutionStats } from '@minion-stack/db/schema';
+import { cached, keys, tags } from '@minion-stack/cache';
 import { nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 
@@ -43,19 +44,31 @@ export async function listSkillStats(
     limit?: number;
   } = {},
 ) {
-  const conditions = [eq(skillExecutionStats.tenantId, ctx.tenantId)];
+  return cached(
+    keys.hub('skill-stats', {
+      t: ctx.tenantId,
+      d: { s: filters.serverId, sk: filters.skillName, f: filters.from, to: filters.to, l: filters.limit },
+    }),
+    {
+      ttl: '30s',
+      tags: tags.tenantDomain(ctx.tenantId, 'reliability'),
+    },
+    async () => {
+      const conditions = [eq(skillExecutionStats.tenantId, ctx.tenantId)];
 
-  if (filters.serverId) conditions.push(eq(skillExecutionStats.serverId, filters.serverId));
-  if (filters.skillName) conditions.push(eq(skillExecutionStats.skillName, filters.skillName));
-  if (filters.from) conditions.push(gte(skillExecutionStats.occurredAt, filters.from));
-  if (filters.to) conditions.push(lte(skillExecutionStats.occurredAt, filters.to));
+      if (filters.serverId) conditions.push(eq(skillExecutionStats.serverId, filters.serverId));
+      if (filters.skillName) conditions.push(eq(skillExecutionStats.skillName, filters.skillName));
+      if (filters.from) conditions.push(gte(skillExecutionStats.occurredAt, filters.from));
+      if (filters.to) conditions.push(lte(skillExecutionStats.occurredAt, filters.to));
 
-  return ctx.db
-    .select()
-    .from(skillExecutionStats)
-    .where(and(...conditions))
-    .orderBy(desc(skillExecutionStats.occurredAt))
-    .limit(filters.limit ?? 200);
+      return ctx.db
+        .select()
+        .from(skillExecutionStats)
+        .where(and(...conditions))
+        .orderBy(desc(skillExecutionStats.occurredAt))
+        .limit(filters.limit ?? 200);
+    },
+  );
 }
 
 export async function getSkillStatsSummary(
@@ -66,27 +79,39 @@ export async function getSkillStatsSummary(
     to?: number;
   } = {},
 ) {
-  const conditions = [eq(skillExecutionStats.tenantId, ctx.tenantId)];
+  return cached(
+    keys.hub('skill-stats-summary', {
+      t: ctx.tenantId,
+      d: { s: filters.serverId, f: filters.from, to: filters.to },
+    }),
+    {
+      ttl: '30s',
+      tags: tags.tenantDomain(ctx.tenantId, 'reliability'),
+    },
+    async () => {
+      const conditions = [eq(skillExecutionStats.tenantId, ctx.tenantId)];
 
-  if (filters.serverId) conditions.push(eq(skillExecutionStats.serverId, filters.serverId));
-  if (filters.from) conditions.push(gte(skillExecutionStats.occurredAt, filters.from));
-  if (filters.to) conditions.push(lte(skillExecutionStats.occurredAt, filters.to));
+      if (filters.serverId) conditions.push(eq(skillExecutionStats.serverId, filters.serverId));
+      if (filters.from) conditions.push(gte(skillExecutionStats.occurredAt, filters.from));
+      if (filters.to) conditions.push(lte(skillExecutionStats.occurredAt, filters.to));
 
-  const where = and(...conditions);
+      const where = and(...conditions);
 
-  const bySkill = await ctx.db
-    .select({
-      skillName: skillExecutionStats.skillName,
-      status: skillExecutionStats.status,
-      count: sql<number>`count(*)`.as('count'),
-      avgDurationMs: sql<number>`avg(${skillExecutionStats.durationMs})`.as('avg_duration'),
-      minDurationMs: sql<number>`min(${skillExecutionStats.durationMs})`.as('min_duration'),
-      maxDurationMs: sql<number>`max(${skillExecutionStats.durationMs})`.as('max_duration'),
-    })
-    .from(skillExecutionStats)
-    .where(where)
-    .groupBy(skillExecutionStats.skillName, skillExecutionStats.status)
-    .orderBy(sql`count(*) desc`);
+      const bySkill = await ctx.db
+        .select({
+          skillName: skillExecutionStats.skillName,
+          status: skillExecutionStats.status,
+          count: sql<number>`count(*)`.as('count'),
+          avgDurationMs: sql<number>`avg(${skillExecutionStats.durationMs})`.as('avg_duration'),
+          minDurationMs: sql<number>`min(${skillExecutionStats.durationMs})`.as('min_duration'),
+          maxDurationMs: sql<number>`max(${skillExecutionStats.durationMs})`.as('max_duration'),
+        })
+        .from(skillExecutionStats)
+        .where(where)
+        .groupBy(skillExecutionStats.skillName, skillExecutionStats.status)
+        .orderBy(sql`count(*) desc`);
 
-  return { bySkill };
+      return { bySkill };
+    },
+  );
 }

--- a/src/server/test-utils/setup.ts
+++ b/src/server/test-utils/setup.ts
@@ -10,3 +10,7 @@ process.env.B2_ENDPOINT ??= 'http://localhost:0';
 process.env.B2_KEY_ID ??= 'test-key-id';
 process.env.B2_APP_KEY ??= 'test-app-key';
 process.env.B2_BUCKET_NAME ??= 'test-bucket';
+
+import { configureCache, createBackend } from '@minion-stack/cache';
+
+configureCache({ backend: createBackend({ backend: 'noop' }) });


### PR DESCRIPTION
## Summary

Extends P4-mini's cache wrap pattern across the remaining server-side hub services:

| Service | Functions wrapped | TTL / SWR |
|---|---|---|
| Sessions | `listSessions`, `listSessionsByServer` + `upsertSession` invalidates | 2m / 30s |
| Agent registry | `listAgents`, `listAgentsForUser` (non-admin) + `upsertAgents` invalidates | 30m / 5m |
| Files | `listFiles` + `uploadFile`/`deleteFile` invalidate | 5m / 30s |
| Reliability | `listCredentialHealthSnapshots`, `listSkillStats`, `getSkillStatsSummary` | 30s / no swr |

Also: vitest setup hook initializes a noop cache backend so service tests exercising mutation paths keep working without coupling to a real cache.

### Deferrals (intentional, documented)

- **Prompt pipeline runs** — gateway-WS only (`fetchSessionPromptReport`, `fetchPromptPreview` in `gateway.svelte.ts`); no server intercept point. Belongs in P7 browser store.
- **Tools per agent** — same: `tools.status` RPC over WS, no server-side function exists.
- **Flow node templates** — bundled static TS type literals in `flow-editor.svelte.ts`; no server load function.

## Test plan

- [ ] All 339 existing tests still pass (vitest)
- [ ] `bun run dev` → navigate sessions / agents / files / reliability pages → watch `[cache] hit/miss/invalidate` lines
- [ ] Mutate (rename/delete a session, upload/delete a file) → verify `[cache] invalidate` precedes next `[cache] miss`

**Stacked PR base:** `feat/cache-agent-groups` (#35). Merge #35 first; then this becomes mergeable against `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)