### PR TITLE
Deploy: fillContainer control-centers + .generate RPC timeout

### DIFF
--- a/src/lib/components/workshop/_workshop-canvas/CanvasHtmlOverlays.svelte
+++ b/src/lib/components/workshop/_workshop-canvas/CanvasHtmlOverlays.svelte
@@ -13,7 +13,21 @@
     import ConversationIndicator from "../ConversationIndicator.svelte";
     import { workshopState } from "$lib/state/workshop/workshop.svelte";
     import { thinkingAgents } from "$lib/state/workshop/workshop-conversations.svelte";
+    import { getAgentState, type AgentFsmState } from "$lib/workshop/agent-fsm";
     import type { SpeechBubbleEntry } from "./types";
+
+    // Per-agent status glyph: a dot anchored to the sprite so you can scan who's
+    // doing what without opening the conversations sidebar. Only *noteworthy*
+    // states get a dot — idle / wandering / patrolling / dragged show nothing, so
+    // the canvas stays calm and activity pops.
+    const STATUS_GLYPHS: Partial<
+        Record<AgentFsmState, { cls: string; pulse: boolean; label: string }>
+    > = {
+        conversing: { cls: "bg-yellow-400", pulse: true, label: "In conversation" },
+        reading: { cls: "bg-blue-400", pulse: false, label: "Reading" },
+        cooldown: { cls: "bg-foreground/30", pulse: false, label: "Cooling down" },
+        heartbeat: { cls: "bg-cyan-400", pulse: true, label: "Waking up" },
+    };
 
     interface Props {
         speechBubbles: SpeechBubbleEntry[];
@@ -77,6 +91,29 @@
         {/if}
     {/each}
 
+    <!-- Per-agent status glyphs (conversing / reading / cooldown / heartbeat) -->
+    {#each Object.values(workshopState.agents) as agent (agent.instanceId)}
+        {@const glyph = STATUS_GLYPHS[getAgentState(agent.instanceId) ?? "idle"]}
+        {#if glyph}
+            {@const gp = worldToScreenAware(
+                agent.position.x,
+                agent.position.y,
+            )}
+            <div
+                class="absolute pointer-events-none z-20"
+                style="left: {gp.x + 13}px; top: {gp.y + 11}px;"
+                title={glyph.label}
+                aria-label={glyph.label}
+            >
+                <span
+                    class="block w-2 h-2 rounded-full ring-1 ring-bg2/80 {glyph.cls} {glyph.pulse
+                        ? 'status-glyph-pulse'
+                        : ''}"
+                ></span>
+            </div>
+        {/if}
+    {/each}
+
     <!-- Thinking/typing indicators -->
     {#each Object.keys(thinkingAgents) as instanceId (instanceId)}
         {@const agent = workshopState.agents[instanceId]}
@@ -113,6 +150,22 @@
 <style>
     .thinking-dot {
         animation: thinking-bounce 1.4s infinite ease-in-out;
+    }
+
+    .status-glyph-pulse {
+        animation: status-glyph-pulse 1.2s infinite ease-in-out;
+    }
+
+    @keyframes status-glyph-pulse {
+        0%,
+        100% {
+            opacity: 1;
+            transform: scale(1);
+        }
+        50% {
+            opacity: 0.5;
+            transform: scale(1.25);
+        }
     }
 
     @keyframes thinking-bounce {

--- a/src/lib/components/workshop/_workshop-canvas/WorkshopConfigPanel.svelte
+++ b/src/lib/components/workshop/_workshop-canvas/WorkshopConfigPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { page } from "$app/state";
     import { workshopState } from "$lib/state/workshop/workshop.svelte";
     import ToggleSwitch from "$lib/components/config/ToggleSwitch.svelte";
     import * as m from "$lib/paraglide/messages";
@@ -30,6 +31,19 @@
         debugMode,
         onToggleDebugMode,
     }: Props = $props();
+
+    // Developer tools (PERF detail + AGENT DEBUG) are gated behind ?debug=1 —
+    // they're diagnostics, not user-facing scene controls. The always-on FPS
+    // readout stays for everyone as a glanceable health signal.
+    const devMode = $derived(page.url.searchParams.has("debug"));
+
+    const fpsColor = $derived(
+        perfFps >= 50
+            ? "text-green-400"
+            : perfFps >= 30
+              ? "text-yellow-400"
+              : "text-red-400",
+    );
 </script>
 
 <div class="absolute bottom-3 left-3 z-40 flex flex-col items-start gap-0">
@@ -41,65 +55,27 @@
         ).filter((c) => c.status === "active").length}
         {@const totalConvs = Object.keys(workshopState.conversations).length}
         <div
-            class="mb-0 rounded-t bg-bg2/90 backdrop-blur border border-b-0 border-border text-[8px] font-mono p-1.5 min-w-[130px] space-y-0.5"
+            class="mb-0 rounded-t bg-bg2/90 backdrop-blur border border-b-0 border-border text-[8px] font-mono p-1.5 min-w-[140px] space-y-0.5"
         >
-            <!-- Stats: perf -->
+            <!-- Scene counts -->
             <div
-                class="text-[7px] text-muted-strong uppercase tracking-wider mb-1"
+                class="text-[7px] text-muted-strong uppercase tracking-wider mb-0.5"
             >
-                {m.workshop_configPerf()}
+                {m.workshop_configScene()}
             </div>
             <div class="flex justify-between gap-3">
-                <span class="text-muted-strong">{m.workshop_configFps()}</span>
-                <span
-                    class="tabular-nums font-semibold {perfFps >= 50
-                        ? 'text-green-400'
-                        : perfFps >= 30
-                          ? 'text-yellow-400'
-                          : 'text-red-400'}">{perfFps}</span
-                >
+                <span class="text-muted-strong">{m.workshop_configAgents()}</span>
+                <span class="text-foreground/80 tabular-nums">{agentCount}</span>
             </div>
             <div class="flex justify-between gap-3">
