### PR TITLE
feat(cache): wire @minion-stack/cache to skill, settings, marketplace services

### DIFF
--- a/src/server/services/marketplace.service.ts
+++ b/src/server/services/marketplace.service.ts
@@ -1,8 +1,15 @@
 import { eq, and, sql } from 'drizzle-orm';
 import { env } from '$env/dynamic/private';
 import { marketplaceAgents, marketplaceInstalls } from '@minion-stack/db/schema';
+import { cached, invalidateTags, keys, tags } from '@minion-stack/cache';
 import { newId, nowMs } from '$server/db/utils';
-import type { TenantContext } from './base';
+import { scopeData, type TenantContext } from './base';
+
+/**
+ * The marketplace catalog is a single GLOBAL dataset (not tenant-scoped), so it
+ * uses a global invalidation tag shared by every reader.
+ */
+const MARKETPLACE_TAGS = tags.global('marketplace');
 
 const GITHUB_REPO = 'NikolasP98/minions';
 const GITHUB_API = 'https://api.github.com';
@@ -249,40 +256,52 @@ export async function listMarketplaceAgents(
 ) {
   const { category, search, limit = 50, offset = 0 } = filters;
 
-  let query = db
-    .select({
-      id: marketplaceAgents.id,
-      name: marketplaceAgents.name,
-      role: marketplaceAgents.role,
-      category: marketplaceAgents.category,
-      tags: marketplaceAgents.tags,
-      description: marketplaceAgents.description,
-      catchphrase: marketplaceAgents.catchphrase,
-      version: marketplaceAgents.version,
-      model: marketplaceAgents.model,
-      avatarSeed: marketplaceAgents.avatarSeed,
-      githubPath: marketplaceAgents.githubPath,
-      installCount: marketplaceAgents.installCount,
-      syncedAt: marketplaceAgents.syncedAt,
-      createdAt: marketplaceAgents.createdAt,
-      updatedAt: marketplaceAgents.updatedAt,
-    })
-    .from(marketplaceAgents)
-    .$dynamic();
+  // Global, read-mostly catalog — cache per filter combination. Invalidated on
+  // sync (upsertMarketplaceAgents) and install (recordInstall); short TTL + SWR
+  // keeps browse/search snappy without re-scanning the table per keystroke.
+  return cached(
+    keys.hub('marketplace', { d: scopeData({ category, search, limit, offset }) }),
+    {
+      ttl: '10m',
+      swr: '30m',
+      tags: MARKETPLACE_TAGS,
+    },
+    async () => {
+      let query = db
+        .select({
+          id: marketplaceAgents.id,
+          name: marketplaceAgents.name,
+          role: marketplaceAgents.role,
+          category: marketplaceAgents.category,
+          tags: marketplaceAgents.tags,
+          description: marketplaceAgents.description,
+          catchphrase: marketplaceAgents.catchphrase,
+          version: marketplaceAgents.version,
+          model: marketplaceAgents.model,
+          avatarSeed: marketplaceAgents.avatarSeed,
+          githubPath: marketplaceAgents.githubPath,
+          installCount: marketplaceAgents.installCount,
+          syncedAt: marketplaceAgents.syncedAt,
+          createdAt: marketplaceAgents.createdAt,
+          updatedAt: marketplaceAgents.updatedAt,
+        })
+        .from(marketplaceAgents)
+        .$dynamic();
 
-  if (category) {
-    query = query.where(eq(marketplaceAgents.category, category));
-  }
+      if (category) {
+        query = query.where(eq(marketplaceAgents.category, category));
+      }
 
-  if (search) {
-    const pattern = `%${search}%`;
-    query = query.where(
-      sql`(${marketplaceAgents.name} LIKE ${pattern} OR ${marketplaceAgents.role} LIKE ${pattern} OR ${marketplaceAgents.description} LIKE ${pattern} OR ${marketplaceAgents.tags} LIKE ${pattern})`,
-    );
-  }
+      if (search) {
+        const pattern = `%${search}%`;
+        query = query.where(
+          sql`(${marketplaceAgents.name} LIKE ${pattern} OR ${marketplaceAgents.role} LIKE ${pattern} OR ${marketplaceAgents.description} LIKE ${pattern} OR ${marketplaceAgents.tags} LIKE ${pattern})`,
+        );
+      }
 
-  const rows = await query.limit(limit).offset(offset).orderBy(marketplaceAgents.installCount);
-  return rows;
+      return query.limit(limit).offset(offset).orderBy(marketplaceAgents.installCount);
+    },
+  );
 }
 
 export async function getMarketplaceAgent(db: TenantContext['db'], id: string) {
@@ -353,6 +372,9 @@ export async function upsertMarketplaceAgents(
     }
   }
 
+  // Catalog metadata changed — drop every cached filter combination.
+  await invalidateTags(MARKETPLACE_TAGS);
+
   return results;
 }
 
@@ -375,6 +397,9 @@ export async function recordInstall(ctx: TenantContext, agentId: string, serverI
     .update(marketplaceAgents)
     .set({ installCount: sql`${marketplaceAgents.installCount} + 1` })
     .where(eq(marketplaceAgents.id, agentId));
+
+  // installCount feeds the listing (and its ordering) — refresh the catalog cache.
+  await invalidateTags(MARKETPLACE_TAGS);
 
   return id;
 }

