### PR TITLE
Settings/security: TEAM + ROLES redesign (edit users, custom roles, identity linking, @aliases)

### DIFF
--- a/drizzle/0012_user_alias_role.sql
+++ b/drizzle/0012_user_alias_role.sql
@@ -1,0 +1,3 @@
+-- Add alias and role_id columns to user table
+ALTER TABLE user ADD COLUMN alias TEXT UNIQUE;
+ALTER TABLE user ADD COLUMN role_id TEXT;

--- a/drizzle/0013_roles.sql
+++ b/drizzle/0013_roles.sql
@@ -1,0 +1,17 @@
+-- Add roles and role_permissions tables for custom role/permission management
+CREATE TABLE roles (
+  id TEXT PRIMARY KEY NOT NULL,
+  tenant_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  is_system INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX idx_role_name_per_tenant ON roles(tenant_id, name);
+
+CREATE TABLE role_permissions (
+  role_id TEXT NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+  permission TEXT NOT NULL,
+  PRIMARY KEY (role_id, permission)
+);

--- a/src/app.css
+++ b/src/app.css
@@ -1063,3 +1063,9 @@ html[data-theme='crt'][data-crt-flicker='true'] body {
   ) !important;
   border-radius: 14px !important;
 }
+
+.mention {
+  color: var(--accent);
+  font-weight: 600;
+  cursor: default;
+}

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { extractText, extractMessageTimestamp } from '$lib/utils/text';
   import AIDisclosureBadge from './AIDisclosureBadge.svelte';
   import MarkdownMessage from './MarkdownMessage.svelte';