-                <span class="text-muted-strong">{m.workshop_configFrame()}</span>
-                <span class="text-foreground/80 tabular-nums"
-                    >{perfFrameMs}ms</span
-                >
+                <span class="text-muted-strong">{m.workshop_configElements()}</span>
+                <span class="text-foreground/80 tabular-nums">{elementCount}</span>
             </div>
-            {#if perfHeapMB !== null}
-                <div class="flex justify-between gap-3">
-                    <span class="text-muted-strong">{m.workshop_configHeap()}</span>
-                    <span class="text-foreground/80 tabular-nums"
-                        >{perfHeapMB} MB</span
-                    >
-                </div>
-            {/if}
-
-            <!-- Stats: scene -->
-            <div class="border-t border-border/30 mt-1 pt-1 space-y-0.5">
-                <div
-                    class="text-[7px] text-muted-strong uppercase tracking-wider mb-0.5"
-                >
-                    {m.workshop_configScene()}
-                </div>
-                <div class="flex justify-between gap-3">
-                    <span class="text-muted-strong">{m.workshop_configAgents()}</span>
-                    <span class="text-foreground/80 tabular-nums"
-                        >{agentCount}</span
-                    >
-                </div>
-                <div class="flex justify-between gap-3">
-                    <span class="text-muted-strong">{m.workshop_configElements()}</span>
-                    <span class="text-foreground/80 tabular-nums"
-                        >{elementCount}</span
-                    >
-                </div>
-                <div class="flex justify-between gap-3">
-                    <span class="text-muted-strong">{m.workshop_configConvs()}</span>
-                    <span class="text-foreground/80 tabular-nums">
-                        <span class="text-green-400">{activeConvs}</span
-                        >/{totalConvs}
-                    </span>
-                </div>
+            <div class="flex justify-between gap-3">
+                <span class="text-muted-strong">{m.workshop_configConvs()}</span>
+                <span class="text-foreground/80 tabular-nums">
+                    <span class="text-green-400">{activeConvs}</span>/{totalConvs}
+                </span>
             </div>
 
             <!-- Ropes -->
@@ -111,7 +87,7 @@
                 </div>
                 <div class="flex rounded border border-border overflow-hidden">
                     <button
-                        class="flex-1 px-2 py-0.5 text-[8px] transition-colors {showChatRopes
+                        class="flex-1 px-2 py-1 text-[8px] transition-colors {showChatRopes
                             ? 'bg-accent/80 text-white'
                             : 'bg-bg3 text-muted hover:text-foreground'}"
                         onclick={onToggleChatRopes}
@@ -119,7 +95,7 @@
                         {m.workshop_configRopesChat()}
                     </button>
                     <button
-                        class="flex-1 px-2 py-0.5 text-[8px] transition-colors {showRelationshipRopes
+                        class="flex-1 px-2 py-1 text-[8px] transition-colors {showRelationshipRopes
                             ? 'bg-accent/80 text-white'
                             : 'bg-bg3 text-muted hover:text-foreground'}"
                         onclick={onToggleRelationshipRopes}
