### PR TITLE
ci: generate Svelte inputs before checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Generate Svelte environment and translations
+        run: |
+          cp .env.example .env
+          bun run i18n:compile
+
       - name: Svelte check + typecheck
         run: bun run check
 


### PR DESCRIPTION
Generate Paraglide output and Svelte environment declarations before `bun run check`, matching the local and Vercel build prerequisites.