### PR TITLE
fix(hub): route paperclip board-key tokens via Authorization: Bearer

### DIFF
--- a/src/lib/server/paperclip-fetch.ts
+++ b/src/lib/server/paperclip-fetch.ts
@@ -6,13 +6,28 @@ function baseUrl(): string {
 	return env.PAPERCLIP_INTERNAL_URL ?? 'http://paperclip:3200';
 }
 
+/**
+ * Paperclip accepts two distinct auth modes that travel on different headers:
+ *   - Board keys (token starts with `pcli_`): must be sent via
+ *     `Authorization: Bearer <token>` (paperclip's auth.ts rejects them on
+ *     `x-hub-identity`).
+ *   - JWT identity mints (everything else): sent via `x-hub-identity: <token>`.
+ * See memory `reference_hub_paperclip_auth_header_split` for the original
+ * surface of this bug (2026-05-12).
+ */
+function authHeaders(token: string): Record<string, string> {
+	return token.startsWith('pcli_')
+		? { Authorization: `Bearer ${token}` }
+		: { 'x-hub-identity': token };
+}
+
 export function paperclipServerClient(event: RequestEvent): PaperclipClient {
 	const token = event.locals.paperclipIdentity?.token;
 	if (!token) throw new Error('paperclipIdentity not populated by hooks');
 	return createPaperclipClient({
 		baseUrl: baseUrl(),
 		fetch: globalThis.fetch,
-		headers: { 'x-hub-identity': token },
+		headers: authHeaders(token),
 	});
 }
 
@@ -24,7 +39,7 @@ export async function paperclipRawFetch<T = unknown>(event: RequestEvent, path: 
 	const token = event.locals.paperclipIdentity?.token;
 	if (!token) throw new Error('paperclipIdentity not populated by hooks');
 	const r = await fetch(`${baseUrl()}${path}`, {
-		headers: { 'x-hub-identity': token },
+		headers: authHeaders(token),
 	});
 	if (!r.ok) {
 		const err = new Error(`paperclip ${path} returned ${r.status}`);


### PR DESCRIPTION
## Summary

`paperclip-fetch.ts` was sending all tokens via `x-hub-identity`. Paperclip's auth accepts board keys (`pcli_*`) ONLY on `Authorization: Bearer` for company-scoped endpoints — every per-company call (\`/api/companies/<id>/...\`) was returning **401** even though the list endpoint passed.

## Verification (verbatim curl)

\`\`\`
GET /api/companies/fea398fc... with Bearer:         200
GET /api/companies/fea398fc... with x-hub-identity: 401
\`\`\`

Fix: branch on `pcli_` prefix in a new `authHeaders(token)` helper; JWT identity mints continue on `x-hub-identity`. Re-applies the fix originally documented in `reference_hub_paperclip_auth_header_split` (2026-05-12) which was lost in a subsequent merge.

## User-visible repro / fix

Before: \`/workforce\` showed "Something went wrong / paperclip unavailable" and company switcher displayed bare UUIDs.
After: switcher shows "FACES SCULPTORS" / "MINION" / "Pinonite corp." properly; workforce loads.

## Test plan

- [x] curl /api/companies/<id> with Bearer board key → 200
- [x] curl /api/companies/<id> with x-hub-identity board key → 401
- [ ] Manual: refresh /workforce after merge, company switcher shows names, page loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)