### PR TITLE
Security: validate flow group ownership (IDOR fix)

### DIFF
--- a/src/routes/api/flow-groups/[id]/+server.ts
+++ b/src/routes/api/flow-groups/[id]/+server.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json, error } from '@sveltejs/kit';
 import { flowGroups, flows } from '$server/db/schema';
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull, or } from 'drizzle-orm';
 import { requireAuth } from '$server/auth/authorize';
 import { getTenantCtx } from '$server/auth/tenant-ctx';
 import type { TenantContext } from '$server/services/base';
@@ -43,7 +43,15 @@ export const DELETE: RequestHandler = async ({ locals, params }) => {
   }
 
   // Non-destructive: move the group's flows to "My Flows" (ungrouped), then drop the group.
-  await ctx.db.update(flows).set({ groupId: null, updatedAt: Date.now() }).where(eq(flows.groupId, group.id));
+  // Scope the update by owner/tenant too (defense-in-depth) so it can never touch
+  // another user's rows even if a group somehow contained foreign flows.
+  await ctx.db.update(flows).set({ groupId: null, updatedAt: Date.now() }).where(
+    and(
+      eq(flows.groupId, group.id),
+      or(eq(flows.userId, user.id), isNull(flows.userId)),
+      or(eq(flows.tenantId, ctx.tenantId), isNull(flows.tenantId)),
+    ),
+  );
   await ctx.db.delete(flowGroups).where(eq(flowGroups.id, group.id));
   return json({ ok: true });
 };

--- a/src/routes/api/flows/+server.ts
+++ b/src/routes/api/flows/+server.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json, error } from '@sveltejs/kit';
-import { flows } from '$server/db/schema';
+import { flows, flowGroups } from '$server/db/schema';
 import { and, desc, eq, isNull, or } from 'drizzle-orm';
 import { randomUUID } from 'crypto';
 import { requireAuth } from '$server/auth/authorize';
@@ -65,6 +65,18 @@ export const POST: RequestHandler = async ({ locals, request }) => {
   };
 
   if (!name || typeof name !== 'string') throw error(400, 'name is required');
+
+  // SECURITY (IDOR): when a target group is specified, the caller must own it
+  // (or it's a legacy null-owner row in the same tenant). Without this check a
+  // client could assign a flow into another user's/tenant's group by id.
+  if (groupId) {
+    const [group] = await ctx.db.select().from(flowGroups).where(eq(flowGroups.id, groupId));
+    if (!group) throw error(404, 'Group not found');
+    const ownedByUser = group.userId === user.id;
+    const legacyRow = group.userId === null;
+    const sameTenant = group.tenantId === ctx.tenantId || group.tenantId === null;
+    if ((!ownedByUser && !legacyRow) || !sameTenant) throw error(403, 'Forbidden');
+  }
 
   // Optional nodes/edges let a plugin-shipped flow template be imported as a new
   // flow in one call. Stored as JSON; the editor/runner validate concrete shapes.

--- a/src/routes/api/flows/flows-grouping.server.test.ts
+++ b/src/routes/api/flows/flows-grouping.server.test.ts
@@ -23,9 +23,10 @@ describe('GET /api/flows — groupId', () => {
 });
 
 describe('POST /api/flows — groupId + templateId', () => {
-  it('persists groupId and the template source', async () => {
+  it('persists groupId and the template source (into a group the user owns)', async () => {
     const { db, resolve } = createMockDb();
-    resolve([]);
+    // group-ownership lookup returns a group owned by this user → passes the check
+    resolve([{ id: 'g1', userId: 'user-1', tenantId: 'org-1', pluginId: 'aw' }]);
     mockGetTenantCtx.mockResolvedValue({ db, tenantId: 'org-1' });
     const { POST } = await import('./+server');
     const res = await POST({
@@ -34,5 +35,51 @@ describe('POST /api/flows — groupId + templateId', () => {
     } as Parameters<typeof POST>[0]);
     expect(res.status).toBe(201);
     expect(db.insert).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates an ungrouped flow with no group lookup when groupId is absent', async () => {
+    const { db, resolve } = createMockDb();
+    resolve([]);
+    mockGetTenantCtx.mockResolvedValue({ db, tenantId: 'org-1' });
+    const { POST } = await import('./+server');
+    const res = await POST({
+      locals: makeLocals(),
+      request: new Request('http://x/api/flows', { method: 'POST', body: JSON.stringify({ name: 'Solo' }) }),
+    } as Parameters<typeof POST>[0]);
+    expect(res.status).toBe(201);
+    expect(db.insert).toHaveBeenCalledTimes(1);
+  });
+
+  it('SECURITY: rejects a groupId owned by another user (IDOR) with 403 and no insert', async () => {
+    const { db, resolve } = createMockDb();
+    // group-ownership lookup returns a group owned by a DIFFERENT user
+    resolve([{ id: 'g-foreign', userId: 'other-user', tenantId: 'org-1', pluginId: null }]);
+    mockGetTenantCtx.mockResolvedValue({ db, tenantId: 'org-1' });
+    const { POST } = await import('./+server');
+    let status = 0;
+    try {
+      await POST({
+        locals: makeLocals(),
+        request: new Request('http://x/api/flows', { method: 'POST', body: JSON.stringify({ name: 'X', groupId: 'g-foreign' }) }),
+      } as Parameters<typeof POST>[0]);
+    } catch (e) { status = (e as { status?: number }).status ?? 0; }
+    expect(status).toBe(403);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('SECURITY: rejects a non-existent groupId with 404 and no insert', async () => {
+    const { db, resolve } = createMockDb();
+    resolve([]); // group lookup finds nothing
+    mockGetTenantCtx.mockResolvedValue({ db, tenantId: 'org-1' });
+    const { POST } = await import('./+server');
+    let status = 0;
+    try {
+      await POST({
+        locals: makeLocals(),
+        request: new Request('http://x/api/flows', { method: 'POST', body: JSON.stringify({ name: 'X', groupId: 'ghost' }) }),
+      } as Parameters<typeof POST>[0]);
+    } catch (e) { status = (e as { status?: number }).status ?? 0; }
+    expect(status).toBe(404);
+    expect(db.insert).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Follow-up to #46. Validates group ownership on POST /api/flows (closes IDOR) + scopes the group-delete flows update by owner/tenant. 4 new tests. 528+/all green, check at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)