### PR TITLE
release: dev → master (Phase A plugin host)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1043,6 +1043,7 @@
   "settings_clickToCopy": "Click to copy",
   "settings_copied": "Copied!",
   "settings_noFieldsMatching": "No fields matching \"{query}\"",
+  "settings_plugins": "Plugins",
   "skills_searchPlaceholder": "Search skills…",
   "skills_enabledCount": "{enabled}/{total} enabled",
   "skills_filterAll": "All",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1034,6 +1034,7 @@
   "settings_clickToCopy": "Clic para copiar",
   "settings_copied": "¡Copiado!",
   "settings_noFieldsMatching": "Sin campos que coincidan con \"{query}\"",
+  "settings_plugins": "Plugins",
   "skills_searchPlaceholder": "Buscar habilidades…",
   "skills_enabledCount": "{enabled}/{total} habilitadas",
   "skills_filterAll": "Todas",

--- a/src/lib/components/settings/SettingsTabBar.svelte
+++ b/src/lib/components/settings/SettingsTabBar.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-    import { Brain, Bot, Radio, Shield, Server, Palette, HardDrive, DatabaseBackup } from "lucide-svelte";
+    import { Brain, Bot, Radio, Shield, Server, Palette, HardDrive, DatabaseBackup, Puzzle } from "lucide-svelte";
+    import { page } from "$app/state";
     import { isAdmin } from "$lib/state/features/user.svelte";
     import { TABS } from "$lib/utils/config-schema";
+    import * as m from "$lib/paraglide/messages";
 
     interface Props {
         activeTab: string;
@@ -10,6 +12,8 @@
     }
 
     let { activeTab, onselect, dirtyTabIds = new Set<string>() }: Props = $props();
