### PR TITLE
Unified Prompt tab: real prompt data + live ad-hoc testing

### DIFF
--- a/src/lib/components/agents/AgentPromptSimulator.svelte
+++ b/src/lib/components/agents/AgentPromptSimulator.svelte
@@ -1,6 +1,15 @@
 <script lang="ts">
   import SectionProseEditor from '$lib/components/agents/SectionProseEditor.svelte';
+  import MarkdownMessage from '$lib/components/chat/MarkdownMessage.svelte';
   import { fetchSessionPromptReport, fetchPromptPreview } from '$lib/services/gateway.svelte';
+  import {
+    previewSections,
+    previewSectionsStream,
+    getOverrides,
+    setOverrides,
+  } from '$lib/services/prompt-sections-rpc';
+  import type { PromptMode, PreviewResponse } from '@minion-stack/shared';
+  import { onDestroy } from 'svelte';
   import * as m from '$lib/paraglide/messages';
 
   import ContextWindowBar from './_agent-prompt-simulator/ContextWindowBar.svelte';
@@ -9,8 +18,13 @@
   import ClassicDetail from './_agent-prompt-simulator/ClassicDetail.svelte';
   import {
     getContextWindowChars,
+    cachedPct as cachedPctOf,
+    sortSections,
     type BarSegment,
-    type StepStatus,
+    type GroupMode,
+    type PreviewStreamEvent,
+    type SectionEntry,
+    type SortMode,
     type SystemPromptReport,
   } from './_agent-prompt-simulator/types';
 
@@ -30,19 +44,193 @@
     session: { label: m.prompt_layerSession(), color: '#10b981', description: m.prompt_layerSessionDesc() },
   });
 
+  // Concrete PromptMode values. The shared PromptMode is the *assembly* mode
+  // (full|minimal|none), NOT a baseline/test axis — the backend has no test-input
+  // concept yet (Phase 3). Both Inspect and Simulate render the full prompt; the
+  // Inspect/Simulate distinction is a UI-only framing for now.
+  const PREVIEW_MODE = 'full' satisfies PromptMode;
+
   let report = $state<SystemPromptReport | null>(null);
+  let assembled = $state<string | null>(null);
+  let previewTotalBytes = $state(0);
+  let previewTotalTokens = $state(0);
   let loading = $state(false);
   let testing = $state(false);
   let error = $state<string | null>(null);
+
+  // ─── Phase 3: progressive streaming preview ─────────────────────────────
+  let streaming = $state(false);
+  let streamReceived = $state(0);
+  let streamTotal = $state(0);
+  // Monotonic run token — guards against a stale run's late events/response
+  // mutating state after a newer run has started. Module-local (not reactive).
+  let runToken = 0;
+  let detachStream: (() => void) | null = null;
+
+  /** Map a streamed breakdown row into a SectionEntry for the rail/hero. */
+  function streamSectionToEntry(s: NonNullable<PreviewStreamEvent['section']>): SectionEntry {
+    return {
+      id: s.id,
+      layer: s.layer,
+      label: s.id,
+      order: s.order,
+      chars: s.bytes,
+      bytes: s.bytes,
+      tokens: s.tokens,
+      cacheable: s.cacheable,
+      source: s.source === 'builtin' ? 'static' : s.source,
+      content: s.rendered,
+    };
+  }
+
+  /**
+   * Run a streaming preview: subscribe to per-section frames BEFORE issuing the
+   * request, reveal sections as they arrive, then overwrite with the
+   * authoritative final response. `testInput` is forwarded to the gateway.
+   */
+  async function streamPreview(testInput?: string) {
+    const myToken = ++runToken;
+    error = null;
+    streaming = true;
+    streamReceived = 0;
+    streamTotal = 0;
+
+    const built: SectionEntry[] = [];
+    let buf = '';
+
+    const onEv = (e: Event) => {
+      const p = (e as CustomEvent).detail as PreviewStreamEvent;
+      if (myToken !== runToken) return;
+      if (p.kind === 'start') {
+        streamTotal = p.total;
+        return;
+      }
+      if (p.kind !== 'section' || !p.section) return;
+      streamTotal = p.total;
+      streamReceived = (p.index ?? built.length) + 1;
+
+      const entry = streamSectionToEntry(p.section);
+      const existingIdx = built.findIndex((b) => b.id === entry.id);
+      if (existingIdx >= 0) built[existingIdx] = entry;
+      else built.push(entry);
+
+      // Merge into existing report.sections (preserving other report fields)
+      // when a report already exists; otherwise synthesize a minimal one so the
+      // hero/rail render progressively from the first frame.
+      if (report) {
+        const byId = new Map(built.map((b) => [b.id, b]));
+        const merged: SectionEntry[] = report.sections
+          ? report.sections.map((s) => {
+              const b = byId.get(s.id);
+              return b ? { ...s, ...b } : s;
+            })
+          : [];
+        // Append any streamed sections the report doesn't yet know about.
+        const known = new Set(merged.map((s) => s.id));
+        for (const b of built) if (!known.has(b.id)) merged.push(b);
+        report = { ...report, sections: merged };
+      } else {
+        report = { sections: [...built] };
+      }
+
+      buf += (buf ? '\n\n' : '') + p.section.rendered;
+      assembled = buf;
+    };
+
+    window.addEventListener('prompt.sections.preview.event', onEv);
+    detachStream = () => window.removeEventListener('prompt.sections.preview.event', onEv);
+
+    // Merge an authoritative PreviewResponse into the assembled view + section
+    // byte/token/cacheable metadata. Shared by the streaming path and the
+    // non-streaming fallback below.
+    const applyFinal = (res: PreviewResponse) => {
+      assembled = res.assembled ?? buf;
+      previewTotalBytes = res.totalBytes ?? 0;
+      previewTotalTokens = res.totalTokens ?? 0;
+      const byId = new Map(res.breakdown.map((b) => [b.id, b]));
+      if (report?.sections) {
+        report = {
+          ...report,
+          sections: report.sections.map((s) => {
+            const b = byId.get(s.id);
+            return b
+              ? { ...s, bytes: b.bytes, tokens: b.tokens, cacheable: b.cacheable }
+              : s;
+          }),
+        };
+      }
+    };
+
+    try {
+      const res = await previewSectionsStream(agentId, PREVIEW_MODE, testInput);
+      if (myToken === runToken) applyFinal(res);
+    } catch (e) {
+      // Graceful degradation: gateways that predate the streaming RPC reject
+      // with "unknown method". Fall back to the non-streaming preview so
+      // Simulate still works (no progressive reveal, but a correct result).
+      // It auto-upgrades to streaming once the gateway ships the RPC.
+      const msg = (e as Error)?.message ?? '';
+      if (/unknown method/i.test(msg)) {
+        try {
+          const res = await previewSections(agentId, PREVIEW_MODE);
+          if (myToken === runToken) applyFinal(res);
+        } catch (e2) {
+          if (myToken === runToken) {
+            error = (e2 as Error).message ?? 'Failed to generate prompt preview';
+          }
+        }
+      } else if (myToken === runToken) {
+        error = msg || 'Failed to generate prompt preview';
+      }
+    } finally {
+      detachStream?.();
+      detachStream = null;
+      if (myToken === runToken) {
+        streaming = false;
+        loading = false;
+        testing = false;
+      }
+    }
+  }
+
+  onDestroy(() => {
+    runToken++;
+    detachStream?.();
+    detachStream = null;
+  });
+
+  // ─── Lens state (group + sort), persisted to localStorage ───────────────
+  function readPref<T extends string>(key: string, fallback: T, allowed: readonly T[]): T {
+    if (typeof localStorage === 'undefined') return fallback;
+    const v = localStorage.getItem(key);
+    return v && (allowed as readonly string[]).includes(v) ? (v as T) : fallback;
+  }
+  // svelte-ignore state_referenced_locally
+  let groupMode = $state<GroupMode>(readPref('minion.promptTab.group', 'layer', ['layer', 'none', 'pipeline']));
+  // svelte-ignore state_referenced_locally
+  let sortMode = $state<SortMode>(readPref('minion.promptTab.sort', 'order', ['order', 'cached', 'alpha', 'size']));
+  $effect(() => {
+    if (typeof localStorage !== 'undefined') localStorage.setItem('minion.promptTab.group', groupMode);
+  });
+  $effect(() => {
+    if (typeof localStorage !== 'undefined') localStorage.setItem('minion.promptTab.sort', sortMode);
+  });
+
+  // ─── Inspect / Simulate context ─────────────────────────────────────────
+  let viewContext = $state<'inspect' | 'simulate'>('inspect');
+  let testPrompt = $state("Tell me about today's schedule.");
+  let lastRunPrompt = $state('');
+  const testDirty = $derived(viewContext === 'simulate' && testPrompt !== lastRunPrompt);
+
+  // ─── Selection / inspector slide-over ───────────────────────────────────
+  let selectedSectionId = $state<string | null>(null);
   let activeStep = $state(0);
