### PR TITLE
ci: format changed Hub files incrementally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -28,8 +30,18 @@ jobs:
       - name: Svelte check + typecheck
         run: bun run check
 
-      - name: Prettier check
-        run: bun run format:check
+      - name: Prettier check (changed files)
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          if [[ -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]]; then
+            BASE_SHA="$(git rev-parse HEAD^)"
+          fi
+          mapfile -d '' files < <(git diff -z --name-only --diff-filter=ACMR "$BASE_SHA" "$GITHUB_SHA" -- \
+            '*.css' '*.js' '*.json' '*.md' '*.svelte' '*.ts' '*.yaml' '*.yml')
+          if (( ${#files[@]} > 0 )); then
+            bunx prettier --plugin=prettier-plugin-svelte --check -- "${files[@]}"
+          fi
 
       - name: Build
         run: bun run build

--- a/bun.lock
+++ b/bun.lock
@@ -110,6 +110,7 @@
         "d3-force": "^3.0.0",
         "happy-dom": "^15.11.7",
         "prettier": "^3.9.4",
+        "prettier-plugin-svelte": "^4.1.1",
         "svelte": "^5.56.4",
         "svelte-check": "^4.7.2",
         "typescript": "^5.9.3",
@@ -1502,6 +1503,8 @@
     "preact": ["preact@10.29.7", "", { "peerDependencies": { "preact-render-to-string": ">=5" }, "optionalPeers": ["preact-render-to-string"] }, "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q=="],
 
     "prettier": ["prettier@3.9.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg=="],
+
+    "prettier-plugin-svelte": ["prettier-plugin-svelte@4.1.1", "", { "peerDependencies": { "prettier": "^3.0.0", "svelte": "^5.0.0" } }, "sha512-wXvbXMjSvb4C9ENWTHXyd+ihakKCsJ6rJhLP6/8HFNj4GkZr48jqL9PoKsl2sk7SyCZRTnJ7O2TTowUpOxP/KA=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "d3-force": "^3.0.0",
     "happy-dom": "^15.11.7",
     "prettier": "^3.9.4",
+    "prettier-plugin-svelte": "^4.1.1",
     "svelte": "^5.56.4",
     "svelte-check": "^4.7.2",
     "typescript": "^5.9.3",

--- a/src/lib/components/settings/GatewayUpdateCard.svelte
+++ b/src/lib/components/settings/GatewayUpdateCard.svelte
@@ -285,7 +285,9 @@
   const notifyTargets = $derived(
     (getField('update.notify') as { channel: string; to: string }[] | undefined) ?? [],
   );
-  const installBusy = $derived(starting || running || !!job?.active || restartState.phase === 'restarting');
+  const installBusy = $derived(
+    starting || running || !!job?.active || restartState.phase === 'restarting',
+  );
 
   const PROGRESS_LABELS: Record<string, () => string> = {
     migrating: m.gateway_update_phase_migrating,
@@ -322,7 +324,9 @@
   <div class="relative px-4 py-3 border-b border-border bg-bg/60 flex items-center gap-2">
     <ScanLine speed={10} opacity={0.02} />
     <PackageCheck size={12} class="text-muted-strong" />
-    <span class="text-[10px] font-mono text-muted uppercase tracking-widest">{m.gateway_update_title()}</span>
+    <span class="text-[10px] font-mono text-muted uppercase tracking-widest"
+      >{m.gateway_update_title()}</span
+    >
   </div>
 
   <div class="p-4 space-y-3">
@@ -358,7 +362,8 @@
               <Download size={12} />
               {installBusy
                 ? m.gateway_update_installing()
-                : updateState.targetSource === 'external-image' || updateState.targetSource === 'mixed'
+                : updateState.targetSource === 'external-image' ||
+                    updateState.targetSource === 'mixed'
                   ? m.gateway_update_rolloutImage()
                   : m.gateway_update_installAndRestart()}
             </button>
@@ -377,7 +382,9 @@
             v{updateState.pending.version}
           </div>
           {#if updateState.pending.notes}
-            <p class="text-xs text-muted-foreground mt-1 whitespace-pre-line">{updateState.pending.notes}</p>
+            <p class="text-xs text-muted-foreground mt-1 whitespace-pre-line">
+              {updateState.pending.notes}
+            </p>
           {/if}
         </div>
       {/if}
@@ -393,7 +400,8 @@
                 onclick={abortFleet}
                 class="flex items-center gap-1 px-2 py-1 rounded border text-[10px] font-mono bg-bg border-border text-muted hover:text-destructive"
               >
-                <Square size={10} /> {m.fleet_update_abort()}
+                <Square size={10} />
+                {m.fleet_update_abort()}
               </button>
             {/if}
           </div>
@@ -402,7 +410,9 @@
             {#each job.instances as inst (inst.gatewayId)}
               {@const rowConnected = conn.connected && connectedUrl === inst.url}
               {@const rowBusy =
-                inst.state === 'draining' || inst.state === 'updating' || inst.state === 'verifying'}
+                inst.state === 'draining' ||
+                inst.state === 'updating' ||
+                inst.state === 'verifying'}
               <li class="text-xs px-2 py-1.5 rounded border border-border/60 bg-bg/40 space-y-1">
                 <div class="flex items-center justify-between gap-2">
                   <span class="font-mono truncate">
@@ -413,7 +423,11 @@
                         : m.fleet_update_connections({ count: inst.connections })}</span
                     >
                   </span>
-                  <span class="shrink-0 px-1.5 py-0.5 rounded-full text-[10px] font-medium {STATE_CLASS[inst.state]}">
+                  <span
+                    class="shrink-0 px-1.5 py-0.5 rounded-full text-[10px] font-medium {STATE_CLASS[
+                      inst.state
+                    ]}"
+                  >
                     {STATE_LABELS[inst.state]()}
                   </span>
                 </div>
@@ -451,7 +465,8 @@
                       aria-label={label}
                     >
                       <div
-                        class="h-full rounded-full transition-[width] duration-500 ease-out {pct >= 100
+                        class="h-full rounded-full transition-[width] duration-500 ease-out {pct >=
+                        100
                           ? 'bg-success'
                           : 'bg-accent'}"
                         style="width: {pct}%"
@@ -478,7 +493,8 @@
                 disabled={starting}
                 class="shrink-0 flex items-center gap-1 px-2 py-1 rounded border text-[10px] font-mono bg-accent/20 border-accent/30 text-accent hover:bg-accent/30 disabled:opacity-50"
               >
-                <RotateCw size={10} class={starting ? 'animate-spin' : ''} /> {m.fleet_update_retry()}
+                <RotateCw size={10} class={starting ? 'animate-spin' : ''} />
+                {m.fleet_update_retry()}
               </button>
             </div>
           {/if}
@@ -490,16 +506,27 @@
            orchestrator's verify timed out but a later manual/retried install
            landed it) — suppress the scare line rather than contradict reality. -->
       {#if updateState.lastResult && !(updateState.lastResult.ok === false && updateState.lastResult.to === currentVersion)}
-        <p class="text-xs {updateState.lastResult.ok ? 'text-muted-foreground' : 'text-destructive'} flex items-center gap-1.5">
+        <p
+          class="text-xs {updateState.lastResult.ok
+            ? 'text-muted-foreground'
+            : 'text-destructive'} flex items-center gap-1.5"
+        >
           {#if !updateState.lastResult.ok}<AlertTriangle size={12} />{/if}
           {updateState.lastResult.ok
-            ? m.gateway_update_lastResultOk({ from: updateState.lastResult.from, to: updateState.lastResult.to })
-            : m.gateway_update_lastResultFailed({ version: updateState.lastResult.rolledBackTo ?? updateState.lastResult.from })}
+            ? m.gateway_update_lastResultOk({
+                from: updateState.lastResult.from,
+                to: updateState.lastResult.to,
+              })
+            : m.gateway_update_lastResultFailed({
+                version: updateState.lastResult.rolledBackTo ?? updateState.lastResult.from,
+              })}
         </p>
       {/if}
 
       <div class="pt-2 border-t border-border/60">
-        <div class="text-[10px] font-mono text-muted uppercase tracking-widest mb-1">{m.gateway_update_notifyTargets()}</div>
+        <div class="text-[10px] font-mono text-muted uppercase tracking-widest mb-1">
+          {m.gateway_update_notifyTargets()}
+        </div>
         {#if notifyTargets.length === 0}
           <p class="text-xs text-muted-strong">{m.gateway_update_notifyNone()}</p>
         {:else}
@@ -509,7 +536,9 @@
             {/each}
           </ul>
         {/if}
-        <a href="/config" class="text-[10px] text-accent hover:underline">{m.gateway_update_notifyEditHint()}</a>
+        <a href="/config" class="text-[10px] text-accent hover:underline"
+          >{m.gateway_update_notifyEditHint()}</a
+        >
       </div>
     {/if}
   </div>

--- a/src/lib/state/gateway/update-state.svelte.ts
+++ b/src/lib/state/gateway/update-state.svelte.ts
@@ -99,7 +99,8 @@ export function isUpdateRestartExpected(): boolean {
 export function bumpUpdateProgress(p: UpdateProgress): void {
   if (updateState.progress && p.pct < updateState.progress.pct) return;
   updateState.progress = p;
-  const tail = displayQueue.length > 0 ? displayQueue[displayQueue.length - 1] : updateState.display;
+  const tail =
+    displayQueue.length > 0 ? displayQueue[displayQueue.length - 1] : updateState.display;
   if (!updateState.display) {
     // First signal of this install — show immediately.
     displayQueue = [];

--- a/src/routes/api/gateway/fleet-update/+server.ts
+++ b/src/routes/api/gateway/fleet-update/+server.ts
@@ -29,7 +29,14 @@ export const POST: RequestHandler = async ({ locals, request }) => {
     switch (body.action) {
       case 'start': {
         if (!body.targetVersion) throw error(400, 'targetVersion is required');
-        return json(await startFleetUpdate(tenantId, user.id, body.targetVersion, body.targetSource ?? 'mixed'));
+        return json(
+          await startFleetUpdate(
+            tenantId,
+            user.id,
+            body.targetVersion,
+            body.targetSource ?? 'mixed',
+          ),
+        );
       }
       case 'advance': {
         const view = await advanceFleetUpdate(tenantId);

--- a/src/routes/api/gateway/update/+server.ts
+++ b/src/routes/api/gateway/update/+server.ts
@@ -19,7 +19,11 @@ export const GET: RequestHandler = async ({ locals }) => {
   const fleet = await getFleetUpdateAvailability();
   if (fleet) return json(fleet);
   const status = await gatewayCall('update.status', {});
-  return json({ ...(status as Record<string, unknown>), updateSource: 'package', targetSource: 'package' });
+  return json({
+    ...(status as Record<string, unknown>),
+    updateSource: 'package',
+    targetSource: 'package',
+  });
 };
 
 export const POST: RequestHandler = async ({ locals, request }) => {
@@ -29,7 +33,11 @@ export const POST: RequestHandler = async ({ locals, request }) => {
     const fleet = await getFleetUpdateAvailability(true);
     if (fleet) return json(fleet);
     const status = await gatewayCall('update.check', {});
-    return json({ ...(status as Record<string, unknown>), updateSource: 'package', targetSource: 'package' });
+    return json({
+      ...(status as Record<string, unknown>),
+      updateSource: 'package',
+      targetSource: 'package',
+    });
   }
   if (body.action === 'run') {
     // The gateway answers update.run only after the npm install completes,

--- a/src/server/services/fleet-update-controller.service.test.ts
+++ b/src/server/services/fleet-update-controller.service.test.ts
@@ -30,7 +30,9 @@ describe('resolveExternalImageTarget', () => {
           },
         }),
       )
-      .mockResolvedValueOnce(new Response(JSON.stringify({ token: 'registry-token' }), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: 'registry-token' }), { status: 200 }),
+      )
       .mockResolvedValueOnce(
         new Response(null, { status: 200, headers: { 'docker-content-digest': 'sha256:target' } }),
       );

--- a/src/server/services/fleet-update-controller.service.ts
+++ b/src/server/services/fleet-update-controller.service.ts
@@ -53,7 +53,8 @@ async function registryRequest(
   const challenge = response.headers.get('www-authenticate') ?? '';
   const realm = /realm="([^"]+)"/.exec(challenge)?.[1];
   if (!realm) return response;
-  if (realm !== 'https://ghcr.io/token') throw new Error('container registry returned an untrusted token realm');
+  if (realm !== 'https://ghcr.io/token')
+    throw new Error('container registry returned an untrusted token realm');
   const service = /service="([^"]+)"/.exec(challenge)?.[1];
   const scope = /scope="([^"]+)"/.exec(challenge)?.[1] ?? `repository:${repository}:pull`;
   const tokenUrl = new URL(realm);
@@ -62,15 +63,22 @@ async function registryRequest(
   const tokenHeaders: Record<string, string> = {};
   if (env.MINION_FLEET_UPDATE_REGISTRY_TOKEN) {
     const actor = env.MINION_FLEET_UPDATE_REGISTRY_USER;
-    if (!actor) throw new Error('container registry authentication requires MINION_FLEET_UPDATE_REGISTRY_USER');
+    if (!actor)
+      throw new Error(
+        'container registry authentication requires MINION_FLEET_UPDATE_REGISTRY_USER',
+      );
     tokenHeaders.authorization = `Basic ${Buffer.from(`${actor}:${env.MINION_FLEET_UPDATE_REGISTRY_TOKEN}`).toString('base64')}`;
   }
   const tokenResponse = await fetch(tokenUrl, { headers: tokenHeaders });
-  if (!tokenResponse.ok) throw new Error(`container registry token request failed (${tokenResponse.status})`);
+  if (!tokenResponse.ok)
+    throw new Error(`container registry token request failed (${tokenResponse.status})`);
   const tokenBody = (await tokenResponse.json()) as { token?: string; access_token?: string };
   const token = tokenBody.token ?? tokenBody.access_token;
   if (!token) throw new Error('container registry token response omitted token');
-  response = await fetch(url, { method: 'HEAD', headers: { ...headers, authorization: `Bearer ${token}` } });
+  response = await fetch(url, {
+    method: 'HEAD',
+    headers: { ...headers, authorization: `Bearer ${token}` },
+  });
   return response;
 }
 
@@ -80,7 +88,8 @@ export async function resolveExternalImageTarget(
   currentArtifacts: ImageArtifact[],
 ): Promise<ImageArtifact> {
   const image = env.MINION_FLEET_UPDATE_IMAGE;
-  if (!image) throw new Error('external image target resolution requires MINION_FLEET_UPDATE_IMAGE');
+  if (!image)
+    throw new Error('external image target resolution requires MINION_FLEET_UPDATE_IMAGE');
   const tag = env.MINION_FLEET_UPDATE_IMAGE_TAG || 'prd';
   const { registry, repository } = parseImage(image);
   if (registry !== 'ghcr.io') throw new Error('external image registry must be ghcr.io');
@@ -96,7 +105,8 @@ export async function resolveExternalImageTarget(
   const taggedImage = `${registry}/${repository}:${tag}`;
   const url = `https://${registry}/v2/${repository}/manifests/${encodeURIComponent(tag)}`;
   const response = await registryRequest(url, repository);
-  if (!response.ok) throw new Error(`container registry manifest resolution failed (${response.status})`);
+  if (!response.ok)
+    throw new Error(`container registry manifest resolution failed (${response.status})`);
   const digest = response.headers.get('docker-content-digest');
   if (!digest) throw new Error('container registry response omitted Docker-Content-Digest');
   return { image: taggedImage, digest };
@@ -169,7 +179,12 @@ export async function getExternalImageRolloutStatus(
   });
   if (!response.ok) throw new Error(`external image controller status failed (${response.status})`);
   const body = (await response.json()) as {
-    workflow_runs?: Array<{ display_title?: string; name?: string; status?: string; conclusion?: string | null }>;
+    workflow_runs?: Array<{
+      display_title?: string;
+      name?: string;
+      status?: string;
+      conclusion?: string | null;
+    }>;
   };
   const run = body.workflow_runs?.find(
     (candidate) =>

--- a/src/server/services/fleet-update.service.test.ts
+++ b/src/server/services/fleet-update.service.test.ts
@@ -103,15 +103,18 @@ vi.mock('$server/db/pg-schema/bg-jobs', () => ({
 }));
 
 vi.mock('drizzle-orm', () => ({
-  eq: (col: string, val: unknown) => (r: Row) => (r as unknown as Record<string, unknown>)[col] === val,
+  eq: (col: string, val: unknown) => (r: Row) =>
+    (r as unknown as Record<string, unknown>)[col] === val,
   and:
     (...fns: ((r: Row) => boolean)[]) =>
     (r: Row) =>
       fns.every((f) => f(r)),
   desc: (col: string) => col,
-  inArray: (col: string, vals: unknown[]) => (r: Row) => vals.includes((r as unknown as Record<string, unknown>)[col]),
+  inArray: (col: string, vals: unknown[]) => (r: Row) =>
+    vals.includes((r as unknown as Record<string, unknown>)[col]),
   isNull: (col: string) => (r: Row) => (r as unknown as Record<string, unknown>)[col] == null,
-  lt: (col: string, val: number) => (r: Row) => Number((r as unknown as Record<string, unknown>)[col]) < val,
+  lt: (col: string, val: number) => (r: Row) =>
+    Number((r as unknown as Record<string, unknown>)[col]) < val,
   or:
     (...fns: ((r: Row) => boolean)[]) =>
     (r: Row) =>
@@ -169,14 +172,20 @@ describe('getFleetUpdateAvailability', () => {
       { id: 'a', name: 'A', url: 'ws://a', authMode: 'token', createdAt: new Date() },
       { id: 'b', name: 'B', url: 'ws://b', authMode: 'token', createdAt: new Date() },
     ]);
-    mockGetCreds.mockImplementation(async (id: string) => ({ url: `ws://${id}`, token: `tok-${id}` }));
+    mockGetCreds.mockImplementation(async (id: string) => ({
+      url: `ws://${id}`,
+      token: `tok-${id}`,
+    }));
     mockCallToInstance.mockImplementation(async (url: string) => ({
       current: '2026.7.12-dev',
       runtime: {
         kind: 'container',
         updateStrategy: 'external-image',
         controllerId: 'swarm:prod/minion',
-        artifact: { image: 'ghcr.io/example/minion:prd', digest: url === 'ws://a' ? 'sha256:new' : 'sha256:old' },
+        artifact: {
+          image: 'ghcr.io/example/minion:prd',
+          digest: url === 'ws://a' ? 'sha256:new' : 'sha256:old',
+        },
       },
     }));
 
@@ -210,7 +219,10 @@ describe('getFleetUpdateAvailability', () => {
       { id: 'a', name: 'container', url: 'ws://a', authMode: 'token', createdAt: new Date() },
       { id: 'b', name: 'systemd', url: 'ws://b', authMode: 'token', createdAt: new Date() },
     ]);
-    mockGetCreds.mockImplementation(async (id: string) => ({ url: `ws://${id}`, token: `tok-${id}` }));
+    mockGetCreds.mockImplementation(async (id: string) => ({
+      url: `ws://${id}`,
+      token: `tok-${id}`,
+    }));
     mockCallToInstance.mockImplementation(async (url: string) =>
       url === 'ws://a'
         ? {
@@ -239,7 +251,10 @@ describe('startFleetUpdate', () => {
       { id: 'b', name: 'systemd-old', url: 'ws://b', authMode: 'token', createdAt: new Date(200) },
       { id: 'c', name: 'systemd-new', url: 'ws://c', authMode: 'token', createdAt: new Date(300) },
     ]);
-    mockGetCreds.mockImplementation(async (id: string) => ({ url: `ws://${id}`, token: `tok-${id}` }));
+    mockGetCreds.mockImplementation(async (id: string) => ({
+      url: `ws://${id}`,
+      token: `tok-${id}`,
+    }));
     mockCallToInstance.mockImplementation(async (url: string) =>
       url === 'ws://a'
         ? {
@@ -257,7 +272,11 @@ describe('startFleetUpdate', () => {
 
     const job = await startFleetUpdate(TENANT, 'user1', 'sha256:new', 'external-image');
     expect(job.targetSource).toBe('external-image');
-    expect(job.instances.filter((instance) => instance.updateSource === 'package').every((instance) => instance.state === 'done')).toBe(true);
+    expect(
+      job.instances
+        .filter((instance) => instance.updateSource === 'package')
+        .every((instance) => instance.state === 'done'),
+    ).toBe(true);
 
     mockDispatchExternal.mockRejectedValue(new Error('controller unavailable'));
     mockCallToInstance.mockClear();
@@ -272,7 +291,10 @@ describe('startFleetUpdate', () => {
       { id: 'a', name: 'container', url: 'ws://a', authMode: 'token', createdAt: new Date(100) },
       { id: 'b', name: 'systemd', url: 'ws://b', authMode: 'token', createdAt: new Date(200) },
     ]);
-    mockGetCreds.mockImplementation(async (id: string) => ({ url: `ws://${id}`, token: `tok-${id}` }));
+    mockGetCreds.mockImplementation(async (id: string) => ({
+      url: `ws://${id}`,
+      token: `tok-${id}`,
+    }));
     mockCallToInstance.mockImplementation(async (url: string) =>
       url === 'ws://a'
         ? {
@@ -297,7 +319,10 @@ describe('startFleetUpdate', () => {
       { id: 'a', name: 'minion-1', url: 'ws://a', authMode: 'token', createdAt: new Date(100) },
       { id: 'b', name: 'minion-2', url: 'ws://b', authMode: 'token', createdAt: new Date(200) },
     ]);
-    mockGetCreds.mockImplementation(async (id: string) => ({ url: `ws://${id}`, token: `tok-${id}` }));
+    mockGetCreds.mockImplementation(async (id: string) => ({
+      url: `ws://${id}`,
+      token: `tok-${id}`,
+    }));
     mockCallToInstance.mockResolvedValue({
       current: '2026.7.12-dev',
       connections: 0,
@@ -334,7 +359,11 @@ describe('startFleetUpdate', () => {
     mockCallToInstance.mockResolvedValue({
       current: 'old',
       connections: 0,
-      runtime: { kind: 'container', updateStrategy: 'external-image', artifact: { digest: 'sha256:old' } },
+      runtime: {
+        kind: 'container',
+        updateStrategy: 'external-image',
+        artifact: { digest: 'sha256:old' },
+      },
     });
 
     const job = await startFleetUpdate(TENANT, 'user1', '2.0.0');
@@ -348,7 +377,10 @@ describe('startFleetUpdate', () => {
       { id: 'b', name: 'B', url: 'ws://b', authMode: 'token', createdAt: new Date(100) },
       { id: 'c', name: 'C', url: 'ws://c', authMode: 'token', createdAt: new Date(300) },
     ]);
-    mockGetCreds.mockImplementation(async (id: string) => ({ url: `ws://${id}`, token: `tok-${id}` }));
+    mockGetCreds.mockImplementation(async (id: string) => ({
+      url: `ws://${id}`,
+      token: `tok-${id}`,
+    }));
     mockCallToInstance.mockImplementation(async (_url, _token, method, _params) => {
       if (method !== 'update.status') throw new Error('unexpected method');
       const conns: Record<string, number> = { a: 5, b: 5, c: 0 };
@@ -367,7 +399,10 @@ describe('startFleetUpdate', () => {
       { id: 'a', name: 'A', url: 'ws://a', authMode: 'token', createdAt: new Date(100) },
       { id: 'b', name: 'B', url: 'ws://b', authMode: 'token', createdAt: new Date(200) },
     ]);
-    mockGetCreds.mockImplementation(async (id: string) => ({ url: `ws://${id}`, token: `tok-${id}` }));
+    mockGetCreds.mockImplementation(async (id: string) => ({
+      url: `ws://${id}`,
+      token: `tok-${id}`,
+    }));
     mockCallToInstance.mockImplementation(async (url: string) => ({
       current: url === 'ws://a' ? '2.0.0' : '1.0.0',
       connections: 0,
@@ -388,7 +423,10 @@ describe('startFleetUpdate', () => {
       { id: 'a', name: 'A', url: 'ws://a', authMode: 'token', createdAt: new Date(100) },
       { id: 'b', name: 'B', url: 'ws://b', authMode: 'token', createdAt: new Date(200) },
     ]);
-    mockGetCreds.mockImplementation(async (id: string) => ({ url: `ws://${id}`, token: `tok-${id}` }));
+    mockGetCreds.mockImplementation(async (id: string) => ({
+      url: `ws://${id}`,
+      token: `tok-${id}`,
+    }));
     mockCallToInstance.mockResolvedValue({
       current: '2026.7.11-dev.20260711212523',
       connections: 0,
@@ -425,7 +463,9 @@ describe('startFleetUpdate', () => {
 
     expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
     expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
-    expect(rows.filter((row) => row.type === 'fleet_update' && row.status === 'running')).toHaveLength(1);
+    expect(
+      rows.filter((row) => row.type === 'fleet_update' && row.status === 'running'),
+    ).toHaveLength(1);
   });
 
   test('permits a new job once the prior one is terminal (failed/cancelled/done)', async () => {
@@ -449,7 +489,10 @@ describe('startFleetUpdate', () => {
       { id: 'a', name: 'A', url: 'ws://a', authMode: 'token', createdAt: new Date(100) },
       { id: 'b', name: 'B', url: 'ws://b', authMode: 'token', createdAt: new Date(200) },
     ]);
-    mockGetCreds.mockImplementation(async (id: string) => ({ url: `ws://${id}`, token: `tok-${id}` }));
+    mockGetCreds.mockImplementation(async (id: string) => ({
+      url: `ws://${id}`,
+      token: `tok-${id}`,
+    }));
     mockCallToInstance.mockImplementation(async (_url: string, token: string, method: string) => {
       if (method !== 'update.status') throw new Error('unexpected method');
       // 'a' is on an old build that never reports `connections` at all.
@@ -490,7 +533,10 @@ describe('advanceFleetUpdate', () => {
       { id: 'a', name: 'A', url: 'ws://a', authMode: 'token', createdAt: new Date(100) },
       { id: 'b', name: 'B', url: 'ws://b', authMode: 'token', createdAt: new Date(200) },
     ]);
-    mockGetCreds.mockImplementation(async (id: string) => ({ url: `ws://${id}`, token: `tok-${id}` }));
+    mockGetCreds.mockImplementation(async (id: string) => ({
+      url: `ws://${id}`,
+      token: `tok-${id}`,
+    }));
     mockCallToInstance.mockImplementation(async (_url, _token, method) => {
       if (method === 'update.status') return { current: '1.0.0', connections: 0 };
       return {};
@@ -526,7 +572,10 @@ describe('advanceFleetUpdate', () => {
       { id: 'a', name: 'minion-1', url: 'ws://a', authMode: 'token', createdAt: new Date(100) },
       { id: 'b', name: 'minion-2', url: 'ws://b', authMode: 'token', createdAt: new Date(200) },
     ]);
-    mockGetCreds.mockImplementation(async (id: string) => ({ url: `ws://${id}`, token: `tok-${id}` }));
+    mockGetCreds.mockImplementation(async (id: string) => ({
+      url: `ws://${id}`,
+      token: `tok-${id}`,
+    }));
     mockCallToInstance.mockResolvedValue({
       current: '2026.7.12-dev',
       connections: 0,
@@ -586,12 +635,16 @@ describe('advanceFleetUpdate', () => {
       await vi.advanceTimersByTimeAsync(0);
       const second = advanceFleetUpdate(TENANT);
       await vi.advanceTimersByTimeAsync(0);
-      expect(mockCallToInstance.mock.calls.filter((call) => call[2] === 'update.run')).toHaveLength(1);
+      expect(mockCallToInstance.mock.calls.filter((call) => call[2] === 'update.run')).toHaveLength(
+        1,
+      );
 
       releaseRun();
       await vi.advanceTimersByTimeAsync(5000);
       await Promise.all([first, second]);
-      expect(mockCallToInstance.mock.calls.filter((call) => call[2] === 'update.run')).toHaveLength(1);
+      expect(mockCallToInstance.mock.calls.filter((call) => call[2] === 'update.run')).toHaveLength(
+        1,
+      );
     } finally {
       vi.useRealTimers();
     }
@@ -834,7 +887,10 @@ describe('getFleetUpdateStatus', () => {
     expect(await getFleetUpdateStatus(TENANT)).toBeNull();
   });
 
-  function seedFailedJob(target: string, instances: { gatewayId: string; name: string; url: string }[]) {
+  function seedFailedJob(
+    target: string,
+    instances: { gatewayId: string; name: string; url: string }[],
+  ) {
     rows.push({
       id: 'ghost',
       tenantId: TENANT,
@@ -871,10 +927,12 @@ describe('getFleetUpdateStatus', () => {
       { gatewayId: 'a', name: 'minion-2', url: 'ws://a' },
       { gatewayId: 'b', name: 'minion-1', url: 'ws://b' },
     ]);
-    mockGetCreds.mockImplementation(async (id: string) => ({ url: `ws://${id}`, token: `tok-${id}` }));
+    mockGetCreds.mockImplementation(async (id: string) => ({
+      url: `ws://${id}`,
+      token: `tok-${id}`,
+    }));
     mockCallToInstance.mockImplementation(async (url: string) => ({
-      current:
-        url === 'ws://a' ? '2026.7.11-dev.20260711212523' : '2026.7.11-dev.20260711055010',
+      current: url === 'ws://a' ? '2026.7.11-dev.20260711212523' : '2026.7.11-dev.20260711055010',
     }));
 
     const view = await getFleetUpdateStatus(TENANT);
@@ -905,7 +963,10 @@ describe('getFleetUpdateStatus', () => {
       { gatewayId: 'a', name: 'minion-1', url: 'ws://a' },
       { gatewayId: 'b', name: 'minion-2', url: 'ws://b' },
     ]);
-    mockGetCreds.mockImplementation(async (id: string) => ({ url: `ws://${id}`, token: `tok-${id}` }));
+    mockGetCreds.mockImplementation(async (id: string) => ({
+      url: `ws://${id}`,
+      token: `tok-${id}`,
+    }));
     mockCallToInstance.mockResolvedValue({
       current: '2026.7.12-dev',
       runtime: {
@@ -916,7 +977,10 @@ describe('getFleetUpdateStatus', () => {
       },
     });
 
-    expect(await getFleetUpdateStatus(TENANT)).toMatchObject({ status: 'cancelled', active: false });
+    expect(await getFleetUpdateStatus(TENANT)).toMatchObject({
+      status: 'cancelled',
+      active: false,
+    });
   });
 
   test('does not retire when the only instance is unreachable (no confirmation)', async () => {

--- a/src/server/services/fleet-update.service.ts
+++ b/src/server/services/fleet-update.service.ts
@@ -44,12 +44,7 @@ const EXTERNAL_VERIFY_TIMEOUT_MS = 15 * 60_000;
 const ADVANCE_LEASE_MS = 10 * 60_000;
 
 export type FleetInstanceState =
-  | 'pending'
-  | 'draining'
-  | 'updating'
-  | 'verifying'
-  | 'done'
-  | 'failed';
+  'pending' | 'draining' | 'updating' | 'verifying' | 'done' | 'failed';
 
 export interface FleetInstance {
   gatewayId: string;
@@ -144,7 +139,11 @@ function normalizeUpdateSource(status: GatewayUpdateStatus): NormalizedUpdateSou
       artifact(raw?.currentArtifact) ??
       artifact(raw?.artifact) ??
       artifact(raw?.current) ??
-      artifact({ image: raw?.image, digest: raw?.digest ?? raw?.imageDigest, version: raw?.version }),
+      artifact({
+        image: raw?.image,
+        digest: raw?.digest ?? raw?.imageDigest,
+        version: raw?.version,
+      }),
     targetArtifact:
       artifact(raw?.targetArtifact) ??
       artifact(raw?.availableArtifact) ??
@@ -193,7 +192,9 @@ export interface FleetUpdateAvailability {
 /** Fleet-aware availability replaces the selected-gateway npm check for
  * externally managed deployments. It resolves each controller's mutable tag
  * to a digest and reports pending when any replica differs. */
-export async function getFleetUpdateAvailability(forceCheck = false): Promise<FleetUpdateAvailability | null> {
+export async function getFleetUpdateAvailability(
+  forceCheck = false,
+): Promise<FleetUpdateAvailability | null> {
   const rows = await listGatewaysForAdmin();
   const snapshots: Array<{
     status: GatewayUpdateStatus & { pending?: { version?: string } | null };
@@ -203,22 +204,14 @@ export async function getFleetUpdateAvailability(forceCheck = false): Promise<Fl
     const creds = await getGatewayCredentialsById(row.id);
     if (!creds) continue;
     try {
-      let status = await gatewayCallToInstance<GatewayUpdateStatus & { pending?: { version?: string } | null }>(
-        creds.url,
-        creds.token,
-        'update.status',
-        {},
-        { timeoutMs: 8000 },
-      );
+      let status = await gatewayCallToInstance<
+        GatewayUpdateStatus & { pending?: { version?: string } | null }
+      >(creds.url, creds.token, 'update.status', {}, { timeoutMs: 8000 });
       const source = normalizeUpdateSource(status);
       if (forceCheck && source.kind === 'package') {
-        status = await gatewayCallToInstance<GatewayUpdateStatus & { pending?: { version?: string } | null }>(
-          creds.url,
-          creds.token,
-          'update.check',
-          {},
-          { timeoutMs: 20_000 },
-        );
+        status = await gatewayCallToInstance<
+          GatewayUpdateStatus & { pending?: { version?: string } | null }
+        >(creds.url, creds.token, 'update.check', {}, { timeoutMs: 20_000 });
       }
       snapshots.push({ status, source });
     } catch {
@@ -234,17 +227,22 @@ export async function getFleetUpdateAvailability(forceCheck = false): Promise<Fl
   if (external.some((snapshot) => !snapshot.source.controllerId)) {
     throw new Error('external-image gateway did not advertise a stable controllerId');
   }
-  const controllerIds = new Set(external.map((snapshot) => snapshot.source.controllerId).filter(Boolean));
+  const controllerIds = new Set(
+    external.map((snapshot) => snapshot.source.controllerId).filter(Boolean),
+  );
   let imagePending = false;
   let targetArtifact: ImageArtifact | undefined;
   for (const controllerId of controllerIds) {
     const members = external.filter((snapshot) => snapshot.source.controllerId === controllerId);
     const target = await resolveExternalImageTarget(
       controllerId!,
-      members.flatMap((member) => (member.source.currentArtifact ? [member.source.currentArtifact] : [])),
+      members.flatMap((member) =>
+        member.source.currentArtifact ? [member.source.currentArtifact] : [],
+      ),
     );
     targetArtifact ??= target;
-    if (members.some((member) => member.source.currentArtifact?.digest !== target.digest)) imagePending = true;
+    if (members.some((member) => member.source.currentArtifact?.digest !== target.digest))
+      imagePending = true;
   }
   const packagePending = packages
     .map((snapshot) => snapshot.status.pending?.version)
@@ -256,14 +254,14 @@ export async function getFleetUpdateAvailability(forceCheck = false): Promise<Fl
     .map((snapshot) => snapshot.status.current)
     .find((version): version is string => typeof version === 'string' && version.length > 0);
   const version =
-    packagePending ?? packageCurrent ?? targetArtifact?.version ?? targetArtifact?.digest ?? 'latest-image';
+    packagePending ??
+    packageCurrent ??
+    targetArtifact?.version ??
+    targetArtifact?.digest ??
+    'latest-image';
   const packageIsPending = !!packagePending;
   const targetSource: FleetTargetSource =
-    imagePending && packageIsPending
-      ? 'mixed'
-      : imagePending
-        ? 'external-image'
-        : 'package';
+    imagePending && packageIsPending ? 'mixed' : imagePending ? 'external-image' : 'package';
   return {
     current: snapshots[0].status.current ?? external[0]?.source.currentArtifact?.version ?? null,
     pending:
@@ -316,8 +314,10 @@ function artifactReached(
 ): boolean {
   if (source.kind === 'package') return false;
   const current = source.currentArtifact;
-  if (targetArtifact?.digest) return current?.digest === targetArtifact.digest && source.healthy === true;
-  if (targetArtifact?.version) return current?.version === targetArtifact.version && source.healthy === true;
+  if (targetArtifact?.digest)
+    return current?.digest === targetArtifact.digest && source.healthy === true;
+  if (targetArtifact?.version)
+    return current?.version === targetArtifact.version && source.healthy === true;
   return current?.version === targetVersion && source.healthy === true;
 }
 
@@ -408,7 +408,11 @@ async function getActiveJobRow(tenantId: string) {
     .select()
     .from(bgJobs)
     .where(
-      and(eq(bgJobs.tenantId, tenantId), eq(bgJobs.type, JOB_TYPE), inArray(bgJobs.status, [...ACTIVE_STATUSES])),
+      and(
+        eq(bgJobs.tenantId, tenantId),
+        eq(bgJobs.type, JOB_TYPE),
+        inArray(bgJobs.status, [...ACTIVE_STATUSES]),
+      ),
     )
     .orderBy(desc(bgJobs.createdAt))
     .limit(1);
@@ -518,12 +522,12 @@ export async function startFleetUpdate(
         : s.source.kind === 'external-image' && targetSource === 'package'
           ? 'done'
           : s.source.kind === 'external-image'
-        ? artifactReached(s.source, s.source.targetArtifact, targetVersion)
-          ? 'done'
-          : 'pending'
-        : isAtOrPast(s.current, targetVersion)
-          ? 'done'
-          : 'pending',
+            ? artifactReached(s.source, s.source.targetArtifact, targetVersion)
+              ? 'done'
+              : 'pending'
+            : isAtOrPast(s.current, targetVersion)
+              ? 'done'
+              : 'pending',
     connections: s.connections,
     fromVersion: s.current,
     toVersion: targetVersion,
@@ -579,7 +583,11 @@ export async function startFleetUpdate(
       inst.state = 'failed';
       inst.error = 'could not determine update source while gateway unreachable';
     }
-    if (targetSource !== 'package' && inst.updateSource === 'external-image' && !inst.controllerId) {
+    if (
+      targetSource !== 'package' &&
+      inst.updateSource === 'external-image' &&
+      !inst.controllerId
+    ) {
       inst.state = 'failed';
       inst.error = 'gateway advertises external-image updates without a stable controllerId';
     }
@@ -623,7 +631,12 @@ export async function startFleetUpdate(
         type: JOB_TYPE,
         refId: null,
         status,
-        cursor: JSON.stringify({ targetVersion, targetSource, instances, currentIndex } satisfies FleetCursor),
+        cursor: JSON.stringify({
+          targetVersion,
+          targetSource,
+          instances,
+          currentIndex,
+        } satisfies FleetCursor),
         attempts: 0,
         createdAt: now,
         updatedAt: now,
@@ -808,7 +821,10 @@ async function runInstanceStep(
       if (isExplicitErrorResponse(msg)) return { ok: false, error: msg };
     }
   }
-  return { ok: false, error: `did not reach ${inst.toVersion} within ${VERIFY_TIMEOUT_MS / 1000}s` };
+  return {
+    ok: false,
+    error: `did not reach ${inst.toVersion} within ${VERIFY_TIMEOUT_MS / 1000}s`,
+  };
 }
 
 async function runExternalImageStep(
@@ -816,7 +832,8 @@ async function runExternalImageStep(
   persistNow: () => Promise<void>,
 ): Promise<{ ok: true } | { ok: false; error: string; pending?: boolean }> {
   const first = members[0]?.inst;
-  if (!first?.controllerId) return { ok: false, error: 'external-image rollout has no controllerId' };
+  if (!first?.controllerId)
+    return { ok: false, error: 'external-image rollout has no controllerId' };
 
   if (!first.rolloutStartedAt) {
     const startedAt = Date.now();
@@ -854,7 +871,10 @@ async function runExternalImageStep(
   if (!controllerStatus || controllerStatus.status !== 'completed') {
     await persistNow().catch(() => {});
     if (Date.now() - (first.rolloutStartedAt ?? Date.now()) >= EXTERNAL_VERIFY_TIMEOUT_MS) {
-      return { ok: false, error: `external image controller operation ${first.operationId} timed out` };
+      return {
+        ok: false,
+        error: `external image controller operation ${first.operationId} timed out`,
+      };
     }
     return { ok: false, pending: true, error: 'external image controller is still running' };
   }
@@ -958,11 +978,7 @@ export async function advanceFleetUpdate(tenantId: string): Promise<FleetJobView
         ...patch,
       })
       .where(
-        and(
-          eq(bgJobs.id, row.id),
-          eq(bgJobs.status, 'running'),
-          eq(bgJobs.leaseUntil, leaseUntil),
-        ),
+        and(eq(bgJobs.id, row.id), eq(bgJobs.status, 'running'), eq(bgJobs.leaseUntil, leaseUntil)),
       )
       .returning({ id: bgJobs.id });
     return updated.length === 1;
@@ -970,7 +986,10 @@ export async function advanceFleetUpdate(tenantId: string): Promise<FleetJobView
 
   const cursor = JSON.parse(row.cursor ?? '{}') as FleetCursor;
   // Skip any instances already on target (bookkeeping only — no RPC calls).
-  while (cursor.currentIndex < cursor.instances.length && cursor.instances[cursor.currentIndex].state === 'done') {
+  while (
+    cursor.currentIndex < cursor.instances.length &&
+    cursor.instances[cursor.currentIndex].state === 'done'
+  ) {
     cursor.currentIndex += 1;
   }
   if (cursor.currentIndex >= cursor.instances.length) {
@@ -994,7 +1013,11 @@ export async function advanceFleetUpdate(tenantId: string): Promise<FleetJobView
     if (!creds) {
       member.state = 'failed';
       member.error = 'gateway credentials not found';
-      await persistClaimed(cursor, { status: 'failed', error: member.error, finishedAt: Date.now() }, true);
+      await persistClaimed(
+        cursor,
+        { status: 'failed', error: member.error, finishedAt: Date.now() },
+        true,
+      );
       return getFleetUpdateStatus(tenantId);
     }
     membersWithCredentials.push({ inst: member, token: creds.token });
@@ -1019,7 +1042,11 @@ export async function advanceFleetUpdate(tenantId: string): Promise<FleetJobView
         member.error = result.error;
       }
     }
-    await persistClaimed(cursor, { status: 'failed', error: result.error, finishedAt: Date.now() }, true);
+    await persistClaimed(
+      cursor,
+      { status: 'failed', error: result.error, finishedAt: Date.now() },
+      true,
+    );
     return getFleetUpdateStatus(tenantId);
   }
 
@@ -1033,7 +1060,10 @@ export async function advanceFleetUpdate(tenantId: string): Promise<FleetJobView
     delete member.error;
   }
   do cursor.currentIndex += 1;
-  while (cursor.currentIndex < cursor.instances.length && cursor.instances[cursor.currentIndex].state === 'done');
+  while (
+    cursor.currentIndex < cursor.instances.length &&
+    cursor.instances[cursor.currentIndex].state === 'done'
+  );
   const done = cursor.currentIndex >= cursor.instances.length;
   await persistClaimed(cursor, done ? { status: 'done', finishedAt: Date.now() } : {}, true);
   return getFleetUpdateStatus(tenantId);


### PR DESCRIPTION
Makes the Prettier gate incremental so it checks the files in each push/PR instead of failing on 668 unrelated legacy files. Adds the Svelte formatter plugin and formats the runtime-aware updater diff.\n\nValidation: bun run check; 46 focused updater tests; changed-file Prettier check.