--- a/src/server/services/settings.service.ts
+++ b/src/server/services/settings.service.ts
@@ -1,5 +1,6 @@
 import { eq, and } from 'drizzle-orm';
 import { settings } from '@minion-stack/db/schema';
+import { cached, invalidateTags, keys, tags } from '@minion-stack/cache';
 import { nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 
@@ -26,18 +27,32 @@ export async function upsertSettings(
         updatedAt: now,
       },
     });
+
+  // Admin edited config — drop the whole-tenant settings cache (both the
+  // aggregate map and per-section reads share this domain tag).
+  await invalidateTags(tags.tenantDomain(ctx.tenantId, 'settings'));
 }
 
 export async function getSettings(
   ctx: TenantContext,
   serverId: string,
 ): Promise<Record<string, unknown>> {
-  const rows = await ctx.db
-    .select({ section: settings.section, value: settings.value })
-    .from(settings)
-    .where(and(eq(settings.serverId, serverId), eq(settings.tenantId, ctx.tenantId)));
+  return cached(
+    keys.hub('settings', { t: ctx.tenantId, d: { serverId } }),
+    {
+      ttl: '30m',
+      swr: '5m',
+      tags: tags.tenantDomain(ctx.tenantId, 'settings'),
+    },
+    async () => {
+      const rows = await ctx.db
+        .select({ section: settings.section, value: settings.value })
+        .from(settings)
+        .where(and(eq(settings.serverId, serverId), eq(settings.tenantId, ctx.tenantId)));
 
-  return Object.fromEntries(rows.map((r) => [r.section, JSON.parse(r.value)]));
+      return Object.fromEntries(rows.map((r) => [r.section, JSON.parse(r.value)]));
+    },
+  );
 }
 
 export async function getSettingsSection(
@@ -45,16 +60,26 @@ export async function getSettingsSection(
   serverId: string,
   section: string,
 ): Promise<unknown> {
-  const rows = await ctx.db
-    .select({ value: settings.value })
-    .from(settings)
-    .where(
-      and(
-        eq(settings.serverId, serverId),
-        eq(settings.section, section),
-        eq(settings.tenantId, ctx.tenantId),
-      ),
-    );
+  return cached(
+    keys.hub('settings', { t: ctx.tenantId, d: { serverId, section } }),
+    {
+      ttl: '30m',
+      swr: '5m',
+      tags: tags.tenantDomain(ctx.tenantId, 'settings'),
+    },
+    async () => {
+      const rows = await ctx.db
+        .select({ value: settings.value })
+        .from(settings)
+        .where(
+          and(
+            eq(settings.serverId, serverId),
+            eq(settings.section, section),
+            eq(settings.tenantId, ctx.tenantId),
+          ),
+        );
 
-  return rows[0] ? JSON.parse(rows[0].value) : null;
+      return rows[0] ? JSON.parse(rows[0].value) : null;
+    },
+  );
 }

--- a/src/server/services/skill.service.ts
+++ b/src/server/services/skill.service.ts
@@ -1,5 +1,6 @@
 import { eq, and, sql } from 'drizzle-orm';
 import { skills } from '@minion-stack/db/schema';
+import { cached, invalidateTags, keys, tags } from '@minion-stack/cache';
 import { nowMs } from '$server/db/utils';
 import type { TenantContext } from './base';
 
@@ -53,13 +54,27 @@ export async function upsertSkills(ctx: TenantContext, serverId: string, items: 
         },
       });
   }
+
+  // Skills change only on gateway sync (upsert) — drop the read-aside entries so
+  // the next listSkills reflects the fresh catalog.
+  await invalidateTags(tags.tenantDomain(ctx.tenantId, 'skills'));
 }
 
 export async function listSkills(ctx: TenantContext, serverId: string) {
-  const rows = await ctx.db
-    .select({ rawJson: skills.rawJson })
-    .from(skills)
-    .where(and(eq(skills.serverId, serverId), eq(skills.tenantId, ctx.tenantId)));
+  return cached(
+    keys.hub('skills', { t: ctx.tenantId, d: { serverId } }),
+    {
+      ttl: '1h',
+      swr: '5m',
+      tags: tags.tenantDomain(ctx.tenantId, 'skills'),
+    },
+    async () => {
+      const rows = await ctx.db
+        .select({ rawJson: skills.rawJson })
+        .from(skills)
+        .where(and(eq(skills.serverId, serverId), eq(skills.tenantId, ctx.tenantId)));
 
-  return rows.map((r) => JSON.parse(r.rawJson));
+      return rows.map((r) => JSON.parse(r.rawJson));
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- `skill.service`: `listSkills` cached 1h/swr 5m with tenant-domain tag invalidation on `upsertSkills`
- `settings.service`: `getSettings` + `getSettingsSection` cached 30m/swr 5m, invalidated on write
- `marketplace.service`: `listMarketplaceAgents` cached 10m/swr 30m with per-filter `scopeData()` key; global tag cleared on catalog sync and `recordInstall`

Valkey backend activates via `CACHE_BACKEND=valkey` + `VALKEY_URL` env vars (Upstash for Vercel).

## Test plan
- [x] `bun run check` → 0 errors / 0 warnings
- [x] `bun run test` → 570/570 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)