+
+    const isPluginsRoute = $derived(page.url.pathname.startsWith("/settings/plugins"));
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const ICON_MAP: Record<string, any> = {
@@ -57,5 +61,23 @@
                 {/if}
             </button>
         {/each}
+
+        <!-- Plugins (separate route, not a ?s= tab) -->
+        <a
+            href="/settings/plugins"
+            role="tab"
+            aria-selected={isPluginsRoute}
+            class="relative flex items-center gap-1.5 px-3 py-2.5 text-xs font-medium transition-colors bg-transparent border-none cursor-pointer font-[inherit] whitespace-nowrap no-underline
+                {isPluginsRoute
+                ? 'text-accent'
+                : 'text-muted-foreground hover:text-foreground'}"
+        >
+            <Puzzle size={14} />
+            <span class="hidden lg:inline">{m.settings_plugins()}</span>
+
+            {#if isPluginsRoute}
+                <div class="absolute bottom-0 left-2 right-2 h-[2px] bg-accent rounded-t-full"></div>
+            {/if}
+        </a>
     </div>
 </div>

--- a/src/lib/plugins/PluginIframe.svelte
+++ b/src/lib/plugins/PluginIframe.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import { mountHostBridge, type MountedHostBridge } from "./bridge-host";
+  import type { Theme } from "./bridge-protocol";
+
+  interface Props {
+    pluginId: string;
+    entrypoint: string;
+    gatewayUrl: string;
+    authToken: string;
+    theme: Theme;
+    tokens: Record<string, string>;
+  }
+
+  let { pluginId, entrypoint, gatewayUrl, authToken, theme, tokens }: Props = $props();
+
+  let iframeEl: HTMLIFrameElement | null = $state(null);
+  let mounted: MountedHostBridge | null = null;
+  let height = $state(600);
+
+  const src = `${gatewayUrl}/plugins/${pluginId}/ui/${entrypoint}`;
+  const pluginOrigin = new URL(gatewayUrl).origin;
+
+  function handleLoad(): void {
+    if (!iframeEl?.contentWindow) return;
+    mounted?.dispose();
+    mounted = mountHostBridge({
+      self: window,
+      target: iframeEl.contentWindow,
+      pluginOrigin,
+      hello: { theme, tokens, gatewayUrl, authToken },
+      onResize: (h) => {
+        height = h;
+      },
+    });
+  }
+
+  $effect(() => {
+    mounted?.sendThemeChange(theme, tokens);
+  });
+
+  onDestroy(() => mounted?.dispose());
+</script>
+
+<iframe
+  bind:this={iframeEl}
+  title="Plugin: {pluginId}"
+  {src}
+  onload={handleLoad}
+  style:height="{height}px"
+  class="w-full border-0"
+></iframe>

--- a/src/lib/plugins/PluginIframe.test.ts
+++ b/src/lib/plugins/PluginIframe.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from "vitest";
+import PluginIframe from "./PluginIframe.svelte";
+
+vi.mock("./bridge-host", () => ({
+  mountHostBridge: vi.fn(() => ({ dispose: vi.fn(), sendThemeChange: vi.fn(), bridge: {} })),
+}));
+
+describe("PluginIframe", () => {
+  it("is a Svelte component (defined)", () => {
+    expect(PluginIframe).toBeDefined();
+  });
+
+  it("is truthy (compiled Svelte 5 component)", () => {
+    expect(!!PluginIframe).toBe(true);
+  });
+});

--- a/src/lib/plugins/PluginSlotHost.svelte
+++ b/src/lib/plugins/PluginSlotHost.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  import PluginIframe from "./PluginIframe.svelte";
+  import { SLOT_DEFINITIONS, type PluginSlot } from "./slots";
+  import type { Theme } from "./bridge-protocol";
+
+  export interface PluginUiManifestOccupant {
+    pluginId: string;
+    slot: PluginSlot;
+    title: string;
+    description: string;
+    entrypoint: string;
+    icon?: string;
+  }
+
+  interface Props {
+    slot: PluginSlot;
+    entries: PluginUiManifestOccupant[];
+    theme: Theme;
+    tokens: Record<string, string>;
+    gatewayBaseUrl: string;
+    authToken?: string;
+  }
+
+  let {
+    slot,
+    entries,
+    theme,
+    tokens,
+    gatewayBaseUrl,
+    authToken = "",
+  }: Props = $props();
+
+  let selected = $state(0);
+
+  const def = $derived(SLOT_DEFINITIONS[slot]);
+  const current = $derived(entries[selected]);
+</script>
+
+{#if entries.length === 0}
+  <div class="p-6 text-sm text-muted-foreground">
+    No plugins installed for this slot ({def.label}).
+  </div>
+{:else}
+  <!-- Layout: tabs is the only Phase A layout. cards/list fall back to tabs. -->
+  <div class="flex flex-col">
+    <div role="tablist" class="flex border-b border-border" aria-label={def.label}>
+      {#each entries as entry, i (entry.pluginId + ":" + entry.entrypoint)}
+        <button
+          type="button"
+          role="tab"
+          aria-selected={selected === i}
+          class="border-b-2 px-4 py-2 text-sm transition-colors hover:bg-muted text-foreground"
+          class:border-foreground={selected === i}
+          class:border-transparent={selected !== i}
+          onclick={() => (selected = i)}
+        >
+          {#if entry.icon}<span class="mr-2">{entry.icon}</span>{/if}
+          {entry.title}
+        </button>
+      {/each}
+    </div>
+
+    {#if current}
+      <div class="flex-1">
+        <PluginIframe
+          pluginId={current.pluginId}
+          entrypoint={current.entrypoint}
+          gatewayUrl={gatewayBaseUrl}
+          {authToken}
+          {theme}
+          {tokens}
+        />
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/src/lib/plugins/PluginSlotHost.test.ts
+++ b/src/lib/plugins/PluginSlotHost.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from "vitest";
+import PluginSlotHost from "./PluginSlotHost.svelte";
+
+describe("PluginSlotHost", () => {
+  it("imports", () => {
+    expect(PluginSlotHost).toBeTruthy();
+  });
+});

--- a/src/lib/plugins/bridge-host.test.ts
+++ b/src/lib/plugins/bridge-host.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mountHostBridge } from "./bridge-host";
+
+class FakeWindow {
+  listeners: Array<(e: MessageEvent) => void> = [];
+  posted: Array<{ data: unknown; origin: string }> = [];
+  addEventListener = vi.fn((_: string, fn: (e: MessageEvent) => void) => {
+    this.listeners.push(fn);
+  });
+  removeEventListener = vi.fn();
+  postMessage = vi.fn((data: unknown, targetOrigin: string) => {
+    this.posted.push({ data, origin: targetOrigin });
+  });
+  emit(data: unknown, origin: string) {
+    for (const l of this.listeners) l({ data, origin } as MessageEvent);
+  }
+}
+
+describe("mountHostBridge", () => {
+  let hostWin: FakeWindow;
+  let iframeWin: FakeWindow;
+
+  beforeEach(() => {
+    hostWin = new FakeWindow();
+    iframeWin = new FakeWindow();
+  });
+
+  it("sends host:hello after plugin:ready from correct origin", () => {
+    const bridge = mountHostBridge({
+      self: hostWin as unknown as Window,
+      target: iframeWin as unknown as Window,
+      pluginOrigin: "https://gw.example.com",
+      hello: {
+        theme: "dark",
+        tokens: { bg: "#000" },
+        gatewayUrl: "wss://gw",
+        authToken: "tok",
+      },
+    });
+    hostWin.emit({ type: "plugin:ready" }, "https://gw.example.com");
+    expect(iframeWin.posted).toHaveLength(1);
+    bridge.dispose();
+  });
+
+  it("ignores plugin:ready from wrong origin", () => {
+    const bridge = mountHostBridge({
+      self: hostWin as unknown as Window,
+      target: iframeWin as unknown as Window,
+      pluginOrigin: "https://gw.example.com",
+      hello: { theme: "dark", tokens: {}, gatewayUrl: "wss://gw", authToken: "tok" },
+    });
+    hostWin.emit({ type: "plugin:ready" }, "https://evil.example.com");
+    expect(iframeWin.posted).toHaveLength(0);
+    bridge.dispose();
+  });
+
+  it("relays resize via onResize", () => {
+    const onResize = vi.fn();
+    const bridge = mountHostBridge({
+      self: hostWin as unknown as Window,
+      target: iframeWin as unknown as Window,
+      pluginOrigin: "https://gw.example.com",
+      hello: { theme: "dark", tokens: {}, gatewayUrl: "wss://gw", authToken: "tok" },
+      onResize,
+    });
+    hostWin.emit({ type: "plugin:resize", height: 420 }, "https://gw.example.com");
+    expect(onResize).toHaveBeenCalledWith(420);
+    bridge.dispose();
+  });
+
+  it("dispose removes listeners", () => {
+    const bridge = mountHostBridge({
+      self: hostWin as unknown as Window,
+      target: iframeWin as unknown as Window,
+      pluginOrigin: "https://gw.example.com",
+      hello: { theme: "dark", tokens: {}, gatewayUrl: "wss://gw", authToken: "tok" },
+    });
+    bridge.dispose();
+    expect(hostWin.removeEventListener).toHaveBeenCalled();
+  });
+});

--- a/src/lib/plugins/bridge-host.ts
+++ b/src/lib/plugins/bridge-host.ts
@@ -1,0 +1,37 @@
+import { HostBridge, type Theme } from "./bridge-protocol";
+
+export interface MountHostBridgeOptions {
+  self: Window;
+  target: Window;
+  pluginOrigin: string;
+  hello: {
+    theme: Theme;
+    tokens: Record<string, string>;
+    gatewayUrl: string;
+    authToken: string;
+  };
+  onResize?: (height: number) => void;
+  onNotify?: (level: "info" | "warn" | "error", message: string) => void;
+}
+
+export interface MountedHostBridge {
+  bridge: HostBridge;
+  dispose: () => void;
+  sendThemeChange: (theme: Theme, tokens: Record<string, string>) => void;
+}
+
+export function mountHostBridge(opts: MountHostBridgeOptions): MountedHostBridge {
+  const bridge = new HostBridge({
+    self: opts.self,
+    target: opts.target,
+    pluginOrigin: opts.pluginOrigin,
+  });
+  bridge.sendHelloOnReady(opts.hello);
+  if (opts.onResize) bridge.onResize(opts.onResize);
+  if (opts.onNotify) bridge.onNotify(opts.onNotify);
+  return {
+    bridge,
+    dispose: () => bridge.dispose(),
+    sendThemeChange: (theme, tokens) => bridge.sendThemeChange({ theme, tokens }),
+  };
+}

--- a/src/lib/plugins/bridge-protocol.ts
+++ b/src/lib/plugins/bridge-protocol.ts
@@ -1,0 +1,93 @@
+// Inlined from @minion-stack/plugin-ui-bridge until that package is published.
+// Phase B can refactor to import from the npm package.
+
+export type Theme = "light" | "dark";
+
+export type HostToPlugin =
+  | {
+      type: "host:hello";
+      theme: Theme;
+      tokens: Record<string, string>;
+      gatewayUrl: string;
+      authToken: string;
+    }
+  | {
+      type: "host:theme-change";
+      theme: Theme;
+      tokens: Record<string, string>;
+    };
+
+export type PluginToHost =
+  | { type: "plugin:ready" }
+  | { type: "plugin:resize"; height: number }
+  | { type: "plugin:notify"; level: "info" | "warn" | "error"; message: string };
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+function isPluginToHost(v: unknown): v is PluginToHost {
+  if (!isObject(v)) return false;
+  const t = v.type;
+  return t === "plugin:ready" || t === "plugin:resize" || t === "plugin:notify";
+}
+
+export interface HostBridgeOptions {
+  self: Window;
+  target: Window;
+  pluginOrigin: string;
+}
+
+export class HostBridge {
+  private pendingHelloPayload: Omit<Extract<HostToPlugin, { type: "host:hello" }>, "type"> | null =
+    null;
+  private resizeHandlers: Array<(height: number) => void> = [];
+  private notifyHandlers: Array<(level: "info" | "warn" | "error", message: string) => void> = [];
+
+  constructor(private opts: HostBridgeOptions) {
+    opts.self.addEventListener("message", this.handle);
+  }
+
+  private handle = (ev: MessageEvent): void => {
+    if (ev.origin !== this.opts.pluginOrigin) return;
+    if (!isPluginToHost(ev.data)) return;
+    if (ev.data.type === "plugin:ready") {
+      if (this.pendingHelloPayload) {
+        const msg: HostToPlugin = { type: "host:hello", ...this.pendingHelloPayload };
+        this.opts.target.postMessage(msg, this.opts.pluginOrigin);
+      }
+    } else if (ev.data.type === "plugin:resize") {
+      const { height } = ev.data;
+      for (const h of this.resizeHandlers) h(height);
+    } else if (ev.data.type === "plugin:notify") {
+      const { level, message } = ev.data;
+      for (const h of this.notifyHandlers) h(level, message);
+    }
+  };
+
+  sendHelloOnReady(
+    payload: Omit<Extract<HostToPlugin, { type: "host:hello" }>, "type">,
+  ): void {
+    this.pendingHelloPayload = payload;
+  }
+
+  sendThemeChange(payload: { theme: Theme; tokens: Record<string, string> }): void {
+    const msg: HostToPlugin = { type: "host:theme-change", ...payload };
+    this.opts.target.postMessage(msg, this.opts.pluginOrigin);
+  }
+
+  onResize(fn: (height: number) => void): void {
+    this.resizeHandlers.push(fn);
+  }
+
+  onNotify(fn: (level: "info" | "warn" | "error", message: string) => void): void {
+    this.notifyHandlers.push(fn);
+  }
+
+  dispose(): void {
+    this.opts.self.removeEventListener("message", this.handle);
+    this.pendingHelloPayload = null;
+    this.resizeHandlers = [];
+    this.notifyHandlers = [];
+  }
+}

--- a/src/lib/plugins/slots.test.ts
+++ b/src/lib/plugins/slots.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { SLOT_DEFINITIONS, isPluginSlot } from "./slots";
+
+describe("slots", () => {
+  it("SLOT_DEFINITIONS has settings.plugins entry", () => {
+    expect(SLOT_DEFINITIONS["settings.plugins"]).toBeDefined();
+    expect(SLOT_DEFINITIONS["settings.plugins"].layout).toBe("tabs");
+  });
+
+  it("isPluginSlot accepts known slot", () => {
+    expect(isPluginSlot("settings.plugins")).toBe(true);
+  });
+
+  it("isPluginSlot rejects unknown slot", () => {
+    expect(isPluginSlot("not.a.slot")).toBe(false);
+  });
+});

--- a/src/lib/plugins/slots.ts
+++ b/src/lib/plugins/slots.ts
@@ -1,0 +1,23 @@
+export type PluginSlot =
+  | "settings.plugins"
+  | "dashboard.widget"
+  | "workforce.sidebar";
+
+export interface SlotDefinition {
+  /** How the slot host arranges occupants. */
+  layout: "tabs" | "cards" | "list";
+  /** Human-readable label for diagnostics. */
+  label: string;
+}
+
+export const SLOT_DEFINITIONS: Record<PluginSlot, SlotDefinition> = {
+  "settings.plugins": { layout: "tabs", label: "Settings → Plugins" },
+  "dashboard.widget": { layout: "cards", label: "Dashboard widget" },
+  "workforce.sidebar": { layout: "list", label: "Workforce sidebar" },
+};
+
+const ALL_SLOTS = new Set<string>(Object.keys(SLOT_DEFINITIONS));
+
+export function isPluginSlot(value: string): value is PluginSlot {
+  return ALL_SLOTS.has(value);
+}

--- a/src/lib/server/gateway-rpc.test.ts
+++ b/src/lib/server/gateway-rpc.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+
+describe('gateway-rpc helper', () => {
+  it('exports gatewayCall and pluginsUiList', async () => {
+    const mod = await import('./gateway-rpc');
+    expect(typeof mod.gatewayCall).toBe('function');
+    expect(typeof mod.pluginsUiList).toBe('function');
+  });
+});

--- a/src/lib/server/gateway-rpc.ts
+++ b/src/lib/server/gateway-rpc.ts
@@ -1,0 +1,162 @@
+/**
+ * Server-side one-shot gateway RPC helper.
+ *
+ * Hub's primary gateway client (`src/lib/services/gateway.svelte.ts`) is a
+ * Svelte 5 rune store and only usable from the browser. SSR loaders need a
+ * pure node-side path, so this module opens a transient WebSocket, performs
+ * the token-auth handshake, sends a single request, and tears down.
+ *
+ * Auth: backward-compat admin mode (Case 2 in `ws-jwt-auth.ts`). We pass a
+ * raw operator token in the `connect` request; the gateway treats
+ * token/password auth without a JWT as `role: "admin"`.
+ *
+ * Env vars (already used elsewhere in hub):
+ *   MINION_GATEWAY_URL        — ws:// or wss:// URL of the gateway
+ *   OPENCLAW_GATEWAY_TOKEN    — operator/admin token
+ */
+import { WebSocket } from 'ws';
+import { randomUUID } from 'node:crypto';
+
+const env = process.env;
+
+import type { PluginUiManifestOccupant } from '$lib/plugins/PluginSlotHost.svelte';
+
+const DEFAULT_TIMEOUT_MS = 8000;
+
+function resolveGatewayUrl(): string {
+  const raw = env.MINION_GATEWAY_URL ?? env.OPENCLAW_GATEWAY_URL ?? '';
+  if (!raw) {
+    throw new Error('MINION_GATEWAY_URL is not set');
+  }
+  // Normalise http(s) → ws(s) so callers can paste either.
+  if (raw.startsWith('http://')) return 'ws://' + raw.slice('http://'.length);
+  if (raw.startsWith('https://')) return 'wss://' + raw.slice('https://'.length);
+  return raw;
+}
+
+function resolveToken(): string {
+  const tok = env.OPENCLAW_GATEWAY_TOKEN ?? '';
+  if (!tok) {
+    throw new Error('OPENCLAW_GATEWAY_TOKEN is not set');
+  }
+  return tok;
+}
+
+/**
+ * Call a gateway RPC over a one-shot WebSocket and return the result.
+ */
+export function gatewayCall<T = unknown>(
+  method: string,
+  params: Record<string, unknown> = {},
+  opts: { timeoutMs?: number } = {},
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const url = resolveGatewayUrl();
+  const token = resolveToken();
+
+  return new Promise<T>((resolve, reject) => {
+    const ws = new WebSocket(url);
+    let settled = false;
+    let connectId: string | null = null;
+    let requestId: string | null = null;
+
+    const cleanup = () => {
+      try {
+        ws.close();
+      } catch {
+        /* ignore */
+      }
+    };
+    const fail = (err: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(err);
+    };
+    const succeed = (value: T) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+
+    const timer = setTimeout(() => fail(new Error('gateway RPC timeout')), timeoutMs);
+    timer.unref?.();
+
+    ws.on('error', (err) => fail(err instanceof Error ? err : new Error(String(err))));
+    ws.on('close', () => fail(new Error('gateway WS closed before response')));
+
+    ws.on('message', (raw) => {
+      let frame: Record<string, unknown>;
+      try {
+        frame = JSON.parse(raw.toString()) as Record<string, unknown>;
+      } catch {
+        return;
+      }
+      const type = frame.type;
+      if (type === 'event' && frame.event === 'connect.challenge') {
+        // Send connect request (token-only auth → admin role per ws-jwt-auth.ts Case 2).
+        connectId = randomUUID();
+        ws.send(
+          JSON.stringify({
+            type: 'req',
+            id: connectId,
+            method: 'connect',
+            params: {
+              minProtocol: 3,
+              maxProtocol: 3,
+              client: {
+                id: 'minion-hub-ssr',
+                version: '1.0',
+                platform: 'node',
+                mode: 'admin',
+              },
+              role: 'operator',
+              scopes: ['operator.admin', 'operator.read', 'operator.write'],
+              caps: [],
+              auth: { token },
+            },
+          }),
+        );
+        return;
+      }
+
+      if (type === 'res' && frame.id === connectId) {
+        if (frame.ok === false) {
+          fail(new Error(`gateway connect failed: ${JSON.stringify(frame.error ?? frame)}`));
+          return;
+        }
+        // Connected. Send the actual request.
+        requestId = randomUUID();
+        ws.send(
+          JSON.stringify({
+            type: 'req',
+            id: requestId,
+            method,
+            params,
+          }),
+        );
+        return;
+      }
+
+      if (type === 'res' && frame.id === requestId) {
+        clearTimeout(timer);
+        if (frame.ok === false) {
+          fail(new Error(`gateway ${method} failed: ${JSON.stringify(frame.error ?? frame)}`));
+          return;
+        }
+        succeed((frame.result ?? frame.payload ?? frame.data) as T);
+      }
+    });
+  });
+}
+
+/** Convenience: list plugin UI manifest occupants. */
+export async function pluginsUiList(): Promise<PluginUiManifestOccupant[]> {
+  const res = await gatewayCall<{ occupants?: PluginUiManifestOccupant[] } | PluginUiManifestOccupant[]>(
+    'plugins.ui.list',
+    {},
+  );
+  if (Array.isArray(res)) return res;
+  return res?.occupants ?? [];
+}

--- a/src/routes/(app)/settings/plugins/+page.server.ts
+++ b/src/routes/(app)/settings/plugins/+page.server.ts
@@ -1,0 +1,25 @@
+import type { PageServerLoad } from './$types';
+import { pluginsUiList } from '$lib/server/gateway-rpc';
+import type { PluginUiManifestOccupant } from '$lib/plugins/PluginSlotHost.svelte';
+
+export const load: PageServerLoad = async () => {
+  const gatewayUrl = process.env.MINION_GATEWAY_URL ?? process.env.OPENCLAW_GATEWAY_URL ?? '';
+  const authToken = process.env.OPENCLAW_GATEWAY_TOKEN ?? '';
+
+  let entries: PluginUiManifestOccupant[] = [];
+  let errorMessage: string | undefined;
+  try {
+    const all = await pluginsUiList();
+    entries = all.filter((entry) => entry.slot === 'settings.plugins');
+  } catch (err) {
+    errorMessage = err instanceof Error ? err.message : String(err);
+    console.warn('[settings/plugins] failed to load plugin UI manifest:', errorMessage);
+  }
+
+  return {
+    entries,
+    gatewayUrl,
+    authToken,
+    error: errorMessage,
+  };
+};

--- a/src/routes/(app)/settings/plugins/+page.svelte
+++ b/src/routes/(app)/settings/plugins/+page.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import PluginSlotHost from '$lib/plugins/PluginSlotHost.svelte';
+  import SettingsTabBar from '$lib/components/settings/SettingsTabBar.svelte';
+  import type { Theme } from '$lib/plugins/bridge-protocol';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  function selectTab(id: string) {
+    goto(`/settings?s=${id}`);
+  }
+
+  // MVP: pick up theme mode from the document root and forward a tiny token
+  // bag. The full theme/preset wiring lands in Phase B alongside the first
+  // consumer plugin. (TODO: subscribe to theme changes via the theme rune
+  // store and forward via PluginSlotHost.)
+  const theme: Theme = 'light';
+  const tokens: Record<string, string> = {};
+</script>
+
+<SettingsTabBar activeTab="" onselect={selectTab} />
+
+<section class="space-y-4 p-6">
+  <header>
+    <h1 class="text-2xl font-semibold">Plugins</h1>
+    <p class="text-sm text-muted-foreground">
+      Plugins that ship a UI appear here. Their configuration is owned by the plugin itself.
+    </p>
+  </header>
+
+  {#if data.error}
+    <div class="rounded border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+      Failed to load plugin manifest: {data.error}
+    </div>
+  {/if}
+
+  <PluginSlotHost
+    slot="settings.plugins"
+    entries={data.entries}
+    {theme}
+    {tokens}
+    gatewayBaseUrl={data.gatewayUrl}
+    authToken={data.authToken}
+  />
+</section>

--- a/src/routes/(app)/settings/plugins/page.server.test.ts
+++ b/src/routes/(app)/settings/plugins/page.server.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+
+describe('/settings/plugins +page.server', () => {
+  it('exports a load function', async () => {
+    const mod = await import('./+page.server');
+    expect(typeof mod.load).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- **#39** Phase A — settings/plugins slot host UI

Empties `/settings/plugins` ready to receive Phase B's complaint-listener SPA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)