### PR TITLE
ci: declare static PostHog public env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,8 @@ HUB_BASE_URL=https://hub.minion-ai.org
 # src/lib/state/gateway/agent-org.ts (client-side, must be PUBLIC_-prefixed).
 # Defaults to 'faces-sculptors'.
 PUBLIC_DEFAULT_ORG_SLUG=faces-sculptors
+PUBLIC_POSTHOG_KEY=
+PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
 # Workforce backend base URL (canonical name; PAPERCLIP_INTERNAL_URL is a
 # compat fallback during the paperclip→workforce rename). Defaults to


### PR DESCRIPTION
Adds the statically imported PostHog public variables to the checked-in environment template so SvelteKit can generate their exports during CI.\n\nValidated locally with the exact CI setup followed by bun run check.