### PR TITLE
fix(db): bound and reuse Supabase connection pool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,10 @@ PUBLIC_AUTH_PROVIDER=supabase
 PUBLIC_SUPABASE_URL=https://gxvsaskbohavnurfvshr.supabase.co
 PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
+# Supabase transaction-pooler DSN (port 6543). Keep the per-process pool small
+# for Vercel/serverless; all Hub PG clients share this one bounded pool.
+SUPABASE_DB_URL=
+SUPABASE_DB_POOL_SIZE=5
 
 # LangGraph flow runner (langgraph-server) — used by the flow editor "Run" button
 PUBLIC_LANGGRAPH_FLOWS_URL=http://localhost:2025

--- a/src/lib/state/features/hosts.svelte.ts
+++ b/src/lib/state/features/hosts.svelte.ts
@@ -63,25 +63,34 @@ function readHostsCache(): Host[] {
  * a stale cached token.
  */
 export async function fetchHostToken(id: string): Promise<string | null> {
-  try {
-    const res = await fetch(`/api/servers/${id}/token`, {
-      method: 'POST',
-      headers: { 'cache-control': 'no-store' },
-    });
-    if (res.status === 401) {
-      console.warn('[hosts] token fetch 401 — session required to connect');
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const res = await fetch(`/api/servers/${id}/token`, {
+        method: 'POST',
+        headers: { 'cache-control': 'no-store' },
+      });
+      if (res.status === 401) {
+        console.warn('[hosts] token fetch 401 — session required to connect');
+        return null;
+      }
+      if (res.status === 503 && attempt === 0) {
+        const retryAfter = Number(res.headers.get('retry-after') ?? '1');
+        const delayMs = Math.min(2_000, Math.max(250, retryAfter * 1_000 || 1_000));
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        continue;
+      }
+      if (!res.ok) {
+        console.warn(`[hosts] token fetch failed: ${res.status}`);
+        return null;
+      }
+      const data = (await res.json()) as { token?: string };
+      return data.token ?? null;
+    } catch (err) {
+      console.warn('[hosts] token fetch threw', err);
       return null;
     }
-    if (!res.ok) {
-      console.warn(`[hosts] token fetch failed: ${res.status}`);
-      return null;
-    }
-    const data = (await res.json()) as { token?: string };
-    return data.token ?? null;
-  } catch (err) {
-    console.warn('[hosts] token fetch threw', err);
-    return null;
   }
+  return null;
 }
 
 const local = $state({
@@ -233,7 +242,11 @@ export async function addHost(host: { name: string; url: string; token: string }
   );
 }
 
-export async function updateHost(id: string, updates: Partial<Omit<Host, 'id'>>, options?: { silent?: boolean }) {
+export async function updateHost(
+  id: string,
+  updates: Partial<Omit<Host, 'id'>>,
+  options?: { silent?: boolean },
+) {
   const run = async () => {
     const res = await fetch(`/api/servers/${id}`, {
       method: 'PUT',

--- a/src/routes/api/servers/[id]/token/+server.ts
+++ b/src/routes/api/servers/[id]/token/+server.ts
@@ -5,7 +5,10 @@ import { userServers } from '@minion-stack/db/schema';
 import { requireAuth } from '$server/auth/authorize';
 import { getTenantCtx } from '$server/auth/tenant-ctx';
 import { getServerToken } from '$server/services/server.service';
-import { userHasGatewayAccess, getGatewayTokenByServerId } from '$server/services/gateway.pg.service';
+import {
+  userHasGatewayAccess,
+  getGatewayTokenByServerId,
+} from '$server/services/gateway.pg.service';
 
 /**
  * Returns the decrypted gateway token for a single server.
@@ -18,7 +21,14 @@ import { userHasGatewayAccess, getGatewayTokenByServerId } from '$server/service
  * proxy access logs, and the default HTTP cache.
  */
 export const POST: RequestHandler = async ({ locals, params }) => {
-  console.log('[token-ep] ENTRY user=', locals.user?.email ?? 'NONE', 'role=', locals.user?.role, 'id=', params.id);
+  console.log(
+    '[token-ep] ENTRY user=',
+    locals.user?.email ?? 'NONE',
+    'role=',
+    locals.user?.role,
+    'id=',
+    params.id,
+  );
   const user = requireAuth(locals);
   const ctx = await getTenantCtx(locals);
   if (!ctx) {
@@ -49,9 +59,11 @@ export const POST: RequestHandler = async ({ locals, params }) => {
   // Try Supabase gateway table first (post-cutover source of truth), then fall
   // back to Turso servers table for legacy rows that haven't migrated yet.
   let token: string | null = null;
+  let registryError: unknown = null;
   try {
     token = await getGatewayTokenByServerId(id);
   } catch (err) {
+    registryError = err;
     console.warn('[token-ep] Supabase gateway lookup threw (will try Turso):', err);
   }
   if (!token) {
@@ -59,10 +71,22 @@ export const POST: RequestHandler = async ({ locals, params }) => {
       token = await getServerToken(ctx, id);
     } catch (err) {
       console.error('[token-ep] getServerToken threw:', err);
-      return json({ error: 'decrypt failed', message: err instanceof Error ? err.message : String(err) }, { status: 500 });
+      return json(
+        { error: 'decrypt failed', message: err instanceof Error ? err.message : String(err) },
+        { status: 500 },
+      );
     }
   }
   if (token === null) {
+    // A PG outage is not evidence that the gateway row is absent. Returning a
+    // 404 here made pool exhaustion look like a missing token and prevented the
+    // browser's gateway client from reconnecting after the database recovered.
+    if (registryError) {
+      return json(
+        { error: 'Gateway registry temporarily unavailable' },
+        { status: 503, headers: { 'retry-after': '2' } },
+      );
+    }
     console.log('[token-ep] token not found in Supabase or Turso -> 404');
     return json({ error: 'Not found' }, { status: 404 });
   }

--- a/src/routes/api/servers/[id]/token/server.test.ts
+++ b/src/routes/api/servers/[id]/token/server.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getGatewayTokenByServerId: vi.fn(),
+  getServerToken: vi.fn(),
+}));
+
+vi.mock('$server/auth/authorize', () => ({
+  requireAuth: () => ({ id: 'user-1', role: 'admin', supabaseId: 'profile-1' }),
+}));
+
+vi.mock('$server/auth/tenant-ctx', () => ({
+  getTenantCtx: () => Promise.resolve({ db: {}, tenantId: 'org-1' }),
+}));
+
+vi.mock('$server/services/server.service', () => ({
+  getServerToken: mocks.getServerToken,
+}));
+
+vi.mock('$server/services/gateway.pg.service', () => ({
+  userHasGatewayAccess: vi.fn(),
+  getGatewayTokenByServerId: mocks.getGatewayTokenByServerId,
+}));
+
+import { POST } from './+server';
+
+function event() {
+  return {
+    locals: { user: { email: 'admin@example.com', role: 'admin' } },
+    params: { id: 'server-1' },
+  } as never;
+}
+
+describe('POST /api/servers/[id]/token', () => {
+  beforeEach(() => {
+    mocks.getGatewayTokenByServerId.mockReset();
+    mocks.getServerToken.mockReset();
+  });
+
+  test('returns 503 instead of a false 404 when PG is unavailable', async () => {
+    mocks.getGatewayTokenByServerId.mockRejectedValue(
+      new Error('EMAXCONN max client connections reached'),
+    );
+    mocks.getServerToken.mockResolvedValue(null);
+
+    const response = await POST(event());
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('retry-after')).toBe('2');
+    await expect(response.json()).resolves.toEqual({
+      error: 'Gateway registry temporarily unavailable',
+    });
+  });
+
+  test('keeps a genuine registry miss as 404', async () => {
+    mocks.getGatewayTokenByServerId.mockResolvedValue(null);
+    mocks.getServerToken.mockResolvedValue(null);
+
+    const response = await POST(event());
+
+    expect(response.status).toBe(404);
+  });
+
+  test('returns the PG gateway token without consulting Turso', async () => {
+    mocks.getGatewayTokenByServerId.mockResolvedValue('gateway-secret');
+
+    const response = await POST(event());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ token: 'gateway-secret' });
+    expect(mocks.getServerToken).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/db/pg-client.ts
+++ b/src/server/db/pg-client.ts
@@ -1,20 +1,11 @@
 import { drizzle } from 'drizzle-orm/postgres-js';
-import postgres from 'postgres';
-import { env } from '$env/dynamic/private';
 import * as pgSchema from '@minion-stack/db/pg';
+import { getPgClient } from './pg-pool';
 
 let _db: ReturnType<typeof createDrizzle> | null = null;
 
 function createDrizzle() {
-  // Trim stray whitespace/newlines — `echo x | vercel env add` appends a \n,
-  // and a trailing newline in the connection URL breaks the postgres-js parser.
-  const url = env.SUPABASE_DB_URL?.trim();
-  if (!url) throw new Error('SUPABASE_DB_URL is required for the PG core client');
-  // max: 20 — conservative bump from 10 to give the hot read paths (sessions,
-  // chat, settings) more concurrent connections without risking Supabase's
-  // pooler limits. Hub-local config; not a shared export.
-  const client = postgres(url, { prepare: false, max: 20 });
-  return drizzle(client, { schema: pgSchema });
+  return drizzle(getPgClient(), { schema: pgSchema });
 }
 
 /** Singleton Drizzle-PG client. Reads/writes the relational-core tables in Supabase. */

--- a/src/server/db/pg-ledger-client.ts
+++ b/src/server/db/pg-ledger-client.ts
@@ -1,23 +1,18 @@
 import { drizzle } from 'drizzle-orm/postgres-js';
 import { sql } from 'drizzle-orm';
-import postgres from 'postgres';
-import { env } from '$env/dynamic/private';
 import { messages } from '@minion-stack/db/pg';
+import { getPgClient } from './pg-pool';
 
 type LedgerDb = ReturnType<typeof drizzle<{ messages: typeof messages }>>;
 
 /** The transaction handle handed to `withOrg` callbacks. */
 export type LedgerTx = Parameters<Parameters<LedgerDb['transaction']>[0]>[0];
 
-let _client: ReturnType<typeof postgres> | null = null;
 let _db: LedgerDb | null = null;
 
 function getLedgerDb(): LedgerDb {
   if (_db) return _db;
-  const url = env.SUPABASE_DB_URL;
-  if (!url) throw new Error('SUPABASE_DB_URL is required for the ledger PG client');
-  _client = postgres(url, { prepare: false, max: 5 });
-  _db = drizzle(_client, { schema: { messages } });
+  _db = drizzle(getPgClient(), { schema: { messages } });
   return _db;
 }
 

--- a/src/server/db/pg-pool.test.ts
+++ b/src/server/db/pg-pool.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const client = { end: vi.fn().mockResolvedValue(undefined) };
+  return {
+    client,
+    postgres: vi.fn(() => client),
+  };
+});
+
+vi.mock('$env/dynamic/private', () => ({
+  env: {
+    SUPABASE_DB_URL: ' postgresql://test:test@localhost:6543/test\n',
+    SUPABASE_DB_POOL_SIZE: '3',
+  },
+}));
+
+vi.mock('postgres', () => ({ default: mocks.postgres }));
+
+describe('getPgClient', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.postgres.mockClear();
+    mocks.client.end.mockClear();
+    delete (globalThis as typeof globalThis & { __minionHubPgPool?: unknown }).__minionHubPgPool;
+  });
+
+  test('reuses one physical pool across server-module reloads', async () => {
+    const firstModule = await import('./pg-pool');
+    const first = firstModule.getPgClient();
+
+    vi.resetModules();
+    const secondModule = await import('./pg-pool');
+    const second = secondModule.getPgClient();
+
+    expect(second).toBe(first);
+    expect(mocks.postgres).toHaveBeenCalledTimes(1);
+  });
+
+  test('creates a bounded, recyclable serverless pool', async () => {
+    const { getPgClient } = await import('./pg-pool');
+    getPgClient();
+
+    expect(mocks.postgres).toHaveBeenCalledWith(
+      'postgresql://test:test@localhost:6543/test',
+      expect.objectContaining({
+        prepare: false,
+        max: 3,
+        idle_timeout: 20,
+        connect_timeout: 10,
+        max_lifetime: 600,
+      }),
+    );
+  });
+});

--- a/src/server/db/pg-pool.ts
+++ b/src/server/db/pg-pool.ts
@@ -1,0 +1,62 @@
+import postgres from 'postgres';
+import { env } from '$env/dynamic/private';
+
+type PgClient = ReturnType<typeof postgres>;
+
+interface PgPoolState {
+  url: string;
+  client: PgClient;
+}
+
+declare global {
+  // SvelteKit can evaluate server modules more than once during HMR and a
+  // serverless isolate can load separate route chunks. Keep the physical pool
+  // on globalThis so all Drizzle wrappers in one process share it.
+  var __minionHubPgPool: PgPoolState | undefined;
+}
+
+const DEFAULT_POOL_SIZE = 5;
+const MAX_POOL_SIZE = 10;
+
+function poolSize(): number {
+  const configured = Number.parseInt(env.SUPABASE_DB_POOL_SIZE ?? '', 10);
+  if (!Number.isFinite(configured)) return DEFAULT_POOL_SIZE;
+  return Math.min(MAX_POOL_SIZE, Math.max(1, configured));
+}
+
+function databaseUrl(): string {
+  const url = env.SUPABASE_DB_URL?.trim();
+  if (!url) throw new Error('SUPABASE_DB_URL is required for the PG client');
+  return url;
+}
+
+/**
+ * One bounded postgres-js pool per Hub process.
+ *
+ * Core queries and the RLS ledger use separate Drizzle schemas, but they can
+ * safely share a physical pool: ledger role/GUC changes use SET LOCAL inside a
+ * transaction and are reset automatically at commit. A short idle timeout and
+ * finite connection lifetime keep dev reloads and retired serverless isolates
+ * from holding Supabase connections indefinitely.
+ */
+export function getPgClient(): PgClient {
+  const url = databaseUrl();
+  const existing = globalThis.__minionHubPgPool;
+  if (existing?.url === url) return existing.client;
+
+  if (existing) {
+    void existing.client.end({ timeout: 5 }).catch((err: unknown) => {
+      console.warn('[pg-pool] failed to close replaced pool', err);
+    });
+  }
+
+  const client = postgres(url, {
+    prepare: false,
+    max: poolSize(),
+    idle_timeout: 20,
+    connect_timeout: 10,
+    max_lifetime: 10 * 60,
+  });
+  globalThis.__minionHubPgPool = { url, client };
+  return client;
+}


### PR DESCRIPTION
Production promotion of the isolated Supabase pool exhaustion fix from dev.

Root cause: core and ledger database modules created independent postgres-js pools, and module reloads could multiply those pools until Supavisor rejected new clients. The token endpoint then incorrectly turned that registry outage into a 404, preventing the browser gateway connection and update checks.

This change shares one bounded process-global pool, recycles idle connections, returns a retryable 503 for registry outages, and retries that transient response once in the client.

Validation:
- focused Vitest: 3 files, 6 tests passed
- Svelte check: 0 errors, 0 warnings
- CI check-and-build passed on dev PR #69
- Vercel preview passed
- live update.status and update.check RPCs both passed against the configured gateway
- Copilot reviewed all 8 files with no comments