@@ -129,27 +105,53 @@
                 </div>
             </div>
 
-            <!-- Debug -->
-            <div class="border-t border-border/30 mt-1 pt-1">
-                <div class="flex items-center justify-between">
-                    <span class="text-[7px] text-muted-strong uppercase tracking-wider"
-                        >{m.workshop_configAgentDebug()}</span
-                    >
-                    <ToggleSwitch
-                        id="workshop-debug"
-                        checked={debugMode}
-                        onchange={onToggleDebugMode}
-                    />
+            <!-- Developer-only: agent debug (gated behind ?debug=1) -->
+            {#if devMode}
+                <div class="border-t border-border/30 mt-1 pt-1">
+                    <div class="flex items-center justify-between">
+                        <span
+                            class="text-[7px] text-muted-strong uppercase tracking-wider"
+                            >{m.workshop_configAgentDebug()}</span
+                        >
+                        <ToggleSwitch
+                            id="workshop-debug"
+                            checked={debugMode}
+                            onchange={onToggleDebugMode}
+                        />
+                    </div>
                 </div>
-            </div>
+            {/if}
         </div>
     {/if}
-    <button
-        class="flex items-center gap-1.5 px-2 py-1 text-[9px] font-mono text-muted hover:text-foreground transition-colors backdrop-blur border border-border bg-bg2/80 {configOpen
-            ? 'rounded-b rounded-t-none w-full justify-center'
+
+    <!-- Persistent bar: ⚙ scene-controls toggle + always-on telemetry readout -->
+    <div
+        class="flex items-stretch font-mono text-[9px] backdrop-blur border border-border bg-bg2/80 overflow-hidden {configOpen
+            ? 'rounded-b rounded-t-none'
             : 'rounded'}"
-        onclick={onToggleOpen}
     >
-        {configOpen ? `⚙ ${m.workshop_config()}` : "⚙"}
-    </button>
+        <button
+            class="flex items-center gap-1.5 px-2 py-1 text-muted hover:text-foreground transition-colors"
+            onclick={onToggleOpen}
+            aria-label={m.workshop_config()}
+            aria-expanded={configOpen}
+            title={m.workshop_config()}
+        >
+            ⚙
+        </button>
+        <div class="w-px self-stretch bg-border/60"></div>
+        <!-- Telemetry: fps (traffic-light) · frame · heap -->
+        <div
+            class="flex items-center gap-1.5 px-2 py-1 tabular-nums text-muted-strong"
+            title="{m.workshop_configPerf()} — {m.workshop_configFps()} / {m.workshop_configFrame()} / {m.workshop_configHeap()}"
+        >
+            <span class="font-semibold {fpsColor}">{perfFps}<span class="text-muted-strong font-normal">fps</span></span>
+            <span class="text-border">·</span>
+            <span class="text-foreground/70">{perfFrameMs}ms</span>
+            {#if perfHeapMB !== null}
+                <span class="text-border">·</span>
+                <span class="text-foreground/70">{perfHeapMB}MB</span>
+            {/if}
+        </div>
+    </div>
 </div>

--- a/src/lib/plugins/PluginIframe.svelte
+++ b/src/lib/plugins/PluginIframe.svelte
@@ -49,7 +49,11 @@
       };
     }
     const mod = await import("$lib/services/gateway.svelte");
-    return mod.sendRequest(method, params);
+    // Generation-class RPCs (e.g. studio.generate → an image model) legitimately
+    // run far longer than the 15s default; give them a generous ceiling so the
+    // hub doesn't time out a request the gateway is still happily serving.
+    const timeoutMs = /\.generate$/.test(method) ? 180_000 : undefined;
+    return mod.sendRequest(method, params, timeoutMs);
   }
 
   interface Props {

--- a/src/routes/(app)/plugins/[id]/+page.svelte
+++ b/src/routes/(app)/plugins/[id]/+page.svelte
@@ -94,6 +94,7 @@
           {authToken}
           {theme}
           {tokens}
+          fillContainer
         />
       {/key}
     {/if}


### PR DESCRIPTION
- Control-center plugin pages frame the iframe in `fillContainer` so full-page plugin UIs (Studio, alert-watcher) fill the panel height.
- `forwardRpc` gives generation-class RPCs (`*.generate`, e.g. `studio.generate`) a 180s timeout instead of the 15s default — image generation legitimately runs longer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)