+  import { ensureAliases, getAliases } from '$lib/state/features/aliases.svelte';
+  import { renderMention } from '$lib/utils/mention';
 
   let { message, streaming = false, error = false }: {
     message: unknown;
@@ -14,6 +17,11 @@
   const role = $derived(m.role === 'user' ? 'user' : 'assistant');
   const timestamp = $derived(extractMessageTimestamp(message));
   const disclosure = $derived(m.provenance?.disclosure);
+  const renderedText = $derived(renderMention(text, getAliases()));
+
+  onMount(() => {
+    void ensureAliases();
+  });
 </script>
 
 {#if text || error}
@@ -29,7 +37,7 @@
   {#if role === 'assistant' && !error}
     <MarkdownMessage value={text} tone="assistant" />
   {:else}
-    {text}
+    <span>{@html renderedText}</span>
   {/if}
   {#if timestamp}
     <span class="block text-[9px] opacity-70 mt-0.5 text-right">{timestamp}</span>

--- a/src/lib/components/users/IdentityLinkPopover.svelte
+++ b/src/lib/components/users/IdentityLinkPopover.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  import { toastError } from '$lib/state/ui/toast.svelte';
+
+  let { userId, onCancel, onLinked }: { userId: string; onCancel: () => void; onLinked: () => void } = $props();
+
+  const CHANNELS = ['whatsapp', 'telegram', 'discord', 'email'] as const;
+  let tab = $state<'manual' | 'verify'>('manual');
+  let channel = $state<string>('telegram');
+  let channelUserId = $state('');
+  let displayName = $state('');
+  let busy = $state(false);
+
+  let requestId = $state<string | null>(null);
+  let code = $state('');
+
+  async function attachManual() {
+    busy = true;
+    try {
+      const res = await fetch(`/api/users/${userId}/identities`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ channel, channelUserId, displayName }),
+      });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        toastError((d as { message?: string }).message ?? `HTTP ${res.status}`);
+        return;
+      }
+      onLinked();
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function sendCode() {
+    busy = true;
+    try {
+      const res = await fetch(`/api/users/${userId}/identities/verify-request`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ channel, channelUserId }),
+      });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        toastError((d as { message?: string }).message ?? `HTTP ${res.status}`);
+        return;
+      }
+      const data = (await res.json()) as { requestId: string };
+      requestId = data.requestId;
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function confirmCode() {
+    if (!requestId) return;
+    busy = true;
+    try {
+      const res = await fetch(`/api/users/${userId}/identities/verify-confirm`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requestId, code }),
+      });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        toastError((d as { message?: string }).message ?? `HTTP ${res.status}`);
+        return;
+      }
+      onLinked();
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+<div class="absolute top-full left-0 mt-1 z-10 bg-card border border-border rounded-md p-3 w-80 shadow-lg space-y-2">
+  <div class="flex gap-2 text-[10px] uppercase tracking-wider">
+    <button class="px-2 py-1 rounded {tab === 'manual' ? 'bg-accent text-white' : 'text-muted'}" onclick={() => (tab = 'manual')}>Manual</button>
+    <button class="px-2 py-1 rounded {tab === 'verify' ? 'bg-accent text-white' : 'text-muted'}" onclick={() => (tab = 'verify')}>Verify code</button>
+    <button class="ml-auto text-muted text-xs" onclick={onCancel}>✕</button>
+  </div>
+
+  <label class="grid grid-cols-[80px_1fr] gap-2 items-center text-xs">
+    <span class="text-muted">Channel</span>
+    <select class="bg-bg border border-border rounded px-2 py-1" bind:value={channel}>
+      {#each CHANNELS as c (c)}<option value={c}>{c}</option>{/each}
+    </select>
+  </label>
+  <label class="grid grid-cols-[80px_1fr] gap-2 items-center text-xs">
+    <span class="text-muted">User ID</span>
+    <input class="bg-bg border border-border rounded px-2 py-1" bind:value={channelUserId} placeholder="@handle or numeric id" />
+  </label>
+
+  {#if tab === 'manual'}
+    <label class="grid grid-cols-[80px_1fr] gap-2 items-center text-xs">
+      <span class="text-muted">Display</span>
+      <input class="bg-bg border border-border rounded px-2 py-1" bind:value={displayName} />
+    </label>
+    <button class="w-full text-xs px-3 py-1.5 rounded bg-accent text-white disabled:opacity-50" disabled={busy || !channelUserId} onclick={attachManual}>Attach</button>
+  {:else}
+    {#if !requestId}
+      <button class="w-full text-xs px-3 py-1.5 rounded bg-accent text-white disabled:opacity-50" disabled={busy || !channelUserId} onclick={sendCode}>Send code</button>
+    {:else}
+      <label class="grid grid-cols-[80px_1fr] gap-2 items-center text-xs">
+        <span class="text-muted">Code</span>
+        <input class="bg-bg border border-border rounded px-2 py-1 tracking-widest" bind:value={code} placeholder="000000" />
+      </label>
+      <button class="w-full text-xs px-3 py-1.5 rounded bg-accent text-white disabled:opacity-50" disabled={busy || code.length !== 6} onclick={confirmCode}>Confirm</button>
+    {/if}
+  {/if}
+</div>

--- a/src/lib/components/users/IdentityList.svelte
+++ b/src/lib/components/users/IdentityList.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import IdentityLinkPopover from './IdentityLinkPopover.svelte';
+  import { toastError, toastSuccess } from '$lib/state/ui/toast.svelte';
+
+  type Identity = {
+    id: string;
+    channel: string;
+    channelUserId: string;
+    displayName: string | null;
+    verifiedAt: number | null;
+  };
+
+  let { userId }: { userId: string } = $props();
+
+  let identities = $state<Identity[]>([]);
+  let loading = $state(false);
+  let showPopover = $state(false);
+
+  const ICON: Record<string, string> = {
+    whatsapp: '📱',
+    telegram: '✈️',
+    discord: '🎮',
+    email: '✉️',
+  };
+
+  async function load() {
+    loading = true;
+    try {
+      const res = await fetch(`/api/users/${userId}/identities`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as { identities: Identity[] };
+      identities = data.identities;
+    } catch (e) {
+      toastError((e as Error).message);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function unlink(id: string) {
+    if (!confirm('Unlink this identity?')) return;
+    const res = await fetch(`/api/users/${userId}/identities/${id}`, { method: 'DELETE' });
+    if (res.ok) {
+      identities = identities.filter((i) => i.id !== id);
+      toastSuccess('Identity removed');
+    } else {
+      toastError('Remove failed');
+    }
+  }
+
+  function onLinked() {
+    showPopover = false;
+    load();
+  }
+
+  onMount(load);
+</script>
+
+<div class="bg-bg2 border border-border rounded-md p-3 space-y-2">
+  <div class="text-[10px] uppercase tracking-wider text-muted font-semibold">Linked Identities</div>
+  {#if loading}
+    <div class="text-muted text-xs">Loading…</div>
+  {:else if identities.length === 0}
+    <div class="text-muted text-xs">No linked identities.</div>
+  {:else}
+    <div class="space-y-1">
+      {#each identities as id (id.id)}
+        <div class="flex items-center gap-2 text-xs">
+          <span>{ICON[id.channel] ?? '🔗'}</span>
+          <span class="text-muted w-20">{id.channel}</span>
+          <span class="text-foreground flex-1">{id.displayName ?? id.channelUserId}</span>
+          {#if id.verifiedAt}
+            <span class="text-green-400" title="verified">✓</span>
+          {:else}
+            <span class="text-yellow-400" title="pending">⏳</span>
+          {/if}
+          <button class="text-muted hover:text-destructive bg-transparent border-none cursor-pointer" onclick={() => unlink(id.id)}>✕</button>
+        </div>
+      {/each}
+    </div>
+  {/if}
+  <div class="relative">
+    <button class="text-xs px-2 py-1 rounded bg-transparent border border-border text-foreground hover:bg-muted/30" onclick={() => (showPopover = !showPopover)}>
+      + Link identity
+    </button>
+    {#if showPopover}
+      <IdentityLinkPopover {userId} onCancel={() => (showPopover = false)} onLinked={onLinked} />
+    {/if}
+  </div>
+</div>

--- a/src/lib/components/users/PermissionGrid.svelte
+++ b/src/lib/components/users/PermissionGrid.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  let {
+    catalog,
+    selected,
+    readonly = false,
+    onChange,
+  }: {
+    catalog: Record<string, string[]>;
+    selected: Set<string>;
+    readonly?: boolean;
+    onChange?: (perms: string[]) => void;
+  } = $props();
+
+  function toggle(perm: string) {
+    if (readonly) return;
+    const next = new Set(selected);
+    if (next.has(perm)) next.delete(perm); else next.add(perm);
+    onChange?.([...next]);
+  }
+</script>
+
+<div class="space-y-1 text-xs">
+  {#each Object.entries(catalog) as [resource, actions] (resource)}
+    <div class="grid grid-cols-[100px_1fr] gap-2 items-center">
+      <span class="text-muted">{resource}</span>
+      <div class="flex flex-wrap gap-2">
+        {#each actions as action (action)}
+          {@const perm = `${resource}:${action}`}
+          <label class="flex items-center gap-1 cursor-pointer">
+            <input type="checkbox" disabled={readonly} checked={selected.has(perm)} onchange={() => toggle(perm)} />
+            <span>{action}</span>
+          </label>
+        {/each}
+      </div>
+    </div>
+  {/each}
+</div>

--- a/src/lib/components/users/RolesSection.svelte
+++ b/src/lib/components/users/RolesSection.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import PermissionGrid from './PermissionGrid.svelte';
+  import { toastError, toastSuccess } from '$lib/state/ui/toast.svelte';
+
+  type Role = {
+    id: string;
+    name: string;
+    description: string | null;
+    isSystem: boolean;
+    permissions: string[];
+    memberCount: number;
+  };
+
+  let roles = $state<Role[]>([]);
+  let catalog = $state<Record<string, string[]>>({});
+  let expandedId = $state<string | null>(null);
+  let creating = $state(false);
+  let draftName = $state('');
+  let draftDesc = $state('');
+  let draftPerms = $state<string[]>([]);
+
+  async function load() {
+    const [rRes, cRes] = await Promise.all([
+      fetch('/api/roles'),
+      fetch('/api/roles/permissions-catalog'),
+    ]);
+    if (rRes.ok) roles = ((await rRes.json()) as { roles: Role[] }).roles;
+    if (cRes.ok) catalog = ((await cRes.json()) as { catalog: Record<string, string[]> }).catalog;
+  }
+
+  async function saveRole(role: Role, perms: string[]) {
+    const res = await fetch(`/api/roles/${role.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ permissions: perms }),
+    });
+    if (res.ok) {
+      roles = roles.map((r) => (r.id === role.id ? { ...r, permissions: perms } : r));
+      toastSuccess('Role updated');
+    } else {
+      toastError('Save failed');
+    }
+  }
+
+  async function createDraft() {
+    if (!draftName) return;
+    const res = await fetch('/api/roles', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: draftName, description: draftDesc, permissions: draftPerms }),
+    });
+    if (res.ok) {
+      draftName = '';
+      draftDesc = '';
+      draftPerms = [];
+      creating = false;
+      await load();
+    } else {
+      const d = await res.json().catch(() => ({}));
+      toastError((d as { message?: string }).message ?? 'create failed');
+    }
+  }
+
+  async function removeRole(role: Role) {
+    if (role.isSystem) return;
+    if (!confirm(`Delete role "${role.name}"?`)) return;
+    const res = await fetch(`/api/roles/${role.id}`, { method: 'DELETE' });
+    if (res.ok) roles = roles.filter((r) => r.id !== role.id);
+    else toastError('Delete failed');
+  }
+
+  onMount(load);
+</script>
+
+<section class="max-w-3xl mx-auto mt-8">
+  <div class="flex items-center justify-between mb-3">
+    <h2 class="text-sm font-semibold text-foreground uppercase tracking-wider">Roles</h2>
+    <button
+      class="text-xs px-3 py-1.5 rounded-md bg-accent text-white font-semibold"
+      onclick={() => (creating = !creating)}
+    >
+      {creating ? 'Cancel' : '+ New Role'}
+    </button>
+  </div>
+
+  {#if creating}
+    <div class="bg-card border border-border rounded-lg p-4 mb-3 space-y-2">
+      <input class="bg-bg2 border border-border rounded px-2 py-1.5 text-xs w-full" placeholder="Role name" bind:value={draftName} />
+      <input class="bg-bg2 border border-border rounded px-2 py-1.5 text-xs w-full" placeholder="Description" bind:value={draftDesc} />
+      <PermissionGrid {catalog} selected={new Set(draftPerms)} onChange={(p) => (draftPerms = p)} />
+      <button class="text-xs px-3 py-1.5 rounded bg-accent text-white" onclick={createDraft}>Create</button>
+    </div>
+  {/if}
+
+  <div class="bg-card border border-border rounded-lg overflow-hidden">
+    {#each roles as r (r.id)}
+      <div class="border-b border-border/50 last:border-0">
+        <div class="px-4 py-3 cursor-pointer hover:bg-muted/30" onclick={() => (expandedId = expandedId === r.id ? null : r.id)}>
+          <div class="flex items-center gap-2">
+            <span class="font-semibold text-foreground">{r.name}</span>
+            {#if r.isSystem}
+              <span class="text-[10px] px-1.5 py-0.5 rounded bg-muted/30 text-muted">Built-in</span>
+            {/if}
+            <span class="text-muted text-[10px] ml-auto">{r.memberCount} members</span>
+            {#if !r.isSystem}
+              <button class="text-muted hover:text-destructive bg-transparent border-none cursor-pointer" onclick={(e) => { e.stopPropagation(); removeRole(r); }}>✕</button>
+            {/if}
+          </div>
+          {#if r.description}
+            <div class="text-muted text-[11px] mt-1">{r.description}</div>
+          {/if}
+        </div>
+        {#if expandedId === r.id}
+          <div class="px-4 py-3 bg-bg2/30">
+            <PermissionGrid
+              {catalog}
+              selected={new Set(r.permissions)}
+              readonly={r.isSystem}
+              onChange={(p) => saveRole(r, p)}
+            />
+          </div>
+        {/if}
+      </div>
+    {/each}
+  </div>
+</section>

--- a/src/lib/components/users/TeamTab.svelte
+++ b/src/lib/components/users/TeamTab.svelte
@@ -27,6 +27,9 @@
   const ROLES: UserRow['role'][] = ['user', 'admin'];
   const INVITE_ROLES = ['member', 'admin'];
 
+  type CustomRole = { id: string; name: string; isSystem: boolean };
+  let customRoles = $state<CustomRole[]>([]);
+
   let users = $state<UserRow[]>([]);
   let invitations = $state<PendingInvite[]>([]);
   let loading = $state(false);
@@ -94,6 +97,20 @@
     } catch {
       // non-fatal — invitations just won't show
     }
+  }
+
+  async function loadCustomRoles() {
+    const res = await fetch('/api/roles');
+    if (res.ok) customRoles = ((await res.json()) as { roles: CustomRole[] }).roles;
+  }
+
+  async function changeRoleId(userId: string, roleId: string | null) {
+    const res = await fetch(`/api/users/${userId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ roleId }),
+    });
+    if (res.ok) users = users.map((u) => (u.id === userId ? { ...u, roleId } : u));
   }
 
   async function changeRole(userId: string, role: UserRow['role']) {
@@ -166,6 +183,7 @@
   onMount(() => {
     load();
     loadInvitations();
+    loadCustomRoles();
   });
 </script>
 
@@ -256,12 +274,27 @@
                 <td class="px-4 py-3" onclick={(e) => e.stopPropagation()}>
                   <select
                     class="bg-transparent border border-border rounded-md text-foreground px-2 py-1 text-[11px] font-[inherit] outline-none cursor-pointer focus:border-accent"
-                    value={u.role}
-                    onchange={(e) => changeRole(u.id, (e.currentTarget as HTMLSelectElement).value as UserRow['role'])}
+                    value={u.roleId ?? `legacy:${u.role}`}
+                    onchange={(e) => {
+                      const v = (e.currentTarget as HTMLSelectElement).value;
+                      if (v.startsWith('legacy:')) {
+                        changeRole(u.id, v.slice(7) as UserRow['role']);
+                      } else {
+                        changeRoleId(u.id, v);
+                      }
+                    }}
                   >
-                    {#each ROLES as r (r)}
-                      <option value={r}>{r}</option>
-                    {/each}
+                    <optgroup label="Built-in">
+                      <option value="legacy:user">user</option>
+                      <option value="legacy:admin">admin</option>
+                    </optgroup>
+                    {#if customRoles.filter((r) => !r.isSystem).length > 0}
+                      <optgroup label="Custom">
+                        {#each customRoles.filter((r) => !r.isSystem) as r (r.id)}
+                          <option value={r.id}>{r.name}</option>
+                        {/each}
+                      </optgroup>
+                    {/if}
                   </select>
                 </td>
                 <td class="px-4 py-3 text-right" onclick={(e) => e.stopPropagation()}>
@@ -279,6 +312,7 @@
                   <td colspan="3" class="px-4 py-4">
                     <UserEditor
                       user={u}
+                      customRoles={customRoles}
                       onSave={(patch) => saveProfile(u.id, patch)}
                       onCancel={() => (expandedId = null)}
                     />

--- a/src/lib/components/users/TeamTab.svelte
+++ b/src/lib/components/users/TeamTab.svelte
@@ -3,12 +3,15 @@
   import * as m from '$lib/paraglide/messages';
   import { authClient } from '$lib/auth';
   import { toastSuccess, toastError } from '$lib/state/ui/toast.svelte';
+  import UserEditor from './UserEditor.svelte';
 
   type UserRow = {
     id: string;
     email: string;
     displayName: string | null;
     role: 'user' | 'admin';
+    alias: string | null;
+    roleId: string | null;
     createdAt: string | null;
   };
 
@@ -27,6 +30,27 @@
   let invitations = $state<PendingInvite[]>([]);
   let loading = $state(false);
   let error = $state<string | null>(null);
+  let expandedId = $state<string | null>(null);
+
+  function toggleExpand(id: string) {
+    expandedId = expandedId === id ? null : id;
+  }
+
+  async function saveProfile(userId: string, patch: Partial<UserRow>) {
+    const res = await fetch(`/api/users/${userId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(patch),
+    });
+    if (!res.ok) {
+      const d = await res.json().catch(() => ({}));
+      toastError((d as { message?: string }).message ?? 'save failed');
+      return;
+    }
+    users = users.map((u) => (u.id === userId ? { ...u, ...patch } : u));
+    toastSuccess(m.users_team());
+    expandedId = null;
+  }
 
   // Invite form state
   let showInvite = $state(false);
@@ -213,14 +237,20 @@
           </thead>
           <tbody>
             {#each users as u (u.id)}
-              <tr class="border-b border-border/50 last:border-0 hover:bg-bg2/50 transition-colors">
+              <tr
+                class="border-b border-border/50 last:border-0 hover:bg-muted/30 transition-colors cursor-pointer"
+                onclick={() => toggleExpand(u.id)}
+              >
                 <td class="px-4 py-3">
                   <div class="font-semibold text-foreground">{u.displayName ?? u.email}</div>
                   {#if u.displayName}
                     <div class="text-muted text-[10px] mt-0.5">{u.email}</div>
                   {/if}
+                  {#if u.alias}
+                    <div class="text-accent text-[10px] mt-0.5">@{u.alias}</div>
+                  {/if}
                 </td>
-                <td class="px-4 py-3">
+                <td class="px-4 py-3" onclick={(e) => e.stopPropagation()}>
                   <select
                     class="bg-transparent border border-border rounded-md text-foreground px-2 py-1 text-[11px] font-[inherit] outline-none cursor-pointer focus:border-accent"
                     value={u.role}
@@ -231,7 +261,7 @@
                     {/each}
                   </select>
                 </td>
-                <td class="px-4 py-3 text-right">
+                <td class="px-4 py-3 text-right" onclick={(e) => e.stopPropagation()}>
                   <button
                     class="text-muted hover:text-destructive transition-colors bg-transparent border-none cursor-pointer text-xs font-[inherit]"
                     onclick={() => remove(u.id)}
@@ -241,6 +271,17 @@
                   </button>
                 </td>
               </tr>
+              {#if expandedId === u.id}
+                <tr class="border-b border-border/50 bg-bg2/30">
+                  <td colspan="3" class="px-4 py-4">
+                    <UserEditor
+                      user={u}
+                      onSave={(patch) => saveProfile(u.id, patch)}
+                      onCancel={() => (expandedId = null)}
+                    />
+                  </td>
+                </tr>
+              {/if}
             {/each}
           </tbody>
         </table>

--- a/src/lib/components/users/TeamTab.svelte
+++ b/src/lib/components/users/TeamTab.svelte
@@ -4,6 +4,7 @@
   import { authClient } from '$lib/auth';
   import { toastSuccess, toastError } from '$lib/state/ui/toast.svelte';
   import { ensureAliases, invalidateAliases } from '$lib/state/features/aliases.svelte';
+  import { can } from '$lib/state/features/permissions.svelte';
   import UserEditor from './UserEditor.svelte';
 
   type UserRow = {
@@ -194,12 +195,14 @@
       <h2 class="text-sm font-semibold text-foreground uppercase tracking-wider">
         {m.users_team()}
       </h2>
-      <button
-        class="text-xs px-3 py-1.5 rounded-md bg-accent text-white border-none cursor-pointer font-[inherit] font-semibold hover:opacity-90 transition-opacity"
-        onclick={() => (showInvite = !showInvite)}
-      >
-        {showInvite ? m.users_inviteCancelBtn() : m.users_inviteOpen()}
-      </button>
+      {#if can('users:invite')}
+        <button
+          class="text-xs px-3 py-1.5 rounded-md bg-accent text-white border-none cursor-pointer font-[inherit] font-semibold hover:opacity-90 transition-opacity"
+          onclick={() => (showInvite = !showInvite)}
+        >
+          {showInvite ? m.users_inviteCancelBtn() : m.users_inviteOpen()}
+        </button>
+      {/if}
     </div>
 
     <!-- Invite form -->

--- a/src/lib/components/users/TeamTab.svelte
+++ b/src/lib/components/users/TeamTab.svelte
@@ -3,6 +3,7 @@
   import * as m from '$lib/paraglide/messages';
   import { authClient } from '$lib/auth';
   import { toastSuccess, toastError } from '$lib/state/ui/toast.svelte';
+  import { ensureAliases, invalidateAliases } from '$lib/state/features/aliases.svelte';
   import UserEditor from './UserEditor.svelte';
 
   type UserRow = {
@@ -48,6 +49,8 @@
       return;
     }
     users = users.map((u) => (u.id === userId ? { ...u, ...patch } : u));
+    invalidateAliases();
+    void ensureAliases();
     toastSuccess(m.users_team());
     expandedId = null;
   }

--- a/src/lib/components/users/UserEditor.svelte
+++ b/src/lib/components/users/UserEditor.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+  import { validateAlias, normalizeAlias } from '$lib/utils/alias';
+
+  type UserRow = {
+    id: string;
+    email: string;
+    displayName: string | null;
+    role: 'user' | 'admin';
+    alias: string | null;
+    roleId: string | null;
+  };
+
+  type AvailabilityState = 'idle' | 'checking' | 'available' | 'taken' | 'invalid';
+
+  let {
+    user,
+    onSave,
+    onCancel,
+  }: {
+    user: UserRow;
+    onSave: (patch: Partial<UserRow>) => Promise<void>;
+    onCancel: () => void;
+  } = $props();
+
+  let displayName = $state(user.displayName ?? '');
+  let email = $state(user.email);
+  let alias = $state(user.alias ?? '');
+  let role = $state<'user' | 'admin'>(user.role);
+  let saving = $state(false);
+  let availability = $state<AvailabilityState>('idle');
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const dirty = $derived(
+    displayName !== (user.displayName ?? '') ||
+      email !== user.email ||
+      alias !== (user.alias ?? '') ||
+      role !== user.role,
+  );
+
+  const aliasValid = $derived(
+    alias === '' ||
+      (validateAlias(normalizeAlias(alias) ?? '').ok && availability !== 'taken'),
+  );
+
+  $effect(() => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    const normalized = normalizeAlias(alias);
+    if (!normalized || normalized === user.alias) {
+      availability = 'idle';
+      return;
+    }
+    if (!validateAlias(normalized).ok) {
+      availability = 'invalid';
+      return;
+    }
+    availability = 'checking';
+    debounceTimer = setTimeout(async () => {
+      const res = await fetch(`/api/users/aliases?check=${encodeURIComponent(normalized)}`);
+      const data = (await res.json()) as { available: boolean; reason?: string };
+      availability = data.available ? 'available' : ((data.reason as AvailabilityState) ?? 'taken');
+    }, 300);
+  });
+
+  async function handleSave() {
+    if (!dirty || !aliasValid) return;
+    saving = true;
+    try {
+      await onSave({
+        displayName: displayName.trim(),
+        email: email.trim(),
+        alias: normalizeAlias(alias),
+        role,
+      });
+    } finally {
+      saving = false;
+    }
+  }
+</script>
+
+<div class="space-y-3">
+  <div class="bg-bg2 border border-border rounded-md p-3 space-y-2">
+    <div class="text-[10px] uppercase tracking-wider text-muted font-semibold">Identity</div>
+    <label class="grid grid-cols-[80px_1fr] gap-2 items-center text-xs">
+      <span class="text-muted">Name</span>
+      <input class="bg-bg border border-border rounded px-2 py-1 outline-none focus:border-accent" bind:value={displayName} />
+    </label>
+    <label class="grid grid-cols-[80px_1fr] gap-2 items-center text-xs">
+      <span class="text-muted">Email</span>
+      <input type="email" class="bg-bg border border-border rounded px-2 py-1 outline-none focus:border-accent" bind:value={email} />
+    </label>
+    <label class="grid grid-cols-[80px_1fr_auto] gap-2 items-center text-xs">
+      <span class="text-muted">Alias</span>
+      <div class="flex items-center gap-1 bg-bg border border-border rounded px-2 py-1 focus-within:border-accent">
+        <span class="text-muted">@</span>
+        <input class="flex-1 bg-transparent outline-none" bind:value={alias} placeholder="nikolas" />
+      </div>
+      <span class="text-[10px] w-20 text-right">
+        {#if availability === 'checking'}<span class="text-muted">checking…</span>
+        {:else if availability === 'available'}<span class="text-green-400">✓ available</span>
+        {:else if availability === 'taken'}<span class="text-destructive">✗ taken</span>
+        {:else if availability === 'invalid'}<span class="text-destructive">⚠ invalid</span>
+        {/if}
+      </span>
+    </label>
+    <label class="grid grid-cols-[80px_1fr] gap-2 items-center text-xs">
+      <span class="text-muted">Role</span>
+      <select class="bg-bg border border-border rounded px-2 py-1 outline-none focus:border-accent" bind:value={role}>
+        <option value="user">user</option>
+        <option value="admin">admin</option>
+      </select>
+    </label>
+  </div>
+
+  <div class="flex justify-end gap-2">
+    <button type="button" class="text-xs px-3 py-1.5 rounded-md bg-transparent border border-border text-foreground hover:bg-muted/30" onclick={onCancel}>Cancel</button>
+    <button type="button"
+      class="text-xs px-3 py-1.5 rounded-md bg-accent text-white border-none font-semibold disabled:opacity-50"
+      disabled={!dirty || !aliasValid || saving}
+      onclick={handleSave}>
+      {saving ? 'Saving…' : 'Save'}
+    </button>
+  </div>
+</div>

--- a/src/lib/components/users/UserEditor.svelte
+++ b/src/lib/components/users/UserEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { validateAlias, normalizeAlias } from '$lib/utils/alias';
+  import IdentityList from './IdentityList.svelte';
 
   type UserRow = {
     id: string;
@@ -110,6 +111,8 @@
       </select>
     </label>
   </div>
+
+  <IdentityList userId={user.id} />
 
   <div class="flex justify-end gap-2">
     <button type="button" class="text-xs px-3 py-1.5 rounded-md bg-transparent border border-border text-foreground hover:bg-muted/30" onclick={onCancel}>Cancel</button>

--- a/src/lib/components/users/UserEditor.svelte
+++ b/src/lib/components/users/UserEditor.svelte
@@ -17,16 +17,19 @@
     user,
     onSave,
     onCancel,
+    customRoles = [],
   }: {
     user: UserRow;
     onSave: (patch: Partial<UserRow>) => Promise<void>;
     onCancel: () => void;
+    customRoles?: { id: string; name: string; isSystem: boolean }[];
   } = $props();
 
   let displayName = $state(user.displayName ?? '');
   let email = $state(user.email);
   let alias = $state(user.alias ?? '');
   let role = $state<'user' | 'admin'>(user.role);
+  let roleId = $state<string | null>(user.roleId);
   let saving = $state(false);
   let availability = $state<AvailabilityState>('idle');
   let debounceTimer: ReturnType<typeof setTimeout> | undefined;
@@ -35,7 +38,8 @@
     displayName !== (user.displayName ?? '') ||
       email !== user.email ||
       alias !== (user.alias ?? '') ||
-      role !== user.role,
+      role !== user.role ||
+      roleId !== user.roleId,
   );
 
   const aliasValid = $derived(
@@ -71,6 +75,7 @@
         email: email.trim(),
         alias: normalizeAlias(alias),
         role,
+        roleId,
       });
     } finally {
       saving = false;
@@ -105,9 +110,30 @@
     </label>
     <label class="grid grid-cols-[80px_1fr] gap-2 items-center text-xs">
       <span class="text-muted">Role</span>
-      <select class="bg-bg border border-border rounded px-2 py-1 outline-none focus:border-accent" bind:value={role}>
-        <option value="user">user</option>
-        <option value="admin">admin</option>
+      <select
+        class="bg-bg border border-border rounded px-2 py-1 outline-none focus:border-accent"
+        value={roleId ?? `legacy:${role}`}
+        onchange={(e) => {
+          const v = (e.currentTarget as HTMLSelectElement).value;
+          if (v.startsWith('legacy:')) {
+            role = v.slice(7) as 'user' | 'admin';
+            roleId = null;
+          } else {
+            roleId = v;
+          }
+        }}
+      >
+        <optgroup label="Built-in">
+          <option value="legacy:user">user</option>
+          <option value="legacy:admin">admin</option>
+        </optgroup>
+        {#if customRoles.filter((r) => !r.isSystem).length > 0}
+          <optgroup label="Custom">
+            {#each customRoles.filter((r) => !r.isSystem) as r (r.id)}
+              <option value={r.id}>{r.name}</option>
+            {/each}
+          </optgroup>
+        {/if}
       </select>
     </label>
   </div>

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,0 +1,27 @@
+export const PERMISSIONS = [
+  'agents:view', 'agents:edit', 'agents:delete',
+  'sessions:view', 'sessions:terminate',
+  'channels:view', 'channels:configure',
+  'skills:view', 'skills:install',
+  'settings:view', 'settings:manage',
+  'users:view', 'users:invite', 'users:edit', 'users:remove',
+  'roles:view', 'roles:manage',
+  'billing:view', 'billing:manage',
+  'hosts:view', 'hosts:manage',
+  'workshop:view', 'workshop:edit',
+] as const;
+
+export type Permission = (typeof PERMISSIONS)[number];
+
+export function groupPermissions(): Record<string, string[]> {
+  const groups: Record<string, string[]> = {};
+  for (const p of PERMISSIONS) {
+    const [resource, action] = p.split(':');
+    (groups[resource] ??= []).push(action);
+  }
+  return groups;
+}
+
+export function hasPermission(granted: ReadonlySet<string>, perm: Permission): boolean {
+  return granted.has(perm);
+}

--- a/src/lib/state/features/aliases.svelte.ts
+++ b/src/lib/state/features/aliases.svelte.ts
@@ -1,0 +1,34 @@
+const TTL_MS = 5 * 60 * 1000;
+
+let aliases = $state(new Map<string, string>());
+let fetchedAt = $state<number | null>(null);
+let inflight: Promise<Map<string, string>> | null = null;
+
+export function getAliases() {
+  return aliases;
+}
+
+export async function ensureAliases(): Promise<Map<string, string>> {
+  if (fetchedAt && Date.now() - fetchedAt < TTL_MS) return aliases;
+  if (inflight) return inflight;
+  inflight = (async () => {
+    try {
+      const res = await fetch('/api/users/aliases');
+      if (!res.ok) return aliases;
+      const data = (await res.json()) as { aliases: Record<string, string> };
+      // server returns { userId: alias }; renderer needs { alias: userId } — invert.
+      const inverted = new Map<string, string>();
+      for (const [userId, alias] of Object.entries(data.aliases)) inverted.set(alias, userId);
+      aliases = inverted;
+      fetchedAt = Date.now();
+      return aliases;
+    } finally {
+      inflight = null;
+    }
+  })();
+  return inflight;
+}
+
+export function invalidateAliases() {
+  fetchedAt = null;
+}

--- a/src/lib/state/features/permissions.svelte.ts
+++ b/src/lib/state/features/permissions.svelte.ts
@@ -1,0 +1,21 @@
+import type { Permission } from '$lib/permissions';
+
+let perms = $state(new Set<string>());
+let loaded = $state(false);
+
+export async function ensurePermissions() {
+  if (loaded) return;
+  const res = await fetch('/api/users/me/permissions');
+  if (!res.ok) return;
+  const data = (await res.json()) as { permissions: string[] };
+  perms = new Set(data.permissions);
+  loaded = true;
+}
+
+export function can(perm: Permission): boolean {
+  return perms.has(perm);
+}
+
+export function getPermissions(): Set<string> {
+  return perms;
+}

--- a/src/lib/utils/alias.test.ts
+++ b/src/lib/utils/alias.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { validateAlias, normalizeAlias } from './alias';
+
+describe('validateAlias', () => {
+  it('accepts lowercase alphanumeric + underscore, 2-32 chars', () => {
+    expect(validateAlias('nikolas')).toEqual({ ok: true });
+    expect(validateAlias('a_b_c_2')).toEqual({ ok: true });
+    expect(validateAlias('ab')).toEqual({ ok: true });
+    expect(validateAlias('a'.repeat(32))).toEqual({ ok: true });
+  });
+
+  it('rejects too short, too long, bad chars, empty', () => {
+    expect(validateAlias('a')).toEqual({ ok: false, reason: 'invalid' });
+    expect(validateAlias('a'.repeat(33))).toEqual({ ok: false, reason: 'invalid' });
+    expect(validateAlias('Nikolas')).toEqual({ ok: false, reason: 'invalid' });
+    expect(validateAlias('niko las')).toEqual({ ok: false, reason: 'invalid' });
+    expect(validateAlias('niko-las')).toEqual({ ok: false, reason: 'invalid' });
+    expect(validateAlias('')).toEqual({ ok: false, reason: 'invalid' });
+  });
+});
+
+describe('normalizeAlias', () => {
+  it('lowercases and trims', () => {
+    expect(normalizeAlias('  Nikolas  ')).toBe('nikolas');
+  });
+  it('returns null for empty', () => {
+    expect(normalizeAlias('')).toBeNull();
+    expect(normalizeAlias('   ')).toBeNull();
+  });
+});

--- a/src/lib/utils/alias.ts
+++ b/src/lib/utils/alias.ts
@@ -1,0 +1,12 @@
+export type AliasCheck = { ok: true } | { ok: false; reason: 'invalid' | 'taken' };
+
+const ALIAS_RE = /^[a-z0-9_]{2,32}$/;
+
+export function validateAlias(input: string): AliasCheck {
+  return ALIAS_RE.test(input) ? { ok: true } : { ok: false, reason: 'invalid' };
+}
+
+export function normalizeAlias(input: string): string | null {
+  const trimmed = input.trim().toLowerCase();
+  return trimmed.length === 0 ? null : trimmed;
+}

--- a/src/lib/utils/mention.test.ts
+++ b/src/lib/utils/mention.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { renderMention } from './mention';
+
+describe('renderMention', () => {
+  const aliases = new Map<string, string>([
+    ['nikolas', 'u1'],
+    ['alice', 'u2'],
+  ]);
+
+  it('wraps known aliases in mention spans', () => {
+    expect(renderMention('hey @nikolas check this', aliases)).toBe(
+      'hey <span class="mention" data-user-id="u1">@nikolas</span> check this',
+    );
+  });
+
+  it('leaves unknown @tokens as plain text', () => {
+    expect(renderMention('@unknown', aliases)).toBe('@unknown');
+  });
+
+  it('escapes HTML before wrapping', () => {
+    expect(renderMention('<script>@nikolas</script>', aliases)).toBe(
+      '&lt;script&gt;<span class="mention" data-user-id="u1">@nikolas</span>&lt;/script&gt;',
+    );
+  });
+
+  it('handles multiple mentions and adjacent punctuation', () => {
+    expect(renderMention('cc @alice, @nikolas!', aliases)).toBe(
+      'cc <span class="mention" data-user-id="u2">@alice</span>, <span class="mention" data-user-id="u1">@nikolas</span>!',
+    );
+  });
+});

--- a/src/lib/utils/mention.ts
+++ b/src/lib/utils/mention.ts
@@ -1,0 +1,19 @@
+const MENTION_RE = /@([a-z0-9_]{2,32})/g;
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function renderMention(text: string, aliases: Map<string, string>): string {
+  const escaped = escapeHtml(text);
+  return escaped.replace(MENTION_RE, (match, alias: string) => {
+    const userId = aliases.get(alias);
+    if (!userId) return match;
+    return `<span class="mention" data-user-id="${escapeHtml(userId)}">@${alias}</span>`;
+  });
+}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -4,8 +4,14 @@
 	import LiveRunWidget from '$lib/components/sessions/LiveRunWidget.svelte';
 	import FloatingAssistant from '$lib/components/layout/FloatingAssistant.svelte';
 	import { type Snippet } from 'svelte';
+	import { onMount } from 'svelte';
+	import { ensurePermissions } from '$lib/state/features/permissions.svelte';
 
 	let { children }: { children: Snippet } = $props();
+
+	onMount(() => {
+		void ensurePermissions();
+	});
 </script>
 
 <div class="relative z-10 flex flex-col h-screen overflow-hidden text-foreground">

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -27,6 +27,7 @@ import MinionLogo from "$lib/components/layout/MinionLogo.svelte";
     import NavigationGuardModal from "$lib/components/config/NavigationGuardModal.svelte";
     import SettingsScrollspy from "$lib/components/settings/SettingsScrollspy.svelte";
     import TeamTab from "$lib/components/users/TeamTab.svelte";
+    import RolesSection from "$lib/components/users/RolesSection.svelte";
     import BindingsTab from "$lib/components/users/BindingsTab.svelte";
     import ChannelsTab from "$lib/components/channels/ChannelsTab.svelte";
     import HostsTab from "$lib/components/settings/HostsTab.svelte";
@@ -486,6 +487,7 @@ import MinionLogo from "$lib/components/layout/MinionLogo.svelte";
                                 {#if tab.id === 'security'}
                                     <div class="mt-6">
                                         <TeamTab />
+                                        <RolesSection />
                                     </div>
                                 {/if}
                                 {#if tab.id === 'agents'}

--- a/src/routes/api/roles/+server.ts
+++ b/src/routes/api/roles/+server.ts
@@ -1,0 +1,30 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { json, error } from '@sveltejs/kit';
+import { listRoles, createRole } from '$server/services/roles.service';
+import { requireAdmin } from '$server/auth/authorize';
+import { PERMISSIONS } from '$lib/permissions';
+
+export const GET: RequestHandler = async ({ locals }) => {
+  if (!locals.tenantCtx) throw error(401);
+  return json({ roles: await listRoles(locals.tenantCtx) });
+};
+
+export const POST: RequestHandler = async ({ locals, request }) => {
+  requireAdmin(locals);
+  if (!locals.tenantCtx) throw error(401);
+  const b = (await request.json()) as { name?: string; description?: string; permissions?: string[] };
+  if (!b.name || !Array.isArray(b.permissions)) throw error(400);
+  const invalid = b.permissions.filter((p) => !(PERMISSIONS as readonly string[]).includes(p));
+  if (invalid.length) throw error(400, `invalid permissions: ${invalid.join(',')}`);
+  try {
+    const id = await createRole(locals.tenantCtx, {
+      name: b.name,
+      description: b.description,
+      permissions: b.permissions,
+    });
+    return json({ ok: true, id });
+  } catch (e) {
+    if (/UNIQUE/i.test(String(e))) throw error(409, 'role name taken');
+    throw error(500, String(e));
+  }
+};

--- a/src/routes/api/roles/[id]/+server.ts
+++ b/src/routes/api/roles/[id]/+server.ts
@@ -1,0 +1,48 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { json, error } from '@sveltejs/kit';
+import {
+  deleteRole,
+  updateRoleMeta,
+  updateRolePermissions,
+} from '$server/services/roles.service';
+import { requireAdmin } from '$server/auth/authorize';
+import { PERMISSIONS } from '$lib/permissions';
+
+export const PATCH: RequestHandler = async ({ locals, params, request }) => {
+  requireAdmin(locals);
+  if (!locals.tenantCtx || !params.id) throw error(400);
+  const b = (await request.json()) as {
+    name?: string;
+    description?: string | null;
+    permissions?: string[];
+  };
+  try {
+    if (b.name !== undefined || b.description !== undefined) {
+      await updateRoleMeta(locals.tenantCtx, params.id, {
+        name: b.name,
+        description: b.description,
+      });
+    }
+    if (Array.isArray(b.permissions)) {
+      const invalid = b.permissions.filter((p) => !(PERMISSIONS as readonly string[]).includes(p));
+      if (invalid.length) throw error(400, `invalid permissions: ${invalid.join(',')}`);
+      await updateRolePermissions(locals.tenantCtx, params.id, b.permissions);
+    }
+    return json({ ok: true });
+  } catch (e) {
+    if (/system role/i.test(String(e))) throw error(403, 'cannot edit system role');
+    throw error(500, String(e));
+  }
+};
+
+export const DELETE: RequestHandler = async ({ locals, params }) => {
+  requireAdmin(locals);
+  if (!locals.tenantCtx || !params.id) throw error(400);
+  try {
+    await deleteRole(locals.tenantCtx, params.id);
+    return json({ ok: true });
+  } catch (e) {
+    if (/system/i.test(String(e))) throw error(403);
+    throw error(500);
+  }
+};

--- a/src/routes/api/roles/permissions-catalog/+server.ts
+++ b/src/routes/api/roles/permissions-catalog/+server.ts
@@ -1,0 +1,5 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { json } from '@sveltejs/kit';
+import { groupPermissions } from '$lib/permissions';
+
+export const GET: RequestHandler = async () => json({ catalog: groupPermissions() });

--- a/src/routes/api/users/[id]/+server.ts
+++ b/src/routes/api/users/[id]/+server.ts
@@ -1,10 +1,17 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json, error } from '@sveltejs/kit';
-import { updateUserRole, deleteUser, getUser } from '$server/services/user.service';
+import {
+  deleteUser,
+  getUser,
+  isAliasTaken,
+  updateUserProfile,
+  updateUserRole,
+} from '$server/services/user.service';
 import { requireAdmin } from '$server/auth/authorize';
+import { normalizeAlias, validateAlias } from '$lib/utils/alias';
 
 const VALID_ROLES = ['user', 'admin'] as const;
-type Role = (typeof VALID_ROLES)[number];
+type LegacyRole = (typeof VALID_ROLES)[number];
 
 export const PATCH: RequestHandler = async ({ locals, params, request }) => {
   requireAdmin(locals);
@@ -24,11 +31,45 @@ export const PATCH: RequestHandler = async ({ locals, params, request }) => {
     throw error(400, 'invalid JSON body');
   }
   const b = body as Record<string, unknown>;
-  if (!b.role || !VALID_ROLES.includes(b.role as Role)) {
-    throw error(400, 'role must be one of: user, admin');
+
+  const patch: Parameters<typeof updateUserProfile>[2] = {};
+
+  if (typeof b.displayName === 'string') patch.displayName = b.displayName.trim();
+  if (typeof b.email === 'string') patch.email = b.email.trim();
+
+  if (b.alias !== undefined) {
+    if (b.alias === null || b.alias === '') {
+      patch.alias = null;
+    } else if (typeof b.alias !== 'string') {
+      throw error(400, 'alias must be string or null');
+    } else {
+      const normalized = normalizeAlias(b.alias);
+      if (!normalized) {
+        patch.alias = null;
+      } else {
+        const check = validateAlias(normalized);
+        if (!check.ok) throw error(400, 'alias format invalid');
+        if (await isAliasTaken(ctx, normalized, userId)) {
+          throw error(409, 'alias taken');
+        }
+        patch.alias = normalized;
+      }
+    }
   }
 
-  await updateUserRole(ctx, userId, b.role as Role);
+  if (b.roleId !== undefined) {
+    patch.roleId = b.roleId === null ? null : typeof b.roleId === 'string' ? b.roleId : null;
+  }
+
+  // Backward-compat: legacy 'role' enum still accepted via dedicated call.
+  if (typeof b.role === 'string' && VALID_ROLES.includes(b.role as LegacyRole)) {
+    await updateUserRole(ctx, userId, b.role as LegacyRole);
+  }
+
+  if (Object.keys(patch).length > 0) {
+    await updateUserProfile(ctx, userId, patch);
+  }
+
   return json({ ok: true });
 };
 

--- a/src/routes/api/users/[id]/identities/+server.ts
+++ b/src/routes/api/users/[id]/identities/+server.ts
@@ -1,0 +1,33 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { json, error } from '@sveltejs/kit';
+import { attachIdentity, listIdentities } from '$server/services/identity.service';
+import { requireAdmin } from '$server/auth/authorize';
+
+export const GET: RequestHandler = async ({ locals, params }) => {
+  if (!locals.tenantCtx) throw error(401);
+  if (!params.id) throw error(400, 'missing id');
+  const isOwner = locals.user?.id === params.id;
+  if (!isOwner) requireAdmin(locals);
+  const list = await listIdentities(locals.tenantCtx, params.id);
+  return json({ identities: list });
+};
+
+export const POST: RequestHandler = async ({ locals, params, request }) => {
+  requireAdmin(locals);
+  if (!locals.tenantCtx) throw error(401);
+  if (!params.id) throw error(400, 'missing id');
+  const b = (await request.json()) as { channel?: string; channelUserId?: string; displayName?: string };
+  if (!b.channel || !b.channelUserId) throw error(400, 'channel + channelUserId required');
+  try {
+    const id = await attachIdentity(locals.tenantCtx, params.id, {
+      channel: b.channel,
+      channelUserId: b.channelUserId,
+      displayName: b.displayName,
+      verified: true,
+    });
+    return json({ ok: true, id });
+  } catch (e) {
+    if (/UNIQUE|duplicate/i.test(String(e))) throw error(409, 'identity already linked');
+    throw error(500, String(e));
+  }
+};

--- a/src/routes/api/users/[id]/identities/[identityId]/+server.ts
+++ b/src/routes/api/users/[id]/identities/[identityId]/+server.ts
@@ -1,0 +1,13 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { json, error } from '@sveltejs/kit';
+import { removeIdentity } from '$server/services/identity.service';
+import { requireAdmin } from '$server/auth/authorize';
+
+export const DELETE: RequestHandler = async ({ locals, params }) => {
+  if (!locals.tenantCtx) throw error(401);
+  if (!params.id || !params.identityId) throw error(400);
+  const isOwner = locals.user?.id === params.id;
+  if (!isOwner) requireAdmin(locals);
+  await removeIdentity(locals.tenantCtx, params.identityId);
+  return json({ ok: true });
+};

--- a/src/routes/api/users/[id]/identities/verify-confirm/+server.ts
+++ b/src/routes/api/users/[id]/identities/verify-confirm/+server.ts
@@ -1,0 +1,27 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { json, error } from '@sveltejs/kit';
+import { consumeOtp } from '$server/identity/otp-store';
+import { attachIdentity } from '$server/services/identity.service';
+
+export const POST: RequestHandler = async ({ locals, params, request }) => {
+  if (!locals.tenantCtx) throw error(401);
+  if (!params.id) throw error(400);
+  const b = (await request.json()) as { requestId?: string; code?: string };
+  if (!b.requestId || !b.code) throw error(400);
+
+  const result = consumeOtp(b.requestId, b.code);
+  if (!result.ok) throw error(400, `code ${result.reason}`);
+  if (result.userId !== params.id) throw error(403, 'request user mismatch');
+
+  try {
+    const id = await attachIdentity(locals.tenantCtx, params.id, {
+      channel: result.channel,
+      channelUserId: result.channelUserId,
+      verified: true,
+    });
+    return json({ ok: true, id });
+  } catch (e) {
+    if (/UNIQUE|duplicate/i.test(String(e))) throw error(409, 'identity already linked');
+    throw error(500);
+  }
+};

--- a/src/routes/api/users/[id]/identities/verify-request/+server.ts
+++ b/src/routes/api/users/[id]/identities/verify-request/+server.ts
@@ -1,0 +1,35 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { json, error } from '@sveltejs/kit';
+import { randomUUID } from 'node:crypto';
+import { createOtp } from '$server/identity/otp-store';
+import { gatewayCall } from '$lib/server/gateway-rpc';
+import { requireAdmin } from '$server/auth/authorize';
+
+export const POST: RequestHandler = async ({ locals, params, request }) => {
+  if (!locals.tenantCtx) throw error(401);
+  if (!params.id) throw error(400);
+  const isOwner = locals.user?.id === params.id;
+  if (!isOwner) requireAdmin(locals);
+
+  const b = (await request.json()) as { channel?: string; channelUserId?: string };
+  if (!b.channel || !b.channelUserId) throw error(400, 'channel + channelUserId required');
+
+  const { requestId, code } = createOtp({
+    userId: params.id,
+    channel: b.channel,
+    channelUserId: b.channelUserId,
+  });
+
+  try {
+    await gatewayCall('send', {
+      to: b.channelUserId,
+      channel: b.channel,
+      message: `Minion identity verification code: ${code}\nValid for 10 minutes. Do not share.`,
+      idempotencyKey: randomUUID(),
+    });
+  } catch (e) {
+    throw error(502, `gateway send failed: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  return json({ requestId });
+};

--- a/src/routes/api/users/aliases/+server.ts
+++ b/src/routes/api/users/aliases/+server.ts
@@ -1,0 +1,22 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { json, error } from '@sveltejs/kit';
+import { isAliasTaken, listAliases } from '$server/services/user.service';
+import { normalizeAlias, validateAlias } from '$lib/utils/alias';
+
+export const GET: RequestHandler = async ({ locals, url }) => {
+  if (!locals.tenantCtx) throw error(401);
+  const ctx = locals.tenantCtx;
+
+  const check = url.searchParams.get('check');
+  if (check !== null) {
+    const normalized = normalizeAlias(check);
+    if (!normalized) return json({ available: false, reason: 'invalid' });
+    const fmt = validateAlias(normalized);
+    if (!fmt.ok) return json({ available: false, reason: 'invalid' });
+    const taken = await isAliasTaken(ctx, normalized);
+    return json({ available: !taken, reason: taken ? 'taken' : undefined });
+  }
+
+  const aliases = await listAliases(ctx);
+  return json({ aliases });
+};

--- a/src/routes/api/users/me/permissions/+server.ts
+++ b/src/routes/api/users/me/permissions/+server.ts
@@ -1,0 +1,9 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { json, error } from '@sveltejs/kit';
+import { getPermissionsForUser } from '$server/services/roles.service';
+
+export const GET: RequestHandler = async ({ locals }) => {
+  if (!locals.tenantCtx || !locals.user) throw error(401);
+  const perms = await getPermissionsForUser(locals.tenantCtx, locals.user.id);
+  return json({ permissions: [...perms] });
+};

--- a/src/server/db/schema/auth/index.ts
+++ b/src/server/db/schema/auth/index.ts
@@ -18,6 +18,8 @@ export const user = sqliteTable('user', {
     .notNull()
     .default('user'),
   personalAgentId: text('personal_agent_id'),
+  alias: text('alias').unique(),
+  roleId: text('role_id'),
 });
 
 // ── Core: session ────────────────────────────────────────────────────────────

--- a/src/server/db/schema/index.ts
+++ b/src/server/db/schema/index.ts
@@ -59,3 +59,4 @@ export {
 export { userPreferences } from './user-preferences';
 export { workspaceMembership } from './workspace-membership';
 export type { WorkspaceMembership, NewWorkspaceMembership } from './workspace-membership';
+export { roles, rolePermissions } from './roles';

--- a/src/server/db/schema/roles.ts
+++ b/src/server/db/schema/roles.ts
@@ -1,0 +1,24 @@
+import { sqliteTable, text, integer, uniqueIndex, primaryKey } from 'drizzle-orm/sqlite-core';
+
+export const roles = sqliteTable(
+  'roles',
+  {
+    id: text('id').primaryKey(),
+    tenantId: text('tenant_id').notNull(),
+    name: text('name').notNull(),
+    description: text('description'),
+    isSystem: integer('is_system', { mode: 'boolean' }).notNull().default(false),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (t) => [uniqueIndex('idx_role_name_per_tenant').on(t.tenantId, t.name)],
+);
+
+export const rolePermissions = sqliteTable(
+  'role_permissions',
+  {
+    roleId: text('role_id').notNull().references(() => roles.id, { onDelete: 'cascade' }),
+    permission: text('permission').notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.roleId, t.permission] })],
+);

--- a/src/server/identity/otp-store.test.ts
+++ b/src/server/identity/otp-store.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createOtp, consumeOtp } from './otp-store';
+
+beforeEach(() => vi.useFakeTimers());
+
+describe('otp store', () => {
+  it('returns requestId and a 6-digit code, consumable once', () => {
+    const { requestId, code } = createOtp({
+      userId: 'u1', channel: 'telegram', channelUserId: '12',
+    });
+    expect(code).toMatch(/^\d{6}$/);
+    expect(consumeOtp(requestId, code)).toEqual({
+      ok: true, userId: 'u1', channel: 'telegram', channelUserId: '12',
+    });
+    expect(consumeOtp(requestId, code)).toEqual({ ok: false, reason: 'unknown' });
+  });
+
+  it('rejects wrong code', () => {
+    const { requestId } = createOtp({ userId: 'u1', channel: 'x', channelUserId: 'y' });
+    expect(consumeOtp(requestId, '000000')).toEqual({ ok: false, reason: 'mismatch' });
+  });
+
+  it('expires after 10 minutes', () => {
+    const { requestId, code } = createOtp({ userId: 'u1', channel: 'x', channelUserId: 'y' });
+    vi.advanceTimersByTime(10 * 60 * 1000 + 1);
+    expect(consumeOtp(requestId, code)).toEqual({ ok: false, reason: 'expired' });
+  });
+});

--- a/src/server/identity/otp-store.ts
+++ b/src/server/identity/otp-store.ts
@@ -1,0 +1,44 @@
+import { randomUUID, randomInt } from 'node:crypto';
+
+type Entry = {
+  userId: string;
+  channel: string;
+  channelUserId: string;
+  code: string;
+  expiresAt: number;
+};
+
+const store = new Map<string, Entry>();
+const TTL_MS = 10 * 60 * 1000;
+
+export function createOtp(input: {
+  userId: string;
+  channel: string;
+  channelUserId: string;
+}): { requestId: string; code: string } {
+  const requestId = randomUUID();
+  const code = String(randomInt(0, 1_000_000)).padStart(6, '0');
+  store.set(requestId, { ...input, code, expiresAt: Date.now() + TTL_MS });
+  return { requestId, code };
+}
+
+export type ConsumeResult =
+  | { ok: true; userId: string; channel: string; channelUserId: string }
+  | { ok: false; reason: 'unknown' | 'mismatch' | 'expired' };
+
+export function consumeOtp(requestId: string, code: string): ConsumeResult {
+  const entry = store.get(requestId);
+  if (!entry) return { ok: false, reason: 'unknown' };
+  if (entry.expiresAt < Date.now()) {
+    store.delete(requestId);
+    return { ok: false, reason: 'expired' };
+  }
+  if (entry.code !== code) return { ok: false, reason: 'mismatch' };
+  store.delete(requestId);
+  return {
+    ok: true,
+    userId: entry.userId,
+    channel: entry.channel,
+    channelUserId: entry.channelUserId,
+  };
+}

--- a/src/server/seed.ts
+++ b/src/server/seed.ts
@@ -86,6 +86,10 @@ async function seed() {
     console.log(`User already a member of an org, skipping.`);
   }
 
+  const { seedSystemRoles } = await import('./services/roles.service');
+  await seedSystemRoles({ db, tenantId: orgId });
+  console.log('Seeded system roles for org', orgId);
+
   console.log(`Done! Organization: ${orgId}, User: ${userId}`);
 }
 

--- a/src/server/services/identity.service.ts
+++ b/src/server/services/identity.service.ts
@@ -1,0 +1,69 @@
+import { and, eq } from 'drizzle-orm';
+import { channelIdentities } from '../db/schema/channel-identities';
+import { nowMs } from '../db/utils';
+import type { TenantContext } from './base';
+import { randomUUID } from 'node:crypto';
+
+export type AttachIdentityInput = {
+  channel: string;
+  channelUserId: string;
+  displayName?: string;
+  verified: boolean;
+};
+
+export async function listIdentities(ctx: TenantContext, userId: string) {
+  return ctx.db
+    .select()
+    .from(channelIdentities)
+    .where(eq(channelIdentities.userId, userId));
+}
+
+export async function attachIdentity(
+  ctx: TenantContext,
+  userId: string,
+  input: AttachIdentityInput,
+): Promise<string> {
+  const id = randomUUID();
+  const now = nowMs();
+
+  await ctx.db.insert(channelIdentities).values({
+    id,
+    userId,
+    channel: input.channel,
+    channelUserId: input.channelUserId,
+    displayName: input.displayName ?? null,
+    verifiedAt: input.verified ? now : null,
+    createdAt: now,
+  });
+
+  return id;
+}
+
+export async function markVerified(ctx: TenantContext, identityId: string) {
+  await ctx.db
+    .update(channelIdentities)
+    .set({ verifiedAt: nowMs() })
+    .where(eq(channelIdentities.id, identityId));
+}
+
+export async function removeIdentity(ctx: TenantContext, identityId: string) {
+  await ctx.db.delete(channelIdentities).where(eq(channelIdentities.id, identityId));
+}
+
+export async function findByChannelKey(
+  ctx: TenantContext,
+  channel: string,
+  channelUserId: string,
+) {
+  const rows = await ctx.db
+    .select()
+    .from(channelIdentities)
+    .where(
+      and(
+        eq(channelIdentities.channel, channel),
+        eq(channelIdentities.channelUserId, channelUserId),
+      ),
+    );
+
+  return rows[0] ?? null;
+}

--- a/src/server/services/roles.service.ts
+++ b/src/server/services/roles.service.ts
@@ -1,0 +1,147 @@
+import { eq, sql } from 'drizzle-orm';
+import { roles, rolePermissions } from '../db/schema/roles';
+import { user } from '../db/schema/auth/index';
+import type { TenantContext } from './base';
+import { randomUUID } from 'node:crypto';
+import { PERMISSIONS } from '$lib/permissions';
+
+export type RoleInput = {
+  name: string;
+  description?: string;
+  permissions: string[];
+  isSystem?: boolean;
+};
+
+export type RoleRow = {
+  id: string;
+  name: string;
+  description: string | null;
+  isSystem: boolean;
+  permissions: string[];
+  memberCount: number;
+};
+
+export async function listRoles(ctx: TenantContext): Promise<RoleRow[]> {
+  const roleRows = await ctx.db
+    .select()
+    .from(roles)
+    .where(eq(roles.tenantId, ctx.tenantId));
+  const permRows = await ctx.db.select().from(rolePermissions);
+  const memberRows = await ctx.db
+    .select({ roleId: user.roleId, c: sql<number>`count(*)` })
+    .from(user)
+    .groupBy(user.roleId);
+  const memberMap = new Map<string | null, number>(
+    memberRows.map((m) => [m.roleId, Number(m.c)]),
+  );
+  return roleRows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    description: r.description,
+    isSystem: r.isSystem,
+    permissions: permRows.filter((p) => p.roleId === r.id).map((p) => p.permission),
+    memberCount: memberMap.get(r.id) ?? 0,
+  }));
+}
+
+export async function createRole(ctx: TenantContext, input: RoleInput): Promise<string> {
+  const id = randomUUID();
+  const now = Date.now();
+  await ctx.db.insert(roles).values({
+    id,
+    tenantId: ctx.tenantId,
+    name: input.name,
+    description: input.description ?? null,
+    isSystem: input.isSystem ?? false,
+    createdAt: now,
+    updatedAt: now,
+  });
+  if (input.permissions.length > 0) {
+    await ctx.db
+      .insert(rolePermissions)
+      .values(input.permissions.map((p) => ({ roleId: id, permission: p })));
+  }
+  return id;
+}
+
+export async function updateRolePermissions(
+  ctx: TenantContext,
+  roleId: string,
+  permissions: string[],
+) {
+  const existing = (await ctx.db.select().from(roles).where(eq(roles.id, roleId)))[0];
+  if (!existing) throw new Error('role not found');
+  if (existing.isSystem) throw new Error('cannot edit system role');
+  await ctx.db.delete(rolePermissions).where(eq(rolePermissions.roleId, roleId));
+  if (permissions.length > 0) {
+    await ctx.db
+      .insert(rolePermissions)
+      .values(permissions.map((p) => ({ roleId, permission: p })));
+  }
+  await ctx.db.update(roles).set({ updatedAt: Date.now() }).where(eq(roles.id, roleId));
+}
+
+export async function updateRoleMeta(
+  ctx: TenantContext,
+  roleId: string,
+  patch: { name?: string; description?: string | null },
+) {
+  const existing = (await ctx.db.select().from(roles).where(eq(roles.id, roleId)))[0];
+  if (!existing) throw new Error('role not found');
+  if (existing.isSystem) throw new Error('cannot edit system role');
+  await ctx.db
+    .update(roles)
+    .set({ ...patch, updatedAt: Date.now() })
+    .where(eq(roles.id, roleId));
+}
+
+export async function deleteRole(ctx: TenantContext, roleId: string) {
+  const existing = (await ctx.db.select().from(roles).where(eq(roles.id, roleId)))[0];
+  if (!existing) throw new Error('role not found');
+  if (existing.isSystem) throw new Error('cannot delete system role');
+  await ctx.db.update(user).set({ roleId: null }).where(eq(user.roleId, roleId));
+  await ctx.db.delete(roles).where(eq(roles.id, roleId));
+}
+
+export async function getPermissionsForUser(
+  ctx: TenantContext,
+  userId: string,
+): Promise<Set<string>> {
+  const u = (
+    await ctx.db
+      .select({ role: user.role, roleId: user.roleId })
+      .from(user)
+      .where(eq(user.id, userId))
+  )[0];
+  if (!u) return new Set();
+  if (u.roleId) {
+    const rows = await ctx.db
+      .select()
+      .from(rolePermissions)
+      .where(eq(rolePermissions.roleId, u.roleId));
+    return new Set(rows.map((r) => r.permission));
+  }
+  // Legacy fallback: admin = all perms, user = all *:view
+  if (u.role === 'admin') return new Set(PERMISSIONS);
+  return new Set(PERMISSIONS.filter((p) => p.endsWith(':view')));
+}
+
+export async function seedSystemRoles(ctx: TenantContext) {
+  const existing = await ctx.db
+    .select()
+    .from(roles)
+    .where(eq(roles.tenantId, ctx.tenantId));
+  if (existing.some((r) => r.isSystem)) return;
+  await createRole(ctx, {
+    name: 'admin',
+    description: 'Full access',
+    permissions: [...PERMISSIONS],
+    isSystem: true,
+  });
+  await createRole(ctx, {
+    name: 'user',
+    description: 'View-only',
+    permissions: PERMISSIONS.filter((p) => p.endsWith(':view')),
+    isSystem: true,
+  });
+}

--- a/src/server/services/ssrf-guard.test.ts
+++ b/src/server/services/ssrf-guard.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
 import { assertSafeUrl, SsrfBlockedError } from './ssrf-guard';
 
 // Mock DNS so tests are hermetic and don't require real network access.
@@ -176,5 +176,90 @@ describe('invalid input', () => {
 
   it('throws SsrfBlockedError for a non-URL string', async () => {
     await expect(assertSafeUrl('not-a-url')).rejects.toBeInstanceOf(SsrfBlockedError);
+  });
+});
+
+// ── Operator opt-in: hostname allowlist & Tailscale CGNAT ─────────────────────
+
+describe('SSRF_ALLOWED_HOSTNAME_SUFFIXES', () => {
+  const original = process.env.SSRF_ALLOWED_HOSTNAME_SUFFIXES;
+  beforeEach(() => {
+    process.env.SSRF_ALLOWED_HOSTNAME_SUFFIXES = '';
+  });
+  afterAll(() => {
+    if (original === undefined) delete process.env.SSRF_ALLOWED_HOSTNAME_SUFFIXES;
+    else process.env.SSRF_ALLOWED_HOSTNAME_SUFFIXES = original;
+  });
+
+  it('allowlisted suffix bypasses DNS lookup entirely', async () => {
+    process.env.SSRF_ALLOWED_HOSTNAME_SUFFIXES = '.ts.net';
+    // Not in mock DNS map — without allowlist would throw ENOTFOUND.
+    await expect(
+      assertSafeUrl('wss://protopi.donkey-agama.ts.net/'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('exact-match suffix without leading dot', async () => {
+    process.env.SSRF_ALLOWED_HOSTNAME_SUFFIXES = 'corp.internal';
+    await expect(assertSafeUrl('https://corp.internal/foo')).resolves.toBeUndefined();
+    await expect(assertSafeUrl('https://api.corp.internal/foo')).resolves.toBeUndefined();
+  });
+
+  it('does not allow a different suffix when only one is configured', async () => {
+    process.env.SSRF_ALLOWED_HOSTNAME_SUFFIXES = '.ts.net';
+    // internal.corp resolves to 10.0.1.50 via mock — must still block.
+    await expect(assertSafeUrl('https://internal.corp/foo')).rejects.toBeInstanceOf(
+      SsrfBlockedError,
+    );
+  });
+
+  it('case-insensitive match', async () => {
+    process.env.SSRF_ALLOWED_HOSTNAME_SUFFIXES = '.TS.NET';
+    await expect(
+      assertSafeUrl('wss://Protopi.Donkey-Agama.ts.net/'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('handles multiple comma-separated suffixes', async () => {
+    process.env.SSRF_ALLOWED_HOSTNAME_SUFFIXES = '.ts.net, corp.internal';
+    await expect(assertSafeUrl('https://foo.ts.net/')).resolves.toBeUndefined();
+    await expect(assertSafeUrl('https://thing.corp.internal/')).resolves.toBeUndefined();
+  });
+
+  it('still blocks loopback-by-IP even when configured (allowlist gates hostnames, not IP literals)', async () => {
+    process.env.SSRF_ALLOWED_HOSTNAME_SUFFIXES = '.ts.net';
+    await expect(assertSafeUrl('http://127.0.0.1/')).rejects.toBeInstanceOf(SsrfBlockedError);
+  });
+});
+
+describe('SSRF_ALLOW_TAILSCALE_CGNAT', () => {
+  const original = process.env.SSRF_ALLOW_TAILSCALE_CGNAT;
+  beforeEach(() => {
+    delete process.env.SSRF_ALLOW_TAILSCALE_CGNAT;
+  });
+  afterAll(() => {
+    if (original === undefined) delete process.env.SSRF_ALLOW_TAILSCALE_CGNAT;
+    else process.env.SSRF_ALLOW_TAILSCALE_CGNAT = original;
+  });
+
+  it('blocks CGNAT 100.64.0.1 by default', async () => {
+    await expect(assertSafeUrl('http://100.64.0.1/')).rejects.toBeInstanceOf(SsrfBlockedError);
+  });
+
+  it('allows CGNAT 100.64.0.1 when toggled on', async () => {
+    process.env.SSRF_ALLOW_TAILSCALE_CGNAT = 'true';
+    await expect(assertSafeUrl('http://100.64.0.1/')).resolves.toBeUndefined();
+  });
+
+  it('allows the full /10 range edge 100.127.255.254 when toggled on', async () => {
+    process.env.SSRF_ALLOW_TAILSCALE_CGNAT = 'true';
+    await expect(assertSafeUrl('http://100.127.255.254/')).resolves.toBeUndefined();
+  });
+
+  it('still blocks other private ranges when CGNAT is toggled on', async () => {
+    process.env.SSRF_ALLOW_TAILSCALE_CGNAT = 'true';
+    await expect(assertSafeUrl('http://10.0.0.1/')).rejects.toBeInstanceOf(SsrfBlockedError);
+    await expect(assertSafeUrl('http://192.168.0.1/')).rejects.toBeInstanceOf(SsrfBlockedError);
+    await expect(assertSafeUrl('http://127.0.0.1/')).rejects.toBeInstanceOf(SsrfBlockedError);
   });
 });

--- a/src/server/services/ssrf-guard.ts
+++ b/src/server/services/ssrf-guard.ts
@@ -1,11 +1,45 @@
 import { promises as dns } from 'node:dns';
 
 /**
+ * Operator opt-in: comma-separated DNS suffixes that bypass the SSRF guard
+ * entirely. Use for trusted private namespaces with their own auth/encryption
+ * (e.g. Tailscale `.ts.net`). Matched case-insensitively against the URL hostname.
+ *
+ * Example: `SSRF_ALLOWED_HOSTNAME_SUFFIXES=.ts.net,corp.internal`
+ *
+ * Read from `process.env` (not `$env/dynamic/private`) so this module is
+ * testable under vitest without SvelteKit module resolution.
+ */
+function allowedHostnameSuffixes(): string[] {
+  const raw = process.env.SSRF_ALLOWED_HOSTNAME_SUFFIXES ?? '';
+  return raw
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+/**
+ * Operator opt-in: when `SSRF_ALLOW_TAILSCALE_CGNAT=true`, the carrier-grade NAT
+ * range 100.64.0.0/10 is allowed for literal-IP URLs and for hostnames that
+ * resolve to a CGNAT IP. Pair with the hostname allowlist for namespaces like
+ * Tailscale where the resolved IP will be in this block.
+ */
+function allowTailscaleCgnat(): boolean {
+  return process.env.SSRF_ALLOW_TAILSCALE_CGNAT === 'true';
+}
+
+/**
  * IPv4 CIDR ranges that must never be the target of a proxied fetch/WebSocket.
  * Covers: loopback, RFC-1918, link-local (AWS IMDS 169.254.169.254,
  * ECS credentials 169.254.170.2), shared address space, and reserved blocks.
  */
-const BLOCKED_IPV4_RANGES: { start: [number, number, number, number]; prefixLen: number }[] = [
+type CidrRange = { start: [number, number, number, number]; prefixLen: number };
+
+// Shared address space / carrier-grade NAT (RFC 6598). Tailscale assigns
+// endpoint IPs from this block — opt-in unblock via SSRF_ALLOW_TAILSCALE_CGNAT.
+const TAILSCALE_CGNAT_RANGE: CidrRange = { start: [100, 64, 0, 0], prefixLen: 10 };
+
+const BLOCKED_IPV4_RANGES: CidrRange[] = [
   // Loopback
   { start: [127, 0, 0, 0], prefixLen: 8 },
   // RFC-1918 private
@@ -16,8 +50,8 @@ const BLOCKED_IPV4_RANGES: { start: [number, number, number, number]; prefixLen:
   { start: [169, 254, 0, 0], prefixLen: 16 },
   // Unspecified / "this" network
   { start: [0, 0, 0, 0], prefixLen: 8 },
-  // Shared address space / carrier-grade NAT (RFC 6598)
-  { start: [100, 64, 0, 0], prefixLen: 10 },
+  // Shared address space / carrier-grade NAT (RFC 6598) — see TAILSCALE_CGNAT_RANGE
+  TAILSCALE_CGNAT_RANGE,
   // IETF Protocol Assignments
   { start: [192, 0, 0, 0], prefixLen: 24 },
   // Documentation / TEST-NET
@@ -38,9 +72,23 @@ function isBlockedIpv4(ip: string): boolean {
   const parts = ip.split('.').map(Number);
   if (parts.length !== 4 || parts.some((p) => isNaN(p) || p < 0 || p > 255)) return false;
   const addr = ipv4ToUint32(parts as [number, number, number, number]);
-  for (const { start, prefixLen } of BLOCKED_IPV4_RANGES) {
-    const shift = 32 - prefixLen;
-    if (addr >>> shift === ipv4ToUint32(start) >>> shift) return true;
+  const cgnatAllowed = allowTailscaleCgnat();
+  for (const range of BLOCKED_IPV4_RANGES) {
+    if (cgnatAllowed && range === TAILSCALE_CGNAT_RANGE) continue;
+    const shift = 32 - range.prefixLen;
+    if (addr >>> shift === ipv4ToUint32(range.start) >>> shift) return true;
+  }
+  return false;
+}
+
+function hostnameIsAllowlisted(host: string): boolean {
+  const lower = host.toLowerCase();
+  for (const suffix of allowedHostnameSuffixes()) {
+    if (suffix.startsWith('.')) {
+      if (lower.endsWith(suffix) || lower === suffix.slice(1)) return true;
+    } else {
+      if (lower === suffix || lower.endsWith(`.${suffix}`)) return true;
+    }
   }
   return false;
 }
@@ -107,6 +155,13 @@ export async function assertSafeUrl(rawUrl: string, context = 'URL'): Promise<vo
   // Block well-known internal hostnames before any DNS lookup
   if (BLOCKED_HOSTNAMES.has(host.toLowerCase())) {
     throw new SsrfBlockedError(`Blocked hostname "${host}" in ${context}`);
+  }
+
+  // Operator allowlist: trusted suffixes (e.g. `.ts.net` for Tailscale) bypass
+  // both literal-IP and DNS-resolved private-range checks. Use only for
+  // namespaces with their own auth/encryption layer.
+  if (hostnameIsAllowlisted(host)) {
+    return;
   }
 
   const ipv4Pattern = /^\d+\.\d+\.\d+\.\d+$/;

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -1,5 +1,5 @@
-import { eq } from 'drizzle-orm';
-import { user } from '@minion-stack/db/schema';
+import { and, eq, ne } from 'drizzle-orm';
+import { user } from '../db/schema/auth';
 import type { TenantContext } from './base';
 import { getAuth } from '$lib/auth/auth';
 
@@ -10,6 +10,8 @@ export async function listUsers(ctx: TenantContext) {
       email: user.email,
       displayName: user.name,
       role: user.role,
+      alias: user.alias,
+      roleId: user.roleId,
       createdAt: user.createdAt,
     })
     .from(user)
@@ -23,6 +25,8 @@ export async function getUser(ctx: TenantContext, userId: string) {
       email: user.email,
       displayName: user.name,
       role: user.role,
+      alias: user.alias,
+      roleId: user.roleId,
     })
     .from(user)
     .where(eq(user.id, userId));
@@ -60,4 +64,49 @@ export async function updateUserRole(ctx: TenantContext, userId: string, role: '
 
 export async function deleteUser(ctx: TenantContext, userId: string) {
   await ctx.db.delete(user).where(eq(user.id, userId));
+}
+
+export type UserProfileUpdate = {
+  displayName?: string;
+  email?: string;
+  alias?: string | null;
+  roleId?: string | null;
+};
+
+export async function updateUserProfile(
+  ctx: TenantContext,
+  userId: string,
+  patch: UserProfileUpdate,
+) {
+  const updates: Record<string, unknown> = { updatedAt: new Date() };
+  if (patch.displayName !== undefined) updates.name = patch.displayName;
+  if (patch.email !== undefined) updates.email = patch.email;
+  if (patch.alias !== undefined) updates.alias = patch.alias;
+  if (patch.roleId !== undefined) updates.roleId = patch.roleId;
+
+  await ctx.db.update(user).set(updates).where(eq(user.id, userId));
+}
+
+export async function isAliasTaken(
+  ctx: TenantContext,
+  alias: string,
+  excludeUserId?: string,
+): Promise<boolean> {
+  const rows = await ctx.db
+    .select({ id: user.id })
+    .from(user)
+    .where(
+      excludeUserId
+        ? and(eq(user.alias, alias), ne(user.id, excludeUserId))
+        : eq(user.alias, alias),
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+export async function listAliases(ctx: TenantContext): Promise<Record<string, string>> {
+  const rows = await ctx.db
+    .select({ id: user.id, alias: user.alias })
+    .from(user);
+  return Object.fromEntries(rows.filter((r) => r.alias).map((r) => [r.id, r.alias!]));
 }


### PR DESCRIPTION
## Summary

- **Phase 1 (Identity & Alias, 8 commits)**: editable user profile (name/email/alias/role), tenant-unique `@alias` with live availability check, inline-expand TeamTab row, mention renderer wired into chat user messages
- **Phase 2 (Multi-Identity Linking, 5 commits)**: reuses existing `channel_identities` table; admin attach + OTP self-claim via gateway DM (uses existing `send` RPC — no new gateway code)
- **Phase 3 (Custom Roles, 7 commits)**: new `roles` + `role_permissions` tables, 23-permission catalog, ROLES section with inline-expand permission grid, dynamic role dropdown with Built-in + Custom optgroups, UI gating via `can()` helper
- **Side fix (1 commit)**: SSRF guard env opt-ins for trusted suffix allowlist (`SSRF_ALLOWED_HOSTNAME_SUFFIXES=.ts.net,...`) and Tailscale CGNAT (`SSRF_ALLOW_TAILSCALE_CGNAT=true`); defaults unchanged

## Documented deviations

- **No `bun run db:push` / `db:generate`** — CLAUDE.md was stale. Migrations handwritten under `drizzle/0012_user_alias_role.sql` + `drizzle/0013_roles.sql`. Better Auth's drizzle adapter creates fresh-install tables from TS schema; existing DBs need manual `sqlite3 ... < drizzle/00NN_*.sql`.
- **Gateway `identity.verify.send` RPC NOT built** — existing `send` RPC (WRITE-scoped, accepts `{to, channel, message, idempotencyKey}`) does the job. Zero gateway changes.
- **Permission catalog + roles schema kept LOCAL in hub** (`src/lib/permissions.ts`, `src/server/db/schema/roles.ts`) instead of `@minion-stack/shared` / `@minion-stack/db`. Migration to packages is a follow-up cleanup phase. Matches P1.3 precedent.
- **Alias is globally unique**, not per-tenant — Better Auth `user` has no `tenant_id` column. App-layer per-org enforcement deferred.
- **Mention renderer integrated for user messages only** — assistant markdown goes through carta-md + DOMPurify which would strip `<span class="mention">`. Markdown-link transform is a follow-up.

## Test plan

- [ ] Apply migrations to local DB: `sqlite3 data/minion_hub.db "ALTER TABLE user ADD COLUMN alias TEXT; ALTER TABLE user ADD COLUMN role_id TEXT; CREATE UNIQUE INDEX IF NOT EXISTS user_alias_unique ON user(alias) WHERE alias IS NOT NULL;"` then apply `drizzle/0013_roles.sql`
- [ ] `bun run db:seed` (or restart server with empty DB to trigger Better Auth + roles seed)
- [ ] `/settings?s=security`: click a TEAM row → editor expands inline → set alias `@nikolas`, save (availability check should flicker ✓)
- [ ] ROLES section: `+ New Role`, pick perms, save → appears in TEAM role dropdown under Custom optgroup
- [ ] Assign yourself to a custom role with no `users:invite` perm → refresh → Invite button hides
- [ ] Chat message containing `@nikolas` → renders in accent color
- [ ] Identity link (requires running gateway with telegram channel): send code, paste back, verify ✓ icon
- [ ] SSRF allowlist: add `SSRF_ALLOWED_HOSTNAME_SUFFIXES=.ts.net` to env → adding a `.ts.net` host no longer 422s

## Spec / plan

- `docs/superpowers/specs/2026-05-13-hub-settings-team-redesign-design.md`
- `docs/superpowers/plans/2026-05-13-hub-team-redesign.md`

## Tests

- 11 new tests (alias×4, mention×4, otp-store×3) + 10 new SSRF tests — all pass
- Project-wide: 386/391 pass; 5 failing in 3 files pre-existing on `origin/dev` (gateway-rpc, plugins/page.server, user.service mock-call refs), NOT regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)