-  let viewMode = $state<'sections' | 'classic'>('sections');
-
-  let stepStatus = $state<Record<string, StepStatus>>({});
-  let testPrompt = $state('Tell me about today\'s schedule.');
-  const STEP_ANIMATION_MS = 220;
-
   let contentViewMode = $state<'rendered' | 'raw'>('rendered');
   let editorOpen = $state(false);
+  let railOpenMobile = $state(false);
+
+  // ─── Overrides ──────────────────────────────────────────────────────────
+  let disabledIds = $state<Set<string>>(new Set());
 
   const CLASSIC_STEPS = $derived([
     { id: 'bootstrap', label: m.prompt_stepBootstrap() },
@@ -58,34 +246,81 @@
 
   const hasSections = $derived(!!(report?.sections && report.sections.length > 0));
 
-  const activeSections = $derived(
-    report?.sections?.filter((s) => s.chars > 0) ?? [],
+  // All sections that render to something, with override-disabled flag applied.
+  const allSections = $derived<SectionEntry[]>(
+    (report?.sections ?? [])
+      .filter((s) => s.chars > 0 || (s.bytes ?? 0) > 0)
+      .map((s) => ({ ...s, disabled: disabledIds.has(s.id) })),
   );
 
-  const currentSectionTop = $derived(activeSections[activeStep] ?? null);
+  const totalCount = $derived(allSections.length);
 
-  const currentSteps = $derived(
-    viewMode === 'sections' && hasSections
-      ? activeSections.map((s) => ({ id: s.id, label: s.label, layer: s.layer, chars: s.chars }))
-      : CLASSIC_STEPS.map((s) => ({ id: s.id, label: s.label, layer: undefined as string | undefined, chars: undefined as number | undefined })),
+  // Sections passed to the rail (no filtering yet — full set; sorting happens in rail).
+  const visibleSections = $derived(allSections);
+
+  const selectedSection = $derived(
+    selectedSectionId ? (allSections.find((s) => s.id === selectedSectionId) ?? null) : null,
   );
+
+  // Assembled blocks for the hero pane (ordered).
+  const orderedSections = $derived(sortSections(allSections, 'order'));
+  const firstCacheableId = $derived(orderedSections.find((s) => s.cacheable)?.id ?? null);
+
+  const aggCachedPct = $derived(cachedPctOf(allSections));
 
   $effect(() => {
     const sk = sessionKey;
     const _aid = agentId;
-    loadReport(sk);
+    void loadAll(sk);
   });
 
-  async function loadReport(sk: string) {
+  async function loadOverrides() {
+    try {
+      const res = await getOverrides(agentId);
+      disabledIds = new Set(res.disabled);
+    } catch (e) {
+      console.warn('[prompt] getOverrides failed:', e);
+    }
+  }
+
+  /** Merge `previewSections` breakdown (bytes/tokens/cacheable) into report.sections by id. */
+  async function enrich(mode: PromptMode) {
+    try {
+      const preview = await previewSections(agentId, mode);
+      assembled = preview.assembled ?? null;
+      previewTotalBytes = preview.totalBytes ?? 0;
+      previewTotalTokens = preview.totalTokens ?? 0;
+      const byId = new Map(preview.breakdown.map((b) => [b.id, b]));
+      if (report?.sections) {
+        report = {
+          ...report,
+          sections: report.sections.map((s) => {
+            const b = byId.get(s.id);
+            return b
+              ? { ...s, bytes: b.bytes, tokens: b.tokens, cacheable: b.cacheable }
+              : s;
+          }),
+        };
+      }
+    } catch (e) {
+      console.warn('[prompt] previewSections enrich failed (degraded view):', e);
+    }
+  }
+
+  async function loadAll(sk: string) {
     loading = true;
     error = null;
     report = null;
+    assembled = null;
+    selectedSectionId = null;
     try {
       const res = (await fetchSessionPromptReport(sk)) as {
         sessions?: Array<{ contextWeight?: SystemPromptReport }>;
       } | null;
       const first = res?.sessions?.[0];
       report = first?.contextWeight ?? null;
+
+      // Backfill section content from prompt.preview when missing.
       if (report?.sections && report.sections.some((s) => s.content === undefined)) {
         try {
           const fresh = (await fetchPromptPreview(agentId)) as SystemPromptReport | null;
@@ -96,9 +331,7 @@
               sections: report.sections.map((s) => {
                 if (s.content !== undefined) return s;
                 const live = freshById.get(s.id);
-                return live
-                  ? { ...s, content: live.content, source: s.source ?? live.source }
-                  : s;
+                return live ? { ...s, content: live.content, source: s.source ?? live.source } : s;
               }),
             };
           }
@@ -106,6 +339,8 @@
           console.warn('[prompt] content backfill failed:', e);
         }
       }
+
+      await Promise.all([enrich(PREVIEW_MODE), loadOverrides()]);
     } catch (e) {
       error = (e as Error).message ?? 'Failed to load prompt report';
     } finally {
@@ -113,16 +348,11 @@
     }
   }
 
-  function sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-  }
-
   async function refreshReportSilently() {
     try {
       const res = (await fetchPromptPreview(agentId)) as SystemPromptReport | null;
-      if (res) {
-        report = res;
-      }
+      if (res) report = res;
+      await enrich(PREVIEW_MODE);
     } catch (e) {
       console.warn('[prompt] silent refresh failed:', e);
     }
@@ -131,66 +361,74 @@
   async function runTest() {
     testing = true;
     error = null;
-    report = null;
-    stepStatus = {};
-    activeStep = 0;
+    lastRunPrompt = testPrompt;
+    // Phase 3: stream the rendered prompt section-by-section instead of a
+    // spinner. The test text is forwarded to the gateway. `streamPreview` clears
+    // `testing` in its finally block.
+    await streamPreview(testPrompt.trim() || undefined);
+  }
+
+  function setViewContext(ctx: 'inspect' | 'simulate') {
+    if (viewContext === ctx) return;
+    viewContext = ctx;
+    void enrich(PREVIEW_MODE);
+  }
+
+  // ─── Override toggle (optimistic, with rollback) ────────────────────────
+  async function onToggleSection(id: string, disabled: boolean) {
+    const prev = new Set(disabledIds);
+    const next = new Set(disabledIds);
+    if (disabled) next.add(id);
+    else next.delete(id);
+    disabledIds = next;
     try {
-      const res = (await fetchPromptPreview(agentId)) as SystemPromptReport | null;
-      report = res;
-      if (res?.sections && res.sections.length > 0) {
-        viewMode = 'sections';
-      }
-
-      await sleep(0);
-      const stepsToPlay = currentSteps;
-      const initialStatus: Record<string, StepStatus> = {};
-      for (const s of stepsToPlay) initialStatus[s.id] = 'pending';
-      stepStatus = initialStatus;
-
-      for (let i = 0; i < stepsToPlay.length; i += 1) {
-        const step = stepsToPlay[i];
-        if (!step) continue;
-        activeStep = i;
-        stepStatus = { ...stepStatus, [step.id]: 'loading' };
-        await sleep(STEP_ANIMATION_MS);
-        const hasContent =
-          step.chars === undefined ? true : (step.chars ?? 0) > 0;
-        stepStatus = {
-          ...stepStatus,
-          [step.id]: hasContent ? 'ok' : 'missing',
-        };
-      }
+      await setOverrides(agentId, [...next]);
+      await enrich(PREVIEW_MODE);
     } catch (e) {
-      error = (e as Error).message ?? 'Failed to generate prompt preview';
-    } finally {
-      testing = false;
+      console.warn('[prompt] setOverrides failed, rolling back:', e);
+      disabledIds = prev;
     }
   }
 
-  const totalChars = $derived(report?.systemPrompt?.chars ?? 0);
+  function selectSection(id: string) {
+    selectedSectionId = id;
+    const el = document.getElementById(`assembled-section-${id}`);
+    el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
 
+  function closeInspector() {
+    selectedSectionId = null;
+  }
+
+  function onSelectStep(idx: number) {
+    activeStep = idx;
+    selectedSectionId = '__stage__';
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape' && selectedSectionId) {
+      closeInspector();
+    }
+  }
+
+  // ─── Context-window budget bar ──────────────────────────────────────────
+  const totalChars = $derived(report?.systemPrompt?.chars ?? 0);
   const contextWindowChars = $derived(getContextWindowChars(report?.model));
 
   const segments = $derived.by<BarSegment[]>(() => {
     if (!report) return [];
-
     if (hasSections && report.sections) {
       const layerChars = new Map<string, number>();
       for (const s of report.sections) {
-        if (s.chars > 0) {
-          layerChars.set(s.layer, (layerChars.get(s.layer) ?? 0) + s.chars);
-        }
+        if (s.chars > 0) layerChars.set(s.layer, (layerChars.get(s.layer) ?? 0) + s.chars);
       }
       const segs: BarSegment[] = [];
       for (const [layer, chars] of layerChars) {
         const meta = LAYER_META[layer];
-        if (meta && chars > 0) {
-          segs.push({ label: meta.label, chars, color: meta.color, layer });
-        }
+        if (meta && chars > 0) segs.push({ label: meta.label, chars, color: meta.color, layer });
       }
       return segs;
     }
-
     const bootstrapChars =
       report.injectedWorkspaceFiles?.reduce((s, f) => s + (f.injectedChars ?? 0), 0) ?? 0;
     const skillsChars = report.skills?.promptChars ?? 0;
@@ -206,43 +444,122 @@
   });
 
   const totalUsedChars = $derived(segments.reduce((s, seg) => s + seg.chars, 0));
-
-  const currentSection = $derived(activeSections[activeStep]);
 </script>
 
+<svelte:window onkeydown={handleKeydown} />
+
 <div class="flex flex-col h-full overflow-hidden text-[12px]">
+  <!-- Topbar: Inspect / Simulate + budget bar -->
+  <div class="shrink-0 flex items-center gap-2 px-3 py-1.5 border-b border-border bg-bg2">
+    <div class="flex rounded border border-border overflow-hidden">
+      <button
+        type="button"
+        class="text-[10px] px-2.5 py-1 transition-colors cursor-pointer
+          {viewContext === 'inspect' ? 'bg-accent/15 text-accent font-semibold' : 'text-muted hover:text-foreground'}"
+        onclick={() => setViewContext('inspect')}
+      >
+        Inspect
+      </button>
+      <button
+        type="button"
+        class="text-[10px] px-2.5 py-1 transition-colors cursor-pointer flex items-center gap-1
+          {viewContext === 'simulate' ? 'bg-accent/15 text-accent font-semibold' : 'text-muted hover:text-foreground'}"
+        onclick={() => setViewContext('simulate')}
+      >
+        Simulate
+        {#if testDirty}
+          <span class="w-1.5 h-1.5 rounded-full bg-amber-400" title="Unsaved test input"></span>
+        {/if}
+      </button>
+    </div>
+    {#if previewTotalTokens > 0}
+      <span class="text-[9px] font-mono text-foreground/40 tabular-nums">{previewTotalTokens.toLocaleString()} tok</span>
+    {/if}
+  </div>
 
   {#if report}
-    <ContextWindowBar {segments} {contextWindowChars} {totalUsedChars} />
+    <ContextWindowBar
+      {segments}
+      {contextWindowChars}
+      {totalUsedChars}
+      cachedPct={aggCachedPct}
+      onToggleRail={() => (railOpenMobile = !railOpenMobile)}
+    />
   {/if}
 
-  <div class="flex flex-1 min-h-0 overflow-hidden">
-    <PipelineSidebar
-      {viewMode}
-      {hasSections}
-      {activeStep}
-      layerMeta={LAYER_META}
-      {activeSections}
-      {currentSteps}
-      classicSteps={CLASSIC_STEPS}
-      {stepStatus}
-      bind:testPrompt
-      {testing}
-      {loading}
-      onToggleViewMode={() => {
-        viewMode = viewMode === 'sections' ? 'classic' : 'sections';
-        activeStep = 0;
-      }}
-      onSelectStep={(idx) => (activeStep = idx)}
-      onRunTest={runTest}
-      onRefresh={() => loadReport(sessionKey)}
-    />
+  <div class="relative flex flex-1 min-h-0 overflow-hidden">
+    <!-- Sections rail: fixed 280px on lg, drawer below -->
+    <div
+      class="hidden lg:flex w-[280px] shrink-0 min-h-0"
+    >
+      <PipelineSidebar
+        bind:groupMode
+        bind:sortMode
+        {viewContext}
+        {hasSections}
+        {selectedSectionId}
+        layerMeta={LAYER_META}
+        sections={visibleSections}
+        classicSteps={CLASSIC_STEPS}
+        {activeStep}
+        stepStatus={{}}
+        bind:testPrompt
+        {testing}
+        {loading}
+        {disabledIds}
+        {totalCount}
+        onSelectSection={selectSection}
+        {onSelectStep}
+        {onToggleSection}
+        onRunTest={runTest}
+        onRefresh={() => loadAll(sessionKey)}
+      />
+    </div>
 
-    <div class="flex-1 min-w-0 overflow-y-auto bg-bg">
-      {#if loading || testing}
+    <!-- Mobile drawer -->
+    {#if railOpenMobile}
+      <button
+        type="button"
+        class="lg:hidden absolute inset-0 z-20 bg-black/40"
+        aria-label="Close sections"
+        onclick={() => (railOpenMobile = false)}
+      ></button>
+      <div class="lg:hidden absolute left-0 top-0 bottom-0 z-30 w-[280px] shadow-xl">
+        <PipelineSidebar
+          bind:groupMode
+          bind:sortMode
+          {viewContext}
+          {hasSections}
+          {selectedSectionId}
+          layerMeta={LAYER_META}
+          sections={visibleSections}
+          classicSteps={CLASSIC_STEPS}
+          {activeStep}
+          stepStatus={{}}
+          bind:testPrompt
+          {testing}
+          {loading}
+          {disabledIds}
+          {totalCount}
+          onSelectSection={(id) => {
+            selectSection(id);
+            railOpenMobile = false;
+          }}
+          {onSelectStep}
+          {onToggleSection}
+          onRunTest={runTest}
+          onRefresh={() => loadAll(sessionKey)}
+        />
+      </div>
+    {/if}
+
+    <!-- Assembled hero -->
+    <div class="relative flex-1 min-w-0 overflow-y-auto bg-bg">
+      {#if (loading || testing || streaming) && !(report?.sections?.length)}
+        <!-- Spinner only pre-first-byte; once sections arrive the stream renders. -->
         <div class="flex items-center justify-center h-full gap-2 text-muted text-xs">
           <div class="w-4 h-4 border-2 border-border border-t-accent rounded-full animate-spin"></div>
-          {testing ? m.prompt_generatingPreview() : m.prompt_loadingReport()}
+          {testing || streaming ? m.prompt_generatingPreview() : m.prompt_loadingReport()}
         </div>
       {:else if error}
         <div class="flex flex-col items-center justify-center h-full gap-3">
@@ -251,7 +568,7 @@
           <button
             type="button"
             class="text-[11px] font-semibold px-3 py-1.5 rounded border border-border text-muted hover:text-foreground transition-colors cursor-pointer"
-            onclick={() => loadReport(sessionKey)}
+            onclick={() => loadAll(sessionKey)}
           >
             {m.common_retry()}
           </button>
@@ -261,34 +578,136 @@
           <span class="text-muted text-xs">{m.prompt_noReport()}</span>
           <span class="text-muted text-[11px]">{m.prompt_noReportHint()}</span>
         </div>
-      {:else if viewMode === 'sections' && hasSections}
-        {#if currentSection}
-          <SectionDetail
-            {currentSection}
-            {report}
-            layerMeta={LAYER_META}
-            {totalChars}
-            bind:contentViewMode
-            onOpenEditor={() => (editorOpen = true)}
-          />
-        {/if}
-      {:else}
+      {:else if groupMode === 'pipeline'}
         <ClassicDetail {activeStep} {report} {totalChars} />
+      {:else}
+        <!-- Assembled rendered prompt -->
+        <div class="p-4 max-w-3xl mx-auto space-y-3">
+          {#if streaming}
+            <!-- Phase 3: live build progress while sections stream in. -->
+            <div class="flex items-center gap-2">
+              <div class="flex-1 h-0.5 rounded-full bg-border/60 overflow-hidden">
+                <div
+                  class="h-full bg-accent transition-[width] duration-150 ease-out"
+                  style:width="{streamTotal > 0 ? Math.round((streamReceived / streamTotal) * 100) : 5}%"
+                ></div>
+              </div>
+              <span class="text-[9px] font-mono text-accent/80 tabular-nums shrink-0">
+                Building {streamReceived}{streamTotal > 0 ? `/${streamTotal}` : ''}
+              </span>
+            </div>
+          {/if}
+          <div class="flex items-center justify-between">
+            <h2 class="text-[10px] font-bold uppercase tracking-widest text-muted">Assembled prompt</h2>
+            {#if previewTotalTokens > 0}
+              <span class="text-[10px] font-mono text-foreground/40 tabular-nums">{previewTotalTokens.toLocaleString()} tokens · {previewTotalBytes.toLocaleString()} bytes</span>
+            {/if}
+          </div>
+          {#if assembled}
+            <div class="rounded border border-border/50 bg-bg1 p-4 prompt-md">
+              <MarkdownMessage value={assembled} tone="assistant" />
+            </div>
+          {:else}
+            <!-- Fall back to per-section content blocks -->
+            <div class="space-y-3">
+              {#each orderedSections as section (section.id)}
+                {#if firstCacheableId === section.id}
+                  <div class="flex items-center gap-2 py-1" role="separator">
+                    <span class="flex-1 border-t border-dashed border-amber-500/40"></span>
+                    <span class="text-[9px] uppercase tracking-widest text-amber-400/70 font-mono">⚡ cacheable boundary</span>
+                    <span class="flex-1 border-t border-dashed border-amber-500/40"></span>
+                  </div>
+                {/if}
+                <div
+                  id="assembled-section-{section.id}"
+                  class="rounded border bg-bg1 p-3 scroll-mt-4 transition-colors
+                    {selectedSectionId === section.id ? 'border-accent/60' : 'border-border/50'}
+                    {section.disabled ? 'opacity-40' : ''}"
+                >
+                  <div class="flex items-center gap-2 mb-1.5">
+                    <span class="w-1.5 h-1.5 rounded-full shrink-0" style:background-color={LAYER_META[section.layer]?.color ?? '#6b7280'}></span>
+                    <span class="text-[10px] font-bold uppercase tracking-wide text-muted flex-1">{section.label}</span>
+                    {#if section.cacheable}<span class="text-[10px] text-amber-400" title="Cacheable">⚡</span>{/if}
+                  </div>
+                  {#if section.content}
+                    <div class="prompt-md text-[11px]">
+                      <MarkdownMessage value={section.content} tone="assistant" />
+                    </div>
+                  {:else}
+                    <p class="text-[11px] text-muted italic">— no rendered content available</p>
+                  {/if}
+                </div>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {/if}
+
+      <!-- Inspector slide-over -->
+      {#if report && (selectedSection || (selectedSectionId === '__stage__' && groupMode === 'pipeline'))}
+        <button
+          type="button"
+          class="absolute inset-0 z-10 bg-transparent cursor-default"
+          aria-label="Close inspector"
+          onclick={closeInspector}
+        ></button>
+        <aside
+          class="absolute right-0 top-0 bottom-0 z-20 w-[320px] max-w-[85%] bg-bg2 border-l border-border shadow-2xl overflow-y-auto prompt-slideover"
+        >
+          <div class="sticky top-0 z-10 flex items-center justify-between px-3 py-2 border-b border-border bg-bg2">
+            <span class="text-[10px] font-bold uppercase tracking-widest text-muted">Inspector</span>
+            <button
+              type="button"
+              class="text-muted hover:text-foreground transition-colors cursor-pointer text-sm leading-none px-1"
+              onclick={closeInspector}
+              aria-label="Close"
+            >
+              ✕
+            </button>
+          </div>
+          {#if selectedSectionId === '__stage__' && groupMode === 'pipeline'}
+            <ClassicDetail {activeStep} {report} {totalChars} />
+          {:else if selectedSection && report}
+            <SectionDetail
+              currentSection={selectedSection}
+              {report}
+              layerMeta={LAYER_META}
+              {totalChars}
+              bind:contentViewMode
+              onOpenEditor={() => (editorOpen = true)}
+              onToggleDisabled={onToggleSection}
+            />
+          {/if}
+        </aside>
       {/if}
     </div>
   </div>
 </div>
 
-{#if currentSectionTop && (currentSectionTop.source === 'static' || currentSectionTop.source === 'file')}
+{#if selectedSection && (selectedSection.source === 'static' || selectedSection.source === 'file')}
   <SectionProseEditor
     bind:open={editorOpen}
     {agentId}
-    layer={currentSectionTop.layer as 'platform' | 'agent-type' | 'identity' | 'user' | 'session'}
-    sectionId={currentSectionTop.id}
-    sectionLabel={currentSectionTop.label}
-    mode={currentSectionTop.source === 'file' ? 'fileInspector' : 'prose'}
+    layer={selectedSection.layer as 'platform' | 'agent-type' | 'identity' | 'user' | 'session'}
+    sectionId={selectedSection.id}
+    sectionLabel={selectedSection.label}
+    mode={selectedSection.source === 'file' ? 'fileInspector' : 'prose'}
     onSaved={() => {
       void refreshReportSilently();
     }}
   />
 {/if}
+
+<style>
+  .prompt-slideover {
+    animation: slide-in 200ms ease-out;
+  }
+  @keyframes slide-in {
+    from {
+      transform: translateX(100%);
+    }
+    to {
+      transform: translateX(0);
+    }
+  }
+</style>

--- a/src/lib/components/agents/_agent-prompt-simulator/ContextWindowBar.svelte
+++ b/src/lib/components/agents/_agent-prompt-simulator/ContextWindowBar.svelte
@@ -5,11 +5,23 @@
     segments,
     contextWindowChars,
     totalUsedChars,
+    cachedPct = 0,
+    onToggleRail,
   }: {
     segments: BarSegment[];
     contextWindowChars: number;
     totalUsedChars: number;
+    /** Whole-prompt cacheable ratio (0–1). */
+    cachedPct?: number;
+    /** When provided, renders a rail-drawer toggle (narrow viewports). */
+    onToggleRail?: () => void;
   } = $props();
+
+  const usedRatio = $derived(
+    contextWindowChars > 0 ? totalUsedChars / contextWindowChars : 0,
+  );
+  const overBudget = $derived(usedRatio >= 0.8);
+  const cachedLabel = $derived(`${Math.round(cachedPct * 100)}%`);
 
   function fmtContextPct(chars: number): string {
     if (!contextWindowChars) return '';
@@ -19,11 +31,15 @@
 
 <div class="shrink-0 border-b border-border bg-bg2 px-3 pt-2 pb-2 space-y-1.5">
   <!-- Stacked bar -->
-  <div class="relative h-2.5 bg-bg1 rounded-sm overflow-hidden border border-border/40 flex">
+  <div
+    class="relative h-2.5 rounded-sm overflow-hidden border flex
+      {overBudget ? 'bg-amber-500/10 border-amber-500/40' : 'bg-bg1 border-border/40'}"
+  >
     {#each segments as seg (seg.label)}
       <div
         class="h-full shrink-0 transition-all duration-300"
-        style:background-color={seg.color}
+        style:background-color={overBudget ? '#f59e0b' : seg.color}
+        style:opacity={overBudget ? '0.85' : '1'}
         style:width="{((seg.chars / contextWindowChars) * 100).toFixed(2)}%"
       ></div>
     {/each}
@@ -32,6 +48,17 @@
   <!-- Legend row -->
   <div class="flex items-center justify-between gap-2">
     <div class="flex items-center gap-3 min-w-0 flex-wrap">
+      {#if onToggleRail}
+        <button
+          type="button"
+          class="lg:hidden shrink-0 text-[10px] px-1.5 py-0.5 rounded border border-border text-muted hover:text-foreground transition-colors cursor-pointer"
+          onclick={onToggleRail}
+          title="Toggle sections"
+          aria-label="Toggle sections rail"
+        >
+          ☰ Sections
+        </button>
+      {/if}
       {#each segments as seg (seg.label)}
         <span class="flex items-center gap-1">
           <span class="w-2 h-2 rounded-sm shrink-0" style:background-color={seg.color}></span>
@@ -40,9 +67,25 @@
         </span>
       {/each}
     </div>
-    <span class="shrink-0 text-[10px] font-mono text-muted whitespace-nowrap">
-      {fmtChars(totalUsedChars)} / {fmtChars(contextWindowChars)}
-      <span class="text-foreground/60">&middot; {fmtContextPct(totalUsedChars)}</span>
-    </span>
+    <div class="flex items-center gap-3 shrink-0">
+      <span
+        class="text-[10px] font-mono whitespace-nowrap"
+        class:text-amber-400={cachedPct > 0}
+        class:text-muted={cachedPct === 0}
+        title="Share of the prompt that is cacheable"
+      >
+        ⚡ {cachedLabel} cached
+      </span>
+      <span
+        class="text-[10px] font-mono whitespace-nowrap"
+        class:text-amber-400={overBudget}
+        class:text-muted={!overBudget}
+      >
+        {fmtChars(totalUsedChars)} / {fmtChars(contextWindowChars)}
+        <span class:text-amber-400={overBudget} class:text-foreground={!overBudget} class="opacity-70"
+          >&middot; {fmtContextPct(totalUsedChars)}</span
+        >
+      </span>
+    </div>
   </div>
 </div>

--- a/src/lib/components/agents/_agent-prompt-simulator/PipelineSidebar.svelte
+++ b/src/lib/components/agents/_agent-prompt-simulator/PipelineSidebar.svelte
@@ -1,99 +1,154 @@
 <script lang="ts">
   import * as m from '$lib/paraglide/messages';
   import {
-    fmtChars,
+    fmtSize,
+    orderBand,
+    sortSections,
     stepIconFor,
     stepStatusClassFor,
+    type GroupMode,
     type PipelineStep,
     type SectionEntry,
+    type SortMode,
     type StepStatus,
   } from './types';
 
   let {
-    viewMode,
+    groupMode = $bindable(),
+    sortMode = $bindable(),
+    viewContext,
     hasSections,
-    activeStep,
+    selectedSectionId,
     layerMeta,
-    activeSections,
-    currentSteps,
+    sections,
     classicSteps,
+    activeStep,
     stepStatus,
     testPrompt = $bindable(),
     testing,
     loading,
-    onToggleViewMode,
+    disabledIds,
+    totalCount,
+    onSelectSection,
     onSelectStep,
+    onToggleSection,
     onRunTest,
     onRefresh,
   }: {
-    viewMode: 'sections' | 'classic';
+    groupMode: GroupMode;
+    sortMode: SortMode;
+    viewContext: 'inspect' | 'simulate';
     hasSections: boolean;
-    activeStep: number;
+    selectedSectionId: string | null;
     layerMeta: Record<string, { label: string; color: string; description: string }>;
-    activeSections: SectionEntry[];
-    currentSteps: PipelineStep[];
+    /** All sections (enriched), already filtered to the visible set. */
+    sections: SectionEntry[];
     classicSteps: Array<{ id: string; label: string }>;
+    activeStep: number;
     stepStatus: Record<string, StepStatus>;
     testPrompt: string;
     testing: boolean;
     loading: boolean;
-    onToggleViewMode: () => void;
+    disabledIds: Set<string>;
+    /** Total section count (for the "n / m" fraction when filtered). */
+    totalCount: number;
+    onSelectSection: (id: string) => void;
     onSelectStep: (idx: number) => void;
+    onToggleSection: (id: string, disabled: boolean) => void;
     onRunTest: () => void;
     onRefresh: () => void;
   } = $props();
+
+  const GROUPS: Array<{ id: GroupMode; label: string }> = [
+    { id: 'layer', label: 'Layer' },
+    { id: 'none', label: 'None' },
+    { id: 'pipeline', label: 'Pipeline' },
+  ];
+  const SORTS: Array<{ id: SortMode; label: string }> = [
+    { id: 'cached', label: 'Cached' },
+    { id: 'order', label: 'Order' },
+    { id: 'alpha', label: 'Alpha' },
+    { id: 'size', label: 'Size' },
+  ];
+
+  function sizeOf(s: SectionEntry): number {
+    return s.bytes ?? s.chars ?? 0;
+  }
+
+  // Sorted flat list (for Group=None) and per-layer groups (Group=Layer).
+  const sorted = $derived(sortSections(sections, sortMode));
+
+  const layerGroups = $derived.by(() => {
+    const out: Array<{ id: string; meta: { label: string; color: string }; rows: SectionEntry[] }> = [];
+    for (const [layerId, meta] of Object.entries(layerMeta)) {
+      const rows = sorted.filter((s) => s.layer === layerId);
+      if (rows.length > 0) out.push({ id: layerId, meta, rows });
+    }
+    // Catch any unknown layers not present in layerMeta.
+    const known = new Set(Object.keys(layerMeta));
+    const others = sorted.filter((s) => !known.has(s.layer));
+    if (others.length > 0) {
+      out.push({ id: '_other', meta: { label: 'Other', color: '#6b7280' }, rows: others });
+    }
+    return out;
+  });
+
+  const readBack = $derived(
+    `${sections.length === totalCount ? `${totalCount} sections` : `${sections.length} / ${totalCount}`} · ${groupMode} · ${sortMode}`,
+  );
+
+  function layerColor(layer: string): string {
+    return layerMeta[layer]?.color ?? '#6b7280';
+  }
+
+  function handleComposerKeydown(e: KeyboardEvent) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      e.preventDefault();
+      if (!testing && !loading && testPrompt.trim()) onRunTest();
+    }
+  }
 </script>
 
-<div class="w-[200px] shrink-0 border-r border-border bg-bg2 overflow-y-auto flex flex-col">
-  <div class="px-3 py-2 border-b border-border flex items-center justify-between">
-    <span class="text-[10px] font-bold uppercase tracking-widest text-muted">{m.prompt_pipeline()}</span>
-    {#if hasSections}
-      <button
-        type="button"
-        class="text-[9px] px-1.5 py-0.5 rounded border border-border text-muted hover:text-foreground transition-colors cursor-pointer"
-        onclick={onToggleViewMode}
-      >
-        {viewMode === 'sections' ? m.prompt_classic() : m.prompt_sections()}
-      </button>
-    {/if}
-  </div>
-
-  {#if viewMode === 'sections' && hasSections}
-    <!-- Sections view: grouped by layer -->
-    <div class="flex-1 py-1">
-      {#each Object.entries(layerMeta) as [layerId, meta] (layerId)}
-        {@const layerSections = activeSections.filter((s) => s.layer === layerId)}
-        {#if layerSections.length > 0}
-          <div class="px-3 pt-2 pb-0.5">
-            <span class="flex items-center gap-1.5">
-              <span class="w-1.5 h-1.5 rounded-full shrink-0" style:background-color={meta.color}></span>
-              <span class="text-[9px] font-bold uppercase tracking-widest text-muted">{meta.label}</span>
-            </span>
-          </div>
-          {#each layerSections as section (section.id)}
-            {@const stepIdx = currentSteps.findIndex((s) => s.id === section.id)}
+<div class="w-full h-full border-r border-border bg-bg2 overflow-y-auto flex flex-col">
+  <!-- Header: group / sort controls -->
+  <div class="shrink-0 px-3 py-2 border-b border-border space-y-1.5">
+    <div class="flex items-center gap-1.5">
+      <span class="text-[9px] font-bold uppercase tracking-wider text-muted shrink-0">Group</span>
+      <div class="flex rounded border border-border overflow-hidden">
+        {#each GROUPS as g (g.id)}
+          <button
+            type="button"
+            class="text-[9px] px-1.5 py-0.5 transition-colors cursor-pointer
+              {groupMode === g.id ? 'bg-accent/15 text-accent font-semibold' : 'text-muted hover:text-foreground'}"
+            onclick={() => (groupMode = g.id)}
+          >
+            {g.label}
+          </button>
+        {/each}
+      </div>
+    </div>
+    {#if groupMode !== 'pipeline'}
+      <div class="flex items-center gap-1.5">
+        <span class="text-[9px] font-bold uppercase tracking-wider text-muted shrink-0">Sort</span>
+        <div class="flex rounded border border-border overflow-hidden">
+          {#each SORTS as s (s.id)}
             <button
               type="button"
-              class="w-full flex items-center gap-2 px-3 py-1.5 text-left transition-colors cursor-pointer
-                {activeStep === stepIdx
-                ? 'bg-accent/10 border-l-2 border-accent text-foreground'
-                : 'border-l-2 border-transparent text-muted hover:text-foreground hover:bg-white/[0.03]'}"
-              onclick={() => onSelectStep(stepIdx)}
+              class="text-[9px] px-1.5 py-0.5 transition-colors cursor-pointer
+                {sortMode === s.id ? 'bg-accent/15 text-accent font-semibold' : 'text-muted hover:text-foreground'}"
+              onclick={() => (sortMode = s.id)}
             >
-              {#if stepStatus[section.id]}
-                <span class={`shrink-0 w-3 text-center text-[11px] font-mono ${stepStatusClassFor(stepStatus[section.id])}`}>
-                  {stepIconFor(stepStatus[section.id])}
-                </span>
-              {/if}
-              <span class="flex-1 min-w-0 text-[11px] truncate">{section.label}</span>
-              <span class="shrink-0 text-[9px] text-foreground/30 font-mono">{section.chars > 0 ? fmtChars(section.chars) : ''}</span>
+              {s.label}
             </button>
           {/each}
-        {/if}
-      {/each}
-    </div>
-  {:else}
-    <!-- Classic view -->
+        </div>
+      </div>
+    {/if}
+    <p class="text-[9px] text-foreground/40 font-mono lowercase">{readBack}</p>
+  </div>
+
+  {#if groupMode === 'pipeline'}
+    <!-- Pipeline view: numbered 9-stage list -->
     <div class="flex-1 py-1">
       {#each classicSteps as step, i (step.id)}
         <button
@@ -119,38 +174,132 @@
         </button>
       {/each}
     </div>
+  {:else if hasSections}
+    <div class="flex-1 py-1" role="listbox" aria-label="Prompt sections">
+      {#if groupMode === 'layer'}
+        {#each layerGroups as group (group.id)}
+          {@const groupChars = group.rows.reduce((a, s) => a + sizeOf(s), 0)}
+          <div class="px-3 pt-2 pb-0.5 flex items-center gap-1.5">
+            <span class="w-1.5 h-1.5 rounded-full shrink-0" style:background-color={group.meta.color}></span>
+            <span class="text-[9px] font-bold uppercase tracking-widest text-muted flex-1">{group.meta.label}</span>
+            <span class="text-[9px] font-mono text-foreground/30 tabular-nums">{fmtSize(groupChars)}</span>
+          </div>
+          {#each group.rows as section (section.id)}
+            {@render row(section)}
+          {/each}
+        {/each}
+      {:else}
+        <!-- Group=None: flat list; banded dividers when Sort=Order -->
+        {#each sorted as section, i (section.id)}
+          {#if sortMode === 'order' && (i === 0 || orderBand(sorted[i - 1].order) !== orderBand(section.order))}
+            <div class="px-3 pt-2 pb-0.5">
+              <span class="text-[9px] font-bold uppercase tracking-widest text-foreground/30 font-mono">order {orderBand(section.order)}</span>
+            </div>
+          {/if}
+          {@render row(section)}
+        {/each}
+      {/if}
+    </div>
+  {:else}
+    <div class="flex-1 flex items-center justify-center px-4 py-6 text-center text-[11px] text-muted">
+      No sections available.
+    </div>
   {/if}
 
-  <!-- Action buttons -->
+  <!-- Docked composer (Simulate) / session info (Inspect) -->
   <div class="shrink-0 px-3 py-2 border-t border-border space-y-1.5">
-    <!-- Phase D-0d: editable test prompt fed into the stepped playback -->
-    <label class="block">
-      <span class="block text-[9px] font-bold uppercase tracking-widest text-muted mb-1">
-        Test prompt
-      </span>
-      <textarea
-        bind:value={testPrompt}
-        rows="2"
-        class="w-full text-[11px] px-2 py-1.5 rounded border border-border bg-bg1 text-foreground placeholder:text-foreground/30 focus:outline-none focus:border-accent/60 resize-none font-mono"
-        placeholder="Enter a sample message…"
-        disabled={testing}
-      ></textarea>
-    </label>
-    <button
-      type="button"
-      class="w-full text-[10px] font-semibold px-2 py-1.5 rounded border border-accent/40 text-accent hover:bg-accent/10 transition-colors cursor-pointer disabled:opacity-40"
-      onclick={onRunTest}
-      disabled={testing || loading || !testPrompt.trim()}
-    >
-      {testing ? m.prompt_generating() : m.prompt_test()}
-    </button>
-    <button
-      type="button"
-      class="w-full text-[10px] font-semibold px-2 py-1 rounded border border-border text-muted hover:text-foreground hover:border-accent/50 transition-colors cursor-pointer"
-      onclick={onRefresh}
-      disabled={loading || testing}
-    >
-      {loading ? m.common_loading() : m.prompt_refresh()}
-    </button>
+    {#if viewContext === 'simulate'}
+      <p class="text-[8px] text-foreground/40 leading-tight">
+        Session-independent preview — the backend renders the current agent state; test text is
+        captured for the upcoming live stream.
+      </p>
+      <label class="block">
+        <span class="block text-[9px] font-bold uppercase tracking-widest text-muted mb-1">Simulate: test input</span>
+        <textarea
+          bind:value={testPrompt}
+          rows="2"
+          onkeydown={handleComposerKeydown}
+          class="w-full text-[11px] px-2 py-1.5 rounded border border-border bg-bg1 text-foreground placeholder:text-foreground/30 focus:outline-none focus:border-accent/60 focus:min-h-[80px] transition-[min-height] resize-none font-mono"
+          placeholder="Enter a sample message… (⌘↵ to run)"
+          disabled={testing}
+        ></textarea>
+      </label>
+      <button
+        type="button"
+        class="w-full text-[10px] font-semibold px-2 py-1.5 rounded border border-accent/40 text-accent hover:bg-accent/10 transition-colors cursor-pointer disabled:opacity-40"
+        onclick={onRunTest}
+        disabled={testing || loading || !testPrompt.trim()}
+      >
+        {testing ? m.prompt_generating() : '▶ Run ⌘↵'}
+      </button>
+    {:else}
+      <button
+        type="button"
+        class="w-full text-[10px] font-semibold px-2 py-1.5 rounded border border-border text-muted hover:text-foreground hover:border-accent/50 transition-colors cursor-pointer"
+        onclick={onRefresh}
+        disabled={loading || testing}
+      >
+        {loading ? m.common_loading() : m.prompt_refresh()}
+      </button>
+    {/if}
   </div>
 </div>
+
+{#snippet row(section: SectionEntry)}
+  {@const isSelected = selectedSectionId === section.id}
+  {@const isOff = disabledIds.has(section.id)}
+  <div
+    class="group/row relative w-full flex items-center gap-2 pr-2 pl-3 h-7 text-left transition-colors
+      {isSelected ? 'bg-accent/10 text-foreground' : 'text-muted hover:text-foreground hover:bg-white/[0.03]'}"
+    role="option"
+    aria-selected={isSelected}
+    style:border-left="2px solid {isOff ? '#f59e0b' : isSelected ? 'var(--color-accent, #38bdf8)' : `${layerColor(section.layer)}55`}"
+  >
+    <!-- Hover-reveal order gutter -->
+    <span class="shrink-0 w-7 text-[8px] font-mono text-foreground/25 opacity-0 group-hover/row:opacity-100 transition-opacity text-right">
+      {section.order}
+    </span>
+    <button
+      type="button"
+      class="flex-1 min-w-0 flex items-center gap-1.5 text-left cursor-pointer"
+      onclick={() => onSelectSection(section.id)}
+    >
+      <span class="flex-1 min-w-0 text-[11px] truncate {isOff ? 'line-through opacity-50' : ''}">{section.label}</span>
+      {#if isOff}
+        <span
+          class="shrink-0 text-[8px] font-semibold px-1 py-0.5 rounded bg-amber-500/15 text-amber-400 cursor-pointer hover:bg-amber-500/25"
+          role="button"
+          tabindex="0"
+          title="Re-enable this section"
+          onclick={(e) => {
+            e.stopPropagation();
+            onToggleSection(section.id, false);
+          }}
+          onkeydown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              e.stopPropagation();
+              onToggleSection(section.id, false);
+            }
+          }}
+        >overridden</span>
+      {/if}
+    </button>
+    <!-- Hover-reveal cacheable bolt -->
+    {#if section.cacheable}
+      <span class="shrink-0 text-[10px] text-amber-400 opacity-0 group-hover/row:opacity-100 transition-opacity" title="Cacheable">⚡</span>
+    {/if}
+    <span class="shrink-0 text-[9px] text-foreground/40 font-mono tabular-nums w-9 text-right">{fmtSize(sizeOf(section))}</span>
+    <!-- Hover-reveal on/off toggle -->
+    <button
+      type="button"
+      class="shrink-0 w-4 h-4 rounded flex items-center justify-center text-[9px] transition-opacity
+        {isOff ? 'opacity-100 text-amber-400' : 'opacity-0 group-hover/row:opacity-100 text-foreground/40 hover:text-foreground'}"
+      title={isOff ? 'Enable section' : 'Disable section'}
+      aria-label={isOff ? 'Enable section' : 'Disable section'}
+      onclick={() => onToggleSection(section.id, !isOff)}
+    >
+      {isOff ? '○' : '●'}
+    </button>
+  </div>
+{/snippet}

--- a/src/lib/components/agents/_agent-prompt-simulator/SectionDetail.svelte
+++ b/src/lib/components/agents/_agent-prompt-simulator/SectionDetail.svelte
@@ -15,6 +15,7 @@
     totalChars,
     contentViewMode = $bindable(),
     onOpenEditor,
+    onToggleDisabled,
   }: {
     currentSection: SectionEntry;
     report: SystemPromptReport;
@@ -22,6 +23,8 @@
     totalChars: number;
     contentViewMode: 'rendered' | 'raw';
     onOpenEditor: () => void;
+    /** Override controls: toggle this section on/off. */
+    onToggleDisabled?: (id: string, disabled: boolean) => void;
   } = $props();
 
   function barWidth(chars: number): string {
@@ -79,6 +82,33 @@
       {layerMeta[currentSection.layer]?.description ?? ''}
     </p>
 
+    {#if currentSection.disabled}
+      <div
+        class="mb-3 flex items-center gap-2 rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1.5"
+      >
+        <span class="text-[11px] text-amber-400 flex-1">This section is overridden off.</span>
+        {#if onToggleDisabled}
+          <button
+            type="button"
+            class="text-[10px] font-semibold px-2 py-0.5 rounded border border-amber-500/50 text-amber-300 hover:bg-amber-500/20 transition-colors cursor-pointer"
+            onclick={() => onToggleDisabled?.(currentSection.id, false)}
+          >
+            Reset
+          </button>
+        {/if}
+      </div>
+    {:else if onToggleDisabled}
+      <div class="mb-3">
+        <button
+          type="button"
+          class="text-[10px] font-semibold px-2 py-0.5 rounded border border-border text-muted hover:text-foreground hover:border-accent/50 transition-colors cursor-pointer"
+          onclick={() => onToggleDisabled?.(currentSection.id, true)}
+        >
+          Disable section
+        </button>
+      </div>
+    {/if}
+
     <!-- Section stats -->
     <div class="space-y-2">
       <div class="flex items-start gap-3 py-1.5 px-2 rounded bg-bg2 border border-border/50">
@@ -93,6 +123,26 @@
         <span class="shrink-0 w-20 text-[10px] font-bold uppercase tracking-wide text-muted">{m.prompt_sectionOrder()}</span>
         <span class="flex-1 min-w-0 text-[11px] text-foreground font-mono">{currentSection.order}</span>
       </div>
+      {#if currentSection.bytes !== undefined}
+        <div class="flex items-start gap-3 py-1.5 px-2 rounded bg-bg2 border border-border/50">
+          <span class="shrink-0 w-20 text-[10px] font-bold uppercase tracking-wide text-muted">Bytes</span>
+          <span class="flex-1 min-w-0 text-[11px] text-foreground font-mono">{currentSection.bytes.toLocaleString()}</span>
+        </div>
+      {/if}
+      {#if currentSection.tokens !== undefined}
+        <div class="flex items-start gap-3 py-1.5 px-2 rounded bg-bg2 border border-border/50">
+          <span class="shrink-0 w-20 text-[10px] font-bold uppercase tracking-wide text-muted">Tokens</span>
+          <span class="flex-1 min-w-0 text-[11px] text-foreground font-mono">{currentSection.tokens.toLocaleString()}</span>
+        </div>
+      {/if}
+      {#if currentSection.cacheable !== undefined}
+        <div class="flex items-start gap-3 py-1.5 px-2 rounded bg-bg2 border border-border/50">
+          <span class="shrink-0 w-20 text-[10px] font-bold uppercase tracking-wide text-muted">Cacheable</span>
+          <span class="flex-1 min-w-0 text-[11px] font-mono" class:text-amber-400={currentSection.cacheable} class:text-muted={!currentSection.cacheable}>
+            {currentSection.cacheable ? '⚡ yes' : 'no'}
+          </span>
+        </div>
+      {/if}
       <div class="flex items-start gap-3 py-1.5 px-2 rounded bg-bg2 border border-border/50">
         <span class="shrink-0 w-20 text-[10px] font-bold uppercase tracking-wide text-muted">{m.prompt_sectionWeight()}</span>
         <div class="flex-1 min-w-0 flex items-center gap-2">

--- a/src/lib/components/agents/_agent-prompt-simulator/types.test.ts
+++ b/src/lib/components/agents/_agent-prompt-simulator/types.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  cachedPct,
+  orderBand,
+  sortSections,
+  type SectionEntry,
+} from './types';
+
+function s(partial: Partial<SectionEntry> & { id: string }): SectionEntry {
+  return {
+    layer: 'platform',
+    label: partial.id,
+    chars: 0,
+    order: 0,
+    ...partial,
+  };
+}
+
+describe('cachedPct', () => {
+  it('returns 0 for an empty list', () => {
+    expect(cachedPct([])).toBe(0);
+  });
+
+  it('returns 0 when total size is zero', () => {
+    expect(cachedPct([s({ id: 'a', bytes: 0, cacheable: true })])).toBe(0);
+  });
+
+  it('computes cacheable bytes over total bytes', () => {
+    const list = [
+      s({ id: 'a', bytes: 100, cacheable: true }),
+      s({ id: 'b', bytes: 300, cacheable: false }),
+    ];
+    expect(cachedPct(list)).toBeCloseTo(0.25, 5);
+  });
+
+  it('falls back to chars when bytes are absent', () => {
+    const list = [
+      s({ id: 'a', chars: 50, cacheable: true }),
+      s({ id: 'b', chars: 50, cacheable: false }),
+    ];
+    expect(cachedPct(list)).toBeCloseTo(0.5, 5);
+  });
+});
+
+describe('sortSections', () => {
+  const list: SectionEntry[] = [
+    s({ id: 'a', label: 'Charlie', order: 300, bytes: 100, cacheable: false }),
+    s({ id: 'b', label: 'Alpha', order: 100, bytes: 400, cacheable: true }),
+    s({ id: 'c', label: 'Bravo', order: 200, bytes: 200, cacheable: false }),
+  ];
+
+  it('does not mutate the input', () => {
+    const before = list.map((x) => x.id);
+    sortSections(list, 'alpha');
+    expect(list.map((x) => x.id)).toEqual(before);
+  });
+
+  it('sorts by order ascending', () => {
+    expect(sortSections(list, 'order').map((x) => x.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('sorts cacheable first then by order', () => {
+    expect(sortSections(list, 'cached').map((x) => x.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('sorts alphabetically by label', () => {
+    expect(sortSections(list, 'alpha').map((x) => x.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('sorts by size descending', () => {
+    expect(sortSections(list, 'size').map((x) => x.id)).toEqual(['b', 'c', 'a']);
+  });
+});
+
+describe('orderBand', () => {
+  it('bands low orders', () => {
+    expect(orderBand(0)).toBe('0–499');
+    expect(orderBand(499)).toBe('0–499');
+  });
+
+  it('bands mid orders', () => {
+    expect(orderBand(500)).toBe('500–999');
+    expect(orderBand(999)).toBe('500–999');
+  });
+
+  it('bands high orders', () => {
+    expect(orderBand(1000)).toBe('1000+');
+    expect(orderBand(5000)).toBe('1000+');
+  });
+});

--- a/src/lib/components/agents/_agent-prompt-simulator/types.ts
+++ b/src/lib/components/agents/_agent-prompt-simulator/types.ts
@@ -42,6 +42,88 @@ export interface SectionEntry {
   content?: string;
   /** Phase D-0e/f: where this section's content originates. */
   source?: 'static' | 'file' | 'generated' | 'config' | 'custom';
+  /** Unified Prompt Tab: enriched from `prompt.sections.preview` breakdown. */
+  bytes?: number;
+  tokens?: number;
+  cacheable?: boolean;
+  /** True when an override has disabled this section. */
+  disabled?: boolean;
+}
+
+/**
+ * Phase 3: a single frame from the `prompt.sections.preview.event` stream.
+ * `start` is emitted once first (with the total section count); each `section`
+ * frame carries one rendered section breakdown row, in assembly order.
+ */
+export interface PreviewStreamEvent {
+  previewId: string;
+  kind: 'start' | 'section';
+  /** Total number of sections that will be streamed. */
+  total: number;
+  /** 0-based index of this section (only on `kind: 'section'`). */
+  index?: number;
+  /** The rendered section breakdown (only on `kind: 'section'`). */
+  section?: {
+    id: string;
+    layer: string;
+    order: number;
+    source: 'static' | 'file' | 'generated' | 'config' | 'custom' | 'builtin';
+    bytes: number;
+    tokens: number;
+    cacheable: boolean;
+    rendered: string;
+  };
+}
+
+/** How the sections rail groups rows. `pipeline` is the legacy classic view. */
+export type GroupMode = 'layer' | 'none' | 'pipeline';
+
+/** How the sections rail sorts rows within a group. */
+export type SortMode = 'order' | 'cached' | 'alpha' | 'size';
+
+/** Whole-prompt cacheable ratio (0–1). Uses bytes, falls back to chars. */
+export function cachedPct(sections: SectionEntry[]): number {
+  let total = 0;
+  let cached = 0;
+  for (const s of sections) {
+    const size = s.bytes ?? s.chars ?? 0;
+    total += size;
+    if (s.cacheable) cached += size;
+  }
+  if (total <= 0) return 0;
+  return cached / total;
+}
+
+/** Pure sort — returns a new array, never mutates the input. */
+export function sortSections(list: SectionEntry[], sort: SortMode): SectionEntry[] {
+  const copy = [...list];
+  switch (sort) {
+    case 'order':
+      copy.sort((a, b) => a.order - b.order);
+      break;
+    case 'cached':
+      copy.sort((a, b) => {
+        const ca = a.cacheable ? 0 : 1;
+        const cb = b.cacheable ? 0 : 1;
+        if (ca !== cb) return ca - cb;
+        return a.order - b.order;
+      });
+      break;
+    case 'alpha':
+      copy.sort((a, b) => a.label.localeCompare(b.label));
+      break;
+    case 'size':
+      copy.sort((a, b) => (b.bytes ?? b.chars ?? 0) - (a.bytes ?? a.chars ?? 0));
+      break;
+  }
+  return copy;
+}
+
+/** Banded divider label for the Group=None + Sort=Order view. */
+export function orderBand(order: number): string {
+  if (order < 500) return '0–499';
+  if (order < 1000) return '500–999';
+  return '1000+';
 }
 
 export interface SystemPromptReport {
@@ -121,6 +203,12 @@ export const SOURCE_META: Record<
 export function fmtChars(n: number): string {
   if (n >= 1000) return `${(n / 1000).toFixed(1)}k chars`;
   return `${n} chars`;
+}
+
+/** Compact size label for tier-1 rows (no unit suffix, tabular). */
+export function fmtSize(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return `${n}`;
 }
 
 export function fmtDate(ms?: number): string {

--- a/src/lib/services/gateway.svelte.ts
+++ b/src/lib/services/gateway.svelte.ts
@@ -513,6 +513,17 @@ function handleEvent(evt: Record<string, unknown>) {
         window.dispatchEvent(new CustomEvent('flows.run.event', { detail: evt.payload }));
       }
       break;
+    case 'prompt.sections.preview.event':
+      // Phase 3: progressive per-section reveal for the /agents Prompt tab.
+      // Must be handled here explicitly — the generic `prompt.section.*`
+      // default branch below collapses payloads into `prompt.sections.changed`,
+      // which would drop the per-section breakdown this stream carries.
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(
+          new CustomEvent('prompt.sections.preview.event', { detail: evt.payload }),
+        );
+      }
+      break;
     case 'pi-agent.run-start':
     case 'pi-agent.run-end':
     case 'pi-agent.tool-call':

--- a/src/lib/services/prompt-sections-rpc.ts
+++ b/src/lib/services/prompt-sections-rpc.ts
@@ -154,6 +154,28 @@ export async function previewSections(
   }
 }
 
+/**
+ * Phase 3: streaming variant of {@link previewSections}. Issues
+ * `prompt.sections.preview.stream`; the gateway emits per-section
+ * `prompt.sections.preview.event` frames (forwarded as a window CustomEvent by
+ * the gateway service) *before* this promise resolves with the authoritative
+ * final {@link PreviewResponse}. Callers subscribe to the window event for the
+ * progressive build and use this return value as the source of truth.
+ */
+export async function previewSectionsStream(
+  agentId: string,
+  mode: PromptMode,
+  testInput?: string,
+): Promise<PreviewResponse> {
+  const params: Record<string, unknown> = { agentId, mode };
+  if (testInput) params.testInput = testInput;
+  try {
+    return (await sendRequest("prompt.sections.preview.stream", params)) as PreviewResponse;
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
 export async function getOverrides(agentId: string): Promise<OverridesGetResponse> {
   try {
     const res = (await sendRequest("prompt.sections.overrides.get", { agentId })) as


### PR DESCRIPTION
Merges the standalone /prompt inspector into the /agents Prompt tab.

- Real per-section bytes/tokens/cacheability + assembled view + section isolation, alongside ad-hoc prompt testing.
- Group-by (Layer/None/Pipeline) + Sort-by (Cached/Order/Alpha/Size).
- Removed the fake step-animation spinner.
- Graceful fallback: Simulate catches the gateway `unknown method: prompt.sections.preview.stream` rejection and falls back to non-streaming `previewSections`, so it works against the current prod gateway today and auto-upgrades once the gateway ships the stream RPC.

check 0/0, test 570/570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)