### PR TITLE
feat(brains): add private Qdrant serving bridge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,6 +102,21 @@ BRAIN_ENRICHMENT_MAX_INPUT_USD_PER_MILLION=1
 BRAIN_ENRICHMENT_MAX_OUTPUT_USD_PER_MILLION=4
 BRAIN_ENRICHMENT_ADAPTER_IDS=
 
+# Self-hosted Unified Brains semantic serving index. Off by default: when
+# disabled or unavailable, retrieval keeps the canonical Supabase exact-vector
+# lane. BRAIN_VECTOR_URL may include an ingress path prefix (for example
+# https://host.example/vectors). The private key accepts PKCS8 PEM, base64 PEM,
+# or a private Ed25519 JWK; only the matching public JWK is mounted by the API.
+BRAIN_VECTOR_ENABLED=false
+BRAIN_VECTOR_URL=
+BRAIN_VECTOR_SIGNING_PRIVATE_KEY=
+BRAIN_VECTOR_SIGNING_KID=
+BRAIN_VECTOR_FINGERPRINT_KEY=
+BRAIN_VECTOR_GENERATION=openai_te3s_1536_g1
+BRAIN_VECTOR_JWT_ISSUER=minion-hub
+BRAIN_VECTOR_JWT_AUDIENCE=minion-brain-vector
+BRAIN_VECTOR_TIMEOUT_MS=800
+
 # Supabase (Phase 1b dual-mode auth). Hub default = supabase (cloud);
 # set both to 'better-auth' to run the self-hosted fallback.
 AUTH_PROVIDER=supabase               # 'supabase' | 'better-auth'

--- a/docs/runbooks/brain-vector-qdrant.md
+++ b/docs/runbooks/brain-vector-qdrant.md
@@ -1,0 +1,148 @@
+# Brain vector serving-index rollout
+
+Supabase is canonical; Qdrant is a rebuildable serving index. The migration
+installs the generation with `enqueue_enabled = false`. Do not enable enqueue
+until the vector API and worker are healthy and the checks below pass.
+
+## 1. Disposable migration proof
+
+Run the real-Postgres behavior test before applying the migration:
+
+```bash
+bash scripts/test-brain-vector-migration.sh
+```
+
+The test uses a disposable Supabase Postgres container and proves:
+
+- a write made as `app_ledger` through a FORCE-RLS table fires the
+  `SECURITY DEFINER` outbox trigger;
+- a non-empty `list_brain_vector_chunks` row contains the requested generation,
+  canonical org, vector, and embedding model;
+- `filter_existing_brain_vector_chunks` reports canonical org ownership and
+  raises SQLSTATE `22023` above 1,000 IDs;
+- a separate custom LOGIN inheriting only `brain_vector_worker` can claim and
+  revision-match ACK a job;
+- enqueue is false again at the end.
+
+## 2. Production worker role
+
+Run as the database owner with a password supplied through the secret manager;
+never put the password in source or shell history:
+
+```sql
+create role brain_vector_worker_login
+  login inherit nobypassrls password :'worker_password';
+grant brain_vector_worker to brain_vector_worker_login;
+```
+
+Connect as that LOGIN—not as `postgres` or the Supabase service role—and verify
+its effective authority:
+
+```sql
+select
+  current_user,
+  pg_has_role(current_user, 'brain_vector_worker', 'USAGE') as inherits_worker,
+  has_function_privilege(
+    current_user,
+    'public.claim_brain_vector_jobs(text,integer,integer)',
+    'EXECUTE'
+  ) as can_claim,
+  has_function_privilege(
+    current_user,
+    'public.ack_brain_vector_job(uuid,text,bigint)',
+    'EXECUTE'
+  ) as can_ack,
+  has_table_privilege(current_user, 'public.brain_vector_outbox', 'SELECT') as direct_outbox_select;
+```
+
+Expected: `inherits_worker`, `can_claim`, and `can_ack` are true;
+`direct_outbox_select` is false.
+
+## 3. FORCE-RLS trigger canary and actual LOGIN claim/ACK
+
+Choose one existing embedded chunk only to supply valid foreign-key parents:
+
+```sql
+select org_id, source_id, document_id
+from public.knowledge_chunks
+where embedding is not null
+  and embedding_model = 'text-embedding-3-small'
+limit 1;
+```
+
+Keep the chosen values in psql variables `org_id`, `source_id`, and
+`document_id`. The owner must first prove there is no existing backlog; do not
+use the manual claim/ACK canary against a non-empty queue:
+
+```sql
+select status, count(*)
+from public.brain_vector_outbox
+group by status;
+
+-- The restricted worker exposes the same operator-safe counters without any
+-- direct table grant.
+select * from public.brain_vector_worker_status('openai_te3s_1536_g1');
+```
+
+Proceed only when this returns no rows. As database owner, temporarily enable
+only the active generation:
+
+```sql
+update public.brain_vector_generations
+set enqueue_enabled = true
+where generation = 'openai_te3s_1536_g1'
+  and is_active;
+```
+
+As `app_ledger`, set the org GUC and insert a synthetic chunk. This is the FORCE
+RLS canary: the insert must satisfy the canonical policy while its trigger must
+still be able to enqueue into the worker-only table.
+
+```sql
+begin;
+select set_config('app.current_org_id', :'org_id', true);
+insert into public.knowledge_chunks (
+  id, org_id, source_id, document_id, chunk_key, kind, seq,
+  chunk_text, content_hash, embedding, embedding_model, metadata
+) values (
+  :'canary_chunk_id'::uuid, :'org_id', :'source_id'::uuid, :'document_id'::uuid,
+  'brain-vector-preflight-' || :'canary_chunk_id', 'raw', 2147483647,
+  'brain vector serving-index preflight canary',
+  'sha256:brain-vector-preflight-' || :'canary_chunk_id',
+  array_fill(0::real, array[1536])::vector,
+  'text-embedding-3-small',
+  '{"preflight":true}'::jsonb
+);
+commit;
+```
+
+Connect through the real `brain_vector_worker_login` credentials and perform an
+actual claim and exact-revision ACK:
+
+```sql
+select *
+from public.claim_brain_vector_jobs('production-preflight', 1, 60)
+where chunk_id = :'canary_chunk_id'::uuid;
+
+select public.ack_brain_vector_job(
+  :'canary_chunk_id'::uuid,
+  'openai_te3s_1536_g1',
+  :'claimed_revision'::bigint
+);
+```
+
+The ACK result must be true. Delete the synthetic chunk as `app_ledger`, then
+claim and ACK the resulting delete job through the same worker LOGIN. Finally,
+as owner, disable enqueue again:
+
+```sql
+update public.brain_vector_generations set enqueue_enabled = false;
+
+select generation, enqueue_enabled
+from public.brain_vector_generations
+order by generation;
+```
+
+Every row must report `enqueue_enabled = false`. Only the controlled deployment
+step may enable the active generation after the real worker has passed health,
+Qdrant collection/alias checks, and this canary.

--- a/scripts/test-brain-vector-migration.sh
+++ b/scripts/test-brain-vector-migration.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Real-Postgres behavior check for the Qdrant outbox migration. This deliberately
+# uses a disposable database because FORCE RLS, SECURITY DEFINER ownership, role
+# inheritance, trigger behavior, and RPC return shapes cannot be proven by mocks.
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+MIGRATION="${REPO_DIR}/supabase/migrations/20260723010000_brain_vector_outbox.sql"
+IMAGE="${BRAIN_VECTOR_TEST_POSTGRES_IMAGE:-pgvector/pgvector:pg15}"
+CONTAINER="brain-vector-migration-$RANDOM-$RANDOM"
+POSTGRES_PASSWORD="brain-vector-test-superuser"
+WORKER_PASSWORD="brain-vector-test-worker"
+
+cleanup() {
+  docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker run --rm -d \
+  --name "${CONTAINER}" \
+  -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" \
+  "${IMAGE}" >/dev/null
+
+for _ in $(seq 1 60); do
+  if docker exec "${CONTAINER}" pg_isready -U postgres -d postgres >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+docker exec "${CONTAINER}" pg_isready -U postgres -d postgres >/dev/null
+
+docker exec -i "${CONTAINER}" psql -v ON_ERROR_STOP=1 -U postgres -d postgres <<'SQL'
+create extension if not exists vector;
+create extension if not exists pgcrypto;
+
+do $$
+begin
+  if not exists (select 1 from pg_roles where rolname = 'anon') then create role anon nologin; end if;
+  if not exists (select 1 from pg_roles where rolname = 'authenticated') then create role authenticated nologin; end if;
+  if not exists (select 1 from pg_roles where rolname = 'app_ledger') then
+    create role app_ledger nologin noinherit nobypassrls;
+  end if;
+end
+$$;
+grant app_ledger to postgres;
+
+create table public.knowledge_chunks (
+  id uuid primary key,
+  org_id text not null,
+  source_id uuid not null,
+  document_id uuid not null,
+  kind text not null,
+  occurred_at timestamptz,
+  content_hash text not null,
+  embedding_model text,
+  embedding vector(1536)
+);
+alter table public.knowledge_chunks enable row level security;
+alter table public.knowledge_chunks force row level security;
+create policy knowledge_chunks_org_guc on public.knowledge_chunks
+  using (org_id = current_setting('app.current_org_id', true))
+  with check (org_id = current_setting('app.current_org_id', true));
+grant select, insert, update, delete on public.knowledge_chunks to app_ledger;
+SQL
+
+docker exec -i "${CONTAINER}" psql -1 -v ON_ERROR_STOP=1 -U postgres -d postgres <"${MIGRATION}"
+
+docker exec -i "${CONTAINER}" psql -v ON_ERROR_STOP=1 -U postgres -d postgres <<'SQL'
+update public.brain_vector_generations
+set enqueue_enabled = true
+where generation = 'openai_te3s_1536_g1';
+
+begin;
+set local role app_ledger;
+select set_config('app.current_org_id', 'org-canary', true);
+insert into public.knowledge_chunks (
+  id, org_id, source_id, document_id, kind, occurred_at,
+  content_hash, embedding_model, embedding
+) values (
+  '018f87f4-e934-7a21-98b6-4f6b8d3898dd',
+  'org-canary',
+  '11111111-1111-4111-8111-111111111111',
+  '22222222-2222-4222-8222-222222222222',
+  'raw',
+  '2026-07-22T20:00:00Z',
+  'sha256:canary',
+  'text-embedding-3-small',
+  array_fill(0::real, array[1536])::vector
+);
+commit;
+
+do $$
+declare
+  listed record;
+  filtered record;
+begin
+  if not (select relrowsecurity and relforcerowsecurity
+          from pg_class where oid = 'public.knowledge_chunks'::regclass) then
+    raise exception 'knowledge_chunks FORCE RLS canary precondition is false';
+  end if;
+  if not exists (
+    select 1 from public.brain_vector_outbox
+    where chunk_id = '018f87f4-e934-7a21-98b6-4f6b8d3898dd'
+      and org_id = 'org-canary'
+      and desired_operation = 'upsert'
+  ) then
+    raise exception 'FORCE RLS app_ledger insert did not enqueue the trigger canary';
+  end if;
+
+  select * into listed
+  from public.list_brain_vector_chunks(null, 10, 'openai_te3s_1536_g1')
+  where chunk_id = '018f87f4-e934-7a21-98b6-4f6b8d3898dd';
+  if listed is null
+     or listed.org_id <> 'org-canary'
+     or listed.generation <> 'openai_te3s_1536_g1'
+     or listed.embedding_model <> 'text-embedding-3-small'
+     or listed.embedding is null then
+    raise exception 'non-empty reconcile RPC row shape is incomplete: %', listed;
+  end if;
+
+  select * into filtered
+  from public.filter_existing_brain_vector_chunks(
+    array['018f87f4-e934-7a21-98b6-4f6b8d3898dd'::uuid],
+    'openai_te3s_1536_g1'
+  );
+  if filtered is null or filtered.org_id <> 'org-canary' then
+    raise exception 'existing-chunk filter did not report canonical org: %', filtered;
+  end if;
+
+  begin
+    perform *
+    from public.filter_existing_brain_vector_chunks(
+      array_fill('018f87f4-e934-7a21-98b6-4f6b8d3898dd'::uuid, array[1001]),
+      'openai_te3s_1536_g1'
+    );
+    raise exception 'existing-chunk filter silently accepted more than 1000 IDs';
+  exception when sqlstate '22023' then
+    null;
+  end;
+
+  begin
+    perform * from public.brain_vector_worker_status('missing_generation');
+    raise exception 'worker status silently accepted an unknown generation';
+  exception when sqlstate '22023' then
+    null;
+  end;
+end
+$$;
+
+create role brain_vector_worker_login
+  login inherit nobypassrls password 'brain-vector-test-worker';
+grant brain_vector_worker to brain_vector_worker_login;
+SQL
+
+claim="$(
+  docker exec -e PGPASSWORD="${WORKER_PASSWORD}" "${CONTAINER}" \
+    psql -v ON_ERROR_STOP=1 -U brain_vector_worker_login -d postgres \
+      -At -F '|' -c \
+      "select chunk_id, generation, revision from public.claim_brain_vector_jobs('preflight-login', 1, 60)"
+)"
+IFS='|' read -r claimed_chunk claimed_generation claimed_revision <<<"${claim}"
+test "${claimed_chunk}" = "018f87f4-e934-7a21-98b6-4f6b8d3898dd"
+test "${claimed_generation}" = "openai_te3s_1536_g1"
+test -n "${claimed_revision}"
+
+ack="$(
+  docker exec -e PGPASSWORD="${WORKER_PASSWORD}" "${CONTAINER}" \
+    psql -v ON_ERROR_STOP=1 -U brain_vector_worker_login -d postgres \
+      -At -c \
+      "select public.ack_brain_vector_job('${claimed_chunk}', '${claimed_generation}', ${claimed_revision})"
+)"
+test "${ack}" = "t"
+
+status="$(
+  docker exec -e PGPASSWORD="${WORKER_PASSWORD}" "${CONTAINER}" \
+    psql -v ON_ERROR_STOP=1 -U brain_vector_worker_login -d postgres \
+      -At -F '|' -c \
+      "select queued, running, dead, canonical_chunks from public.brain_vector_worker_status('openai_te3s_1536_g1')"
+)"
+test "${status}" = "0|0|0|1"
+
+docker exec -i "${CONTAINER}" psql -v ON_ERROR_STOP=1 -U postgres -d postgres <<'SQL'
+do $$
+begin
+  if exists (
+    select 1 from public.brain_vector_outbox
+    where chunk_id = '018f87f4-e934-7a21-98b6-4f6b8d3898dd'
+  ) then
+    raise exception 'custom worker LOGIN claim/ack did not clear the exact revision';
+  end if;
+end
+$$;
+
+update public.brain_vector_generations
+set enqueue_enabled = false
+where generation = 'openai_te3s_1536_g1';
+
+do $$
+begin
+  if exists (select 1 from public.brain_vector_generations where enqueue_enabled) then
+    raise exception 'migration behavior test left enqueue enabled';
+  end if;
+end
+$$;
+SQL
+
+echo "brain-vector migration behavior: PASS"

--- a/src/server/services/brain-hybrid-retrieval.service.test.ts
+++ b/src/server/services/brain-hybrid-retrieval.service.test.ts
@@ -7,6 +7,9 @@ const mocks = vi.hoisted(() => ({
   withOrgCore: vi.fn(),
   embeddingsEnabled: vi.fn(),
   embedTexts: vi.fn(),
+  brainVectorServingEnabled: vi.fn(),
+  brainVectorClientConfig: vi.fn(),
+  searchBrainVectorApi: vi.fn(),
 }));
 
 vi.mock('./brains.service', () => ({
@@ -24,6 +27,19 @@ vi.mock('./embeddings', () => ({
   toVectorLiteral: (vector: number[]) => `[${vector.join(',')}]`,
 }));
 
+vi.mock('./brain-vector-client', () => ({
+  BRAIN_VECTOR_MAX_SOURCE_IDS: 512,
+  brainVectorServingEnabled: mocks.brainVectorServingEnabled,
+  brainVectorClientConfig: mocks.brainVectorClientConfig,
+  searchBrainVectorApi: mocks.searchBrainVectorApi,
+  brainVectorContentFingerprint: (
+    key: string,
+    chunkId: string,
+    contentHash: string,
+    generation: string,
+  ) => `${key}:${chunkId}:${contentHash}:${generation}`,
+}));
+
 import {
   HNSW_EF_SEARCH,
   HYBRID_RRF_K,
@@ -36,6 +52,7 @@ import {
   fuzzySearchStatus,
   hnswIterativeScanConfigSql,
   hnswSearchConfigSql,
+  isCanonicalChunkId,
   neighborScopeConditions,
   rankHybridCandidates,
   searchBrainHybrid,
@@ -73,6 +90,12 @@ function candidate(overrides: Partial<HybridCandidate> = {}): HybridCandidate {
 }
 
 describe('brain hybrid retrieval — deterministic scoring', () => {
+  it('accepts every canonical UUID version while rejecting malformed Qdrant chunk IDs', () => {
+    expect(isCanonicalChunkId('018f87f4-e934-7a21-98b6-4f6b8d3898dd')).toBe(true);
+    expect(isCanonicalChunkId('d7cb8de1-05f3-822a-b514-aa419dca59de')).toBe(true);
+    expect(isCanonicalChunkId('not-a-uuid')).toBe(false);
+  });
+
   it('sets a transaction-local HNSW breadth before post-filtered vector retrieval', () => {
     const query = new PgDialect().sqlToQuery(hnswSearchConfigSql());
 
@@ -457,6 +480,7 @@ describe('brain hybrid retrieval — canonical/legacy compatibility', () => {
     vi.clearAllMocks();
     mocks.canAccessBrain.mockResolvedValue(true);
     mocks.embeddingsEnabled.mockReturnValue(false);
+    mocks.brainVectorServingEnabled.mockReturnValue(false);
     mocks.withOrgCore.mockResolvedValue([]);
     mocks.searchBrain.mockResolvedValue([]);
   });
@@ -593,6 +617,150 @@ describe('brain hybrid retrieval — canonical/legacy compatibility', () => {
     });
     expect(result.hits[0].chunkText).toContain('KRISPI');
     expect(mocks.searchBrain).not.toHaveBeenCalled();
+  });
+
+  it('rehydrates Qdrant IDs under canonical scope and drops the raw payload boundary', async () => {
+    mocks.embeddingsEnabled.mockReturnValue(true);
+    mocks.brainVectorServingEnabled.mockReturnValue(true);
+    mocks.embedTexts.mockResolvedValue([Array.from({ length: 1536 }, () => 0)]);
+    mocks.brainVectorClientConfig.mockReturnValue({
+      generation: 'openai_te3s_1536_g1',
+      fingerprintKey: 'fingerprint-key',
+    });
+    mocks.searchBrainVectorApi.mockResolvedValue({
+      generation: 'openai_te3s_1536_g1',
+      collection: 'minion_knowledge_active',
+      tookMs: 2,
+      candidates: [
+        {
+          chunkId: '44444444-4444-4444-8444-444444444444',
+          score: 0.91,
+          indexedFingerprint:
+            'fingerprint-key:44444444-4444-4444-8444-444444444444:current-hash:openai_te3s_1536_g1',
+        },
+      ],
+    });
+    const qdrantRow = {
+      chunkId: '44444444-4444-4444-8444-444444444444',
+      sourceId: '22222222-2222-4222-8222-222222222222',
+      sourceName: 'WhatsApp +51999',
+      connector: 'whatsapp',
+      sourceExternalKey: 'account-1',
+      sourceConfig: {},
+      documentId: '33333333-3333-4333-8333-333333333333',
+      documentExternalId: 'conversation:account-1:chat-1:2026-07',
+      documentTitle: 'Conversation with Ada',
+      chunkKey: 'raw:000000',
+      kind: 'raw',
+      seq: 0,
+      chunkText: 'Refund policy from the canonical database',
+      contextPrefix: null,
+      contentHash: 'current-hash',
+      occurredAt: NOW,
+      metadata: { chatId: 'chat-1' },
+      includeAllSources: true,
+      membershipWeight: null,
+      membershipConfig: null,
+      retrievalScore: 0,
+    };
+    // Lexical query starts first. Vector resumes after embedding and resolves
+    // source scope, then rehydrates the untrusted Qdrant ID, then neighbors.
+    mocks.withOrgCore
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ sourceId: qdrantRow.sourceId }])
+      .mockResolvedValueOnce([qdrantRow])
+      .mockResolvedValueOnce([]);
+
+    const result = await searchBrainHybrid(
+      { db: {} as never, tenantId: 'org-1', profileId: 'profile-1' },
+      '11111111-1111-4111-8111-111111111111',
+      'refund policy',
+      { limit: 5 },
+      {},
+    );
+
+    expect(mocks.searchBrainVectorApi).toHaveBeenCalledWith(
+      expect.objectContaining({ generation: 'openai_te3s_1536_g1' }),
+      expect.objectContaining({
+        orgId: 'org-1',
+        brainId: '11111111-1111-4111-8111-111111111111',
+        subject: 'profile-1',
+        filters: {
+          scopeMode: 'source_list',
+          sourceIds: [qdrantRow.sourceId],
+          kinds: undefined,
+        },
+      }),
+    );
+    expect(result.hits[0]).toMatchObject({
+      chunkId: qdrantRow.chunkId,
+      evidenceText: qdrantRow.chunkText,
+      scores: { vector: 0.91 },
+    });
+    expect(result.diagnostics.warnings).toEqual([]);
+  });
+
+  it('falls back to exact Supabase vectors when a Qdrant fingerprint is stale', async () => {
+    mocks.embeddingsEnabled.mockReturnValue(true);
+    mocks.brainVectorServingEnabled.mockReturnValue(true);
+    mocks.embedTexts.mockResolvedValue([[0.1, 0.2, 0.3]]);
+    mocks.brainVectorClientConfig.mockReturnValue({
+      generation: 'openai_te3s_1536_g1',
+      fingerprintKey: 'fingerprint-key',
+    });
+    mocks.searchBrainVectorApi.mockResolvedValue({
+      generation: 'openai_te3s_1536_g1',
+      collection: 'minion_knowledge_active',
+      tookMs: 2,
+      candidates: [
+        {
+          chunkId: '44444444-4444-4444-8444-444444444444',
+          score: 0.91,
+          indexedFingerprint: 'fingerprint-key:stale',
+        },
+      ],
+    });
+    const row = {
+      chunkId: '44444444-4444-4444-8444-444444444444',
+      sourceId: '22222222-2222-4222-8222-222222222222',
+      sourceName: 'CRM',
+      connector: 'hub-business',
+      sourceExternalKey: 'crm',
+      sourceConfig: {},
+      documentId: '33333333-3333-4333-8333-333333333333',
+      documentExternalId: 'crm:1',
+      documentTitle: 'Refund policy',
+      chunkKey: 'raw:0',
+      kind: 'raw',
+      seq: 0,
+      chunkText: 'Refund policy current evidence',
+      contextPrefix: null,
+      contentHash: 'current-hash',
+      occurredAt: NOW,
+      metadata: {},
+      includeAllSources: true,
+      membershipWeight: null,
+      membershipConfig: null,
+      retrievalScore: 0.8,
+    };
+    mocks.withOrgCore
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ sourceId: row.sourceId }])
+      .mockResolvedValueOnce([row])
+      .mockResolvedValueOnce([row])
+      .mockResolvedValueOnce([]);
+
+    const result = await searchBrainHybrid(
+      { db: {} as never, tenantId: 'org-1' },
+      '11111111-1111-4111-8111-111111111111',
+      'refund policy',
+      { limit: 5 },
+      {},
+    );
+    expect(result.hits[0].scores.vector).toBe(0.8);
+    expect(result.diagnostics.warnings).toContain(
+      'Qdrant returned no current authorized candidates; exact vector fallback used',
+    );
   });
 
   it('does not bypass relevance policy through legacy fallback after rejecting canonical noise', async () => {

--- a/src/server/services/brain-hybrid-retrieval.service.ts
+++ b/src/server/services/brain-hybrid-retrieval.service.ts
@@ -11,6 +11,14 @@ import {
 import { withOrgCore } from '$server/db/with-org-core';
 import { canAccessBrain, searchBrain, type AccessPrincipal } from './brains.service';
 import { embeddingsEnabled, embedTexts, toVectorLiteral } from './embeddings';
+import {
+  BRAIN_VECTOR_MAX_SOURCE_IDS,
+  brainVectorClientConfig,
+  brainVectorContentFingerprint,
+  brainVectorServingEnabled,
+  searchBrainVectorApi,
+  type BrainVectorCandidate,
+} from './brain-vector-client';
 
 /** Cerebras-style deterministic fusion. Ranks are one-based. */
 export const HYBRID_RRF_K = 60;
@@ -18,6 +26,12 @@ export const HYBRID_RRF_K = 60;
 export const HNSW_EF_SEARCH = 200;
 /** Indexed word-similarity threshold; exact one-edit policy still decides eligibility. */
 export const PG_TRGM_WORD_SIMILARITY_THRESHOLD = 0.3;
+export const CANONICAL_CHUNK_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+
+export function isCanonicalChunkId(value: string): boolean {
+  return CANONICAL_CHUNK_ID_PATTERN.test(value);
+}
 
 const VECTOR_WEIGHT = 1;
 const LEXICAL_WEIGHT = 1;
@@ -819,17 +833,15 @@ function candidateSelection(retrievalScore: SQL<number>) {
   };
 }
 
-async function retrieveVector(
+async function retrieveExactVector(
   ctx: CoreCtx,
   brainId: string,
-  query: string,
+  embedding: number[],
   options: BrainHybridSearchOptions,
   searchableModules: string[],
   fieldLevels: Record<string, number>,
   cap: number,
 ): Promise<HybridCandidate[]> {
-  if (!embeddingsEnabled()) return [];
-  const [embedding] = await embedTexts([query]);
   const literal = toVectorLiteral(embedding);
   const vectorDistance = sql<number>`${knowledgeChunks.embedding} <=> ${literal}::vector`;
   const vectorScore = sql<number>`1 - (${vectorDistance})`;
@@ -866,6 +878,201 @@ async function retrieveVector(
       .limit(cap);
   });
   return (rows as CanonicalCandidateRow[]).map((row) => toCandidate(row, 'vector'));
+}
+
+async function resolveVectorSourceScope(
+  ctx: CoreCtx,
+  brainId: string,
+  options: BrainHybridSearchOptions,
+  searchableModules: string[],
+  fieldLevels: Record<string, number>,
+): Promise<string[]> {
+  const rows = await withOrgCore(ctx, (tx) =>
+    tx
+      .selectDistinct({ sourceId: knowledgeSources.id })
+      .from(knowledgeChunks)
+      .innerJoin(
+        knowledgeDocuments,
+        and(
+          eq(knowledgeDocuments.id, knowledgeChunks.documentId),
+          eq(knowledgeDocuments.sourceId, knowledgeChunks.sourceId),
+        ),
+      )
+      .innerJoin(knowledgeSources, eq(knowledgeSources.id, knowledgeChunks.sourceId))
+      .innerJoin(brains, and(eq(brains.id, brainId), eq(brains.orgId, ctx.tenantId)))
+      .leftJoin(
+        brainSources,
+        and(
+          eq(brainSources.brainId, brains.id),
+          eq(brainSources.sourceId, knowledgeSources.id),
+          eq(brainSources.orgId, ctx.tenantId),
+        ),
+      )
+      .where(scopeConditions(ctx, brainId, options, searchableModules, fieldLevels))
+      .orderBy(knowledgeSources.id),
+  );
+  return rows.map((row) => row.sourceId);
+}
+
+async function rehydrateVectorCandidates(
+  ctx: CoreCtx,
+  brainId: string,
+  options: BrainHybridSearchOptions,
+  searchableModules: string[],
+  fieldLevels: Record<string, number>,
+  candidates: BrainVectorCandidate[],
+  generation: string,
+  fingerprintKey: string,
+): Promise<HybridCandidate[]> {
+  if (candidates.length === 0) return [];
+  const byId = new Map(
+    candidates
+      .filter((candidate) => isCanonicalChunkId(candidate.chunkId))
+      .map((candidate) => [candidate.chunkId, candidate]),
+  );
+  if (byId.size === 0) return [];
+  const rows = await withOrgCore(ctx, (tx) =>
+    tx
+      .select(candidateSelection(sql<number>`0`))
+      .from(knowledgeChunks)
+      .innerJoin(
+        knowledgeDocuments,
+        and(
+          eq(knowledgeDocuments.id, knowledgeChunks.documentId),
+          eq(knowledgeDocuments.sourceId, knowledgeChunks.sourceId),
+        ),
+      )
+      .innerJoin(knowledgeSources, eq(knowledgeSources.id, knowledgeChunks.sourceId))
+      .innerJoin(brains, and(eq(brains.id, brainId), eq(brains.orgId, ctx.tenantId)))
+      .leftJoin(
+        brainSources,
+        and(
+          eq(brainSources.brainId, brains.id),
+          eq(brainSources.sourceId, knowledgeSources.id),
+          eq(brainSources.orgId, ctx.tenantId),
+        ),
+      )
+      .where(
+        and(
+          scopeConditions(ctx, brainId, options, searchableModules, fieldLevels),
+          inArray(knowledgeChunks.id, [...byId.keys()]),
+        ),
+      ),
+  );
+  return (rows as CanonicalCandidateRow[])
+    .flatMap((row) => {
+      const indexed = byId.get(row.chunkId);
+      if (!indexed) return [];
+      const expected = brainVectorContentFingerprint(
+        fingerprintKey,
+        row.chunkId,
+        row.contentHash,
+        generation,
+      );
+      if (expected !== indexed.indexedFingerprint) return [];
+      return [toCandidate({ ...row, retrievalScore: indexed.score }, 'vector')];
+    })
+    .sort(
+      (left, right) =>
+        (right.vectorScore ?? Number.NEGATIVE_INFINITY) -
+          (left.vectorScore ?? Number.NEGATIVE_INFINITY) ||
+        left.chunkId.localeCompare(right.chunkId),
+    );
+}
+
+interface VectorRetrievalResult {
+  candidates: HybridCandidate[];
+  warnings: string[];
+}
+
+async function retrieveVector(
+  ctx: CoreCtx,
+  brainId: string,
+  query: string,
+  options: BrainHybridSearchOptions,
+  searchableModules: string[],
+  fieldLevels: Record<string, number>,
+  cap: number,
+): Promise<VectorRetrievalResult> {
+  if (!embeddingsEnabled()) return { candidates: [], warnings: [] };
+  const [embedding] = await embedTexts([query]);
+  if (!brainVectorServingEnabled()) {
+    return {
+      candidates: await retrieveExactVector(
+        ctx,
+        brainId,
+        embedding,
+        options,
+        searchableModules,
+        fieldLevels,
+        cap,
+      ),
+      warnings: [],
+    };
+  }
+
+  const warnings: string[] = [];
+  try {
+    const config = brainVectorClientConfig();
+    const sourceIds = await resolveVectorSourceScope(
+      ctx,
+      brainId,
+      options,
+      searchableModules,
+      fieldLevels,
+    );
+    const partitions: string[][] = [];
+    for (let offset = 0; offset < sourceIds.length; offset += BRAIN_VECTOR_MAX_SOURCE_IDS) {
+      partitions.push(sourceIds.slice(offset, offset + BRAIN_VECTOR_MAX_SOURCE_IDS));
+    }
+    const responses = await Promise.all(
+      partitions.map((partition) =>
+        searchBrainVectorApi(config, {
+          orgId: ctx.tenantId,
+          brainId,
+          subject: ctx.profileId || `org:${ctx.tenantId}`,
+          vector: embedding,
+          limit: cap,
+          filters: {
+            scopeMode: 'source_list',
+            sourceIds: partition,
+            kinds: options.kinds,
+          },
+        }),
+      ),
+    );
+    const candidates = responses
+      .flatMap((response) => response.candidates)
+      .sort((left, right) => right.score - left.score || left.chunkId.localeCompare(right.chunkId))
+      .slice(0, cap);
+    const hydrated = await rehydrateVectorCandidates(
+      ctx,
+      brainId,
+      options,
+      searchableModules,
+      fieldLevels,
+      candidates,
+      config.generation,
+      config.fingerprintKey,
+    );
+    if (hydrated.length > 0) return { candidates: hydrated, warnings };
+    warnings.push('Qdrant returned no current authorized candidates; exact vector fallback used');
+  } catch {
+    warnings.push('Qdrant vector retrieval unavailable; exact vector fallback used');
+  }
+
+  return {
+    candidates: await retrieveExactVector(
+      ctx,
+      brainId,
+      embedding,
+      options,
+      searchableModules,
+      fieldLevels,
+      cap,
+    ),
+    warnings,
+  };
 }
 
 async function retrieveLexical(
@@ -1248,10 +1455,11 @@ export async function searchBrainHybrid(
     retrieveLexical(ctx, brainId, q, options, searchableModules, fieldLevels, candidateCap),
     retrieveFuzzy(ctx, brainId, q, options, searchableModules, fieldLevels, candidateCap),
   ]);
-  const vectorCandidates = vectorResult.status === 'fulfilled' ? vectorResult.value : [];
+  const vectorCandidates = vectorResult.status === 'fulfilled' ? vectorResult.value.candidates : [];
   const lexicalCandidates = lexicalResult.status === 'fulfilled' ? lexicalResult.value : [];
   const fuzzyCandidates = fuzzyResult.status === 'fulfilled' ? fuzzyResult.value : [];
   if (vectorResult.status === 'rejected') warnings.push('vector retrieval unavailable');
+  if (vectorResult.status === 'fulfilled') warnings.push(...vectorResult.value.warnings);
   if (!embeddingsEnabled()) warnings.push('vector retrieval disabled');
   if (lexicalResult.status === 'rejected') warnings.push('lexical retrieval unavailable');
   if (fuzzyResult.status === 'rejected') warnings.push('fuzzy retrieval unavailable');

--- a/src/server/services/brain-vector-client.test.ts
+++ b/src/server/services/brain-vector-client.test.ts
@@ -1,0 +1,346 @@
+import { readFileSync } from 'node:fs';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { exportPKCS8, generateKeyPair, jwtVerify } from 'jose';
+
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+
+import {
+  BRAIN_VECTOR_CONTRACT_VERSION,
+  brainVectorCollectionName,
+  brainVectorContentFingerprint,
+  brainVectorSourceScopeHash,
+  canonicalizeBrainVectorSourceIds,
+  mintBrainVectorCapability,
+  searchBrainVectorApi,
+  type BrainVectorClientConfig,
+} from './brain-vector-client';
+
+let config: BrainVectorClientConfig;
+
+beforeAll(async () => {
+  const pair = await generateKeyPair('EdDSA', { extractable: true });
+  config = {
+    url: 'https://vectors.example.test/vectors',
+    signingPrivateKey: await exportPKCS8(pair.privateKey),
+    signingKid: 'fixture-kid',
+    fingerprintKey: '0123456789abcdef0123456789abcdef',
+    generation: 'openai_te3s_1536_g1',
+    issuer: 'minion-hub',
+    audience: 'minion-brain-vector',
+    timeoutMs: 800,
+  };
+  Object.assign(config, { publicKey: pair.publicKey });
+});
+
+describe('brain vector shared cryptographic contract', () => {
+  it('matches the published cross-repo source-scope fixture', () => {
+    expect(brainVectorSourceScopeHash(['7f-source', '1a-source', '7f-source'])).toBe(
+      'sha256:v1:gemxrtsXdAz07R5K44ohdNWe4xD_Otb7vHicOD_Bn3g',
+    );
+  });
+
+  it('rejects whitespace and non-ASCII source IDs rather than normalizing them', () => {
+    expect(() => canonicalizeBrainVectorSourceIds(['source-a', ' '])).toThrow(
+      'source IDs must use only ASCII',
+    );
+    expect(() => canonicalizeBrainVectorSourceIds(['source-💡'])).toThrow(
+      'source IDs must use only ASCII',
+    );
+  });
+
+  it('matches the published cross-repo content-fingerprint fixture', () => {
+    const key = String.fromCharCode(...Array.from({ length: 32 }, (_, index) => index));
+    expect(
+      brainVectorContentFingerprint(
+        key,
+        '018f87f4-e934-7a21-98b6-4f6b8d3898dd',
+        'sha256:8f83665f2b7ac3ec',
+        'openai_te3s_1536_g1',
+      ),
+    ).toBe('hmac-sha256:v1:huYmtzmlJ6XYRgPOuJEnCMOd3IRyOmqUKHdca3q3h6w');
+  });
+
+  it('mints a short-lived Ed25519 capability bound to org, brain, generation, and sources', async () => {
+    const pair = await generateKeyPair('EdDSA', { extractable: true });
+    const privateKey = await exportPKCS8(pair.privateKey);
+    const token = await mintBrainVectorCapability(
+      { ...config, signingPrivateKey: privateKey },
+      {
+        orgId: 'org-1',
+        brainId: '11111111-1111-4111-8111-111111111111',
+        subject: 'profile-1',
+        sourceIds: ['7f-source', '1a-source'],
+      },
+      1_000,
+    );
+    const verified = await jwtVerify(token, pair.publicKey, {
+      issuer: 'minion-hub',
+      audience: 'minion-brain-vector',
+      currentDate: new Date(1_030_000),
+    });
+    expect(verified.protectedHeader).toMatchObject({
+      alg: 'EdDSA',
+      typ: 'JWT',
+      kid: 'fixture-kid',
+    });
+    expect(verified.payload).toMatchObject({
+      sub: 'profile-1',
+      org_id: 'org-1',
+      brain_id: '11111111-1111-4111-8111-111111111111',
+      generation: 'openai_te3s_1536_g1',
+      source_scope_mode: 'source_list',
+      source_scope_hash: 'sha256:v1:gemxrtsXdAz07R5K44ohdNWe4xD_Otb7vHicOD_Bn3g',
+      op: 'search',
+      iat: 1_000,
+      exp: 1_060,
+    });
+    expect(verified.payload.jti).toEqual(expect.any(String));
+  });
+});
+
+describe('brain vector API client', () => {
+  it('canonicalizes source IDs and validates the serving generation', async () => {
+    const fetchImpl = vi.fn(async (url: URL | RequestInfo, init?: RequestInit) => {
+      expect(String(url)).toBe('https://vectors.example.test/vectors/v1/search');
+      const body = JSON.parse(String(init?.body)) as {
+        contractVersion: number;
+        filters: { scopeMode: string; sourceIds: string[] };
+      };
+      expect(body.filters.sourceIds).toEqual(['source-a', 'source-b']);
+      expect(body).toMatchObject({
+        contractVersion: BRAIN_VECTOR_CONTRACT_VERSION,
+        filters: { scopeMode: 'source_list' },
+      });
+      expect(init?.headers).toMatchObject({ Authorization: expect.stringMatching(/^Bearer /) });
+      return Response.json({
+        contractVersion: BRAIN_VECTOR_CONTRACT_VERSION,
+        generation: config.generation,
+        collection: brainVectorCollectionName(config.generation),
+        tookMs: 12,
+        candidates: [
+          {
+            chunkId: '11111111-1111-4111-8111-111111111111',
+            score: 0.8,
+            indexedFingerprint: 'hmac-sha256:v1:huYmtzmlJ6XYRgPOuJEnCMOd3IRyOmqUKHdca3q3h6w',
+          },
+        ],
+      });
+    });
+    const result = await searchBrainVectorApi(
+      config,
+      {
+        orgId: 'org-1',
+        brainId: '22222222-2222-4222-8222-222222222222',
+        subject: 'profile-1',
+        vector: Array.from({ length: 1536 }, () => 0),
+        limit: 20,
+        filters: {
+          scopeMode: 'source_list',
+          sourceIds: ['source-b', 'source-a', 'source-b'],
+        },
+      },
+      fetchImpl as typeof fetch,
+    );
+    expect(result.candidates).toHaveLength(1);
+  });
+
+  it('rejects a generation mismatch instead of accepting an unknown collection', async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json({ generation: 'wrong', collection: 'shadow', tookMs: 1, candidates: [] }),
+    );
+    await expect(
+      searchBrainVectorApi(
+        config,
+        {
+          orgId: 'org-1',
+          brainId: '22222222-2222-4222-8222-222222222222',
+          subject: 'profile-1',
+          vector: Array.from({ length: 1536 }, () => 0),
+          limit: 20,
+          filters: { scopeMode: 'source_list', sourceIds: ['source-a'] },
+        },
+        fetchImpl as typeof fetch,
+      ),
+    ).rejects.toThrow(/mismatched generation/);
+  });
+
+  it('matches the shared collection fixture and rejects unsafe generations', () => {
+    expect(brainVectorCollectionName('openai_te3s_1536_g1')).toBe(
+      'minion_brains_v1__openai_te3s_1536_g1',
+    );
+    expect(() => brainVectorCollectionName('Bad-Generation')).toThrow('generation must be');
+    expect(() => brainVectorCollectionName('a'.repeat(65))).toThrow('generation must be');
+  });
+
+  it('rejects overlong source IDs and kinds before sending a request', async () => {
+    await expect(
+      searchBrainVectorApi(config, {
+        orgId: 'org-1',
+        brainId: '22222222-2222-4222-8222-222222222222',
+        subject: 'profile-1',
+        vector: Array.from({ length: 1536 }, () => 0),
+        limit: 20,
+        filters: { scopeMode: 'source_list', sourceIds: ['s'.repeat(129)] },
+      }),
+    ).rejects.toThrow('source IDs must use only ASCII');
+    await expect(
+      searchBrainVectorApi(config, {
+        orgId: 'org-1',
+        brainId: '22222222-2222-4222-8222-222222222222',
+        subject: 'profile-1',
+        vector: Array.from({ length: 1536 }, () => 0),
+        limit: 20,
+        filters: { scopeMode: 'source_list', sourceIds: ['source-a'], kinds: ['k'.repeat(65)] },
+      }),
+    ).rejects.toThrow('kinds are invalid');
+  });
+
+  it('rejects impossible UTC calendar instants before sending a request', async () => {
+    const fetchImpl = vi.fn();
+    await expect(
+      searchBrainVectorApi(
+        config,
+        {
+          orgId: 'org-1',
+          brainId: '22222222-2222-4222-8222-222222222222',
+          subject: 'profile-1',
+          vector: Array.from({ length: 1536 }, () => 0),
+          limit: 20,
+          filters: {
+            scopeMode: 'source_list',
+            sourceIds: ['source-a'],
+            occurredAfter: '2026-02-30T00:00:00Z',
+          },
+        },
+        fetchImpl as typeof fetch,
+      ),
+    ).rejects.toThrow('dates must be RFC 3339 UTC');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('accepts non-empty canonical chunk IDs including UUIDv7/v8 shapes', async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json({
+        contractVersion: BRAIN_VECTOR_CONTRACT_VERSION,
+        generation: config.generation,
+        collection: brainVectorCollectionName(config.generation),
+        tookMs: 1,
+        candidates: [
+          {
+            chunkId: '018f87f4-e934-7a21-98b6-4f6b8d3898dd',
+            score: 0.8,
+            indexedFingerprint: 'fingerprint-v1',
+          },
+          {
+            chunkId: '018f87f4-e934-8a21-98b6-4f6b8d3898dd',
+            score: 0.7,
+            indexedFingerprint: 'fingerprint-v1',
+          },
+        ],
+      }),
+    );
+    const result = await searchBrainVectorApi(
+      config,
+      {
+        orgId: 'org-1',
+        brainId: '22222222-2222-4222-8222-222222222222',
+        subject: 'profile-1',
+        vector: Array.from({ length: 1536 }, () => 0),
+        limit: 2,
+        filters: { scopeMode: 'source_list', sourceIds: ['source-a'] },
+      },
+      fetchImpl as typeof fetch,
+    );
+    expect(result.candidates.map((candidate) => candidate.chunkId)).toEqual([
+      '018f87f4-e934-7a21-98b6-4f6b8d3898dd',
+      '018f87f4-e934-8a21-98b6-4f6b8d3898dd',
+    ]);
+  });
+
+  it('rejects a response with more candidates than the originating request limit', async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json({
+        contractVersion: BRAIN_VECTOR_CONTRACT_VERSION,
+        generation: config.generation,
+        collection: brainVectorCollectionName(config.generation),
+        tookMs: 1,
+        candidates: [
+          { chunkId: 'chunk-1', score: 0.8, indexedFingerprint: 'fingerprint-v1' },
+          { chunkId: 'chunk-2', score: 0.7, indexedFingerprint: 'fingerprint-v1' },
+        ],
+      }),
+    );
+    await expect(
+      searchBrainVectorApi(
+        config,
+        {
+          orgId: 'org-1',
+          brainId: '22222222-2222-4222-8222-222222222222',
+          subject: 'profile-1',
+          vector: Array.from({ length: 1536 }, () => 0),
+          limit: 1,
+          filters: { scopeMode: 'source_list', sourceIds: ['source-a'] },
+        },
+        fetchImpl as typeof fetch,
+      ),
+    ).rejects.toThrow('too many candidates');
+  });
+
+  it('fails closed on org_all until the Hub can prove all-source policy scope', async () => {
+    await expect(
+      searchBrainVectorApi(config, {
+        orgId: 'org-1',
+        brainId: '22222222-2222-4222-8222-222222222222',
+        subject: 'profile-1',
+        vector: Array.from({ length: 1536 }, () => 0),
+        limit: 20,
+        filters: { scopeMode: 'org_all' },
+      }),
+    ).rejects.toThrow(/org_all vector scope is not implemented/);
+  });
+});
+
+describe('brain vector outbox migration contract', () => {
+  const migration = readFileSync(
+    new URL('../../../supabase/migrations/20260723010000_brain_vector_outbox.sql', import.meta.url),
+    'utf8',
+  );
+
+  it('installs inert generation control and delete-precedence trigger semantics', () => {
+    expect(migration).toContain(
+      "values ('openai_te3s_1536_g1', 'text-embedding-3-small', 1536, false, true)",
+    );
+    expect(migration).toContain("operation := 'delete'");
+    expect(migration).toContain('revision = public.brain_vector_outbox.revision + 1');
+    expect(migration).toContain("status = 'queued'");
+    expect(migration).toContain("generation ~ '^[a-z0-9_]{1,64}$'");
+  });
+
+  it('uses revision-matched ACK deletion and RPC-only worker authority', () => {
+    expect(migration).toContain('delete from public.brain_vector_outbox o');
+    expect(migration).toContain('and o.revision = ack_brain_vector_job.revision');
+    expect(migration).toContain('create role brain_vector_worker nologin noinherit nobypassrls');
+    expect(migration).toContain(
+      'grant execute on function public.claim_brain_vector_jobs(text, integer, integer) to brain_vector_worker',
+    );
+    expect(migration).toContain(
+      'grant execute on function public.enqueue_brain_vector_backfill(text, uuid, integer) to brain_vector_worker',
+    );
+    expect(migration).toContain(
+      'grant execute on function public.brain_vector_worker_status(text) to brain_vector_worker',
+    );
+    expect(migration).toContain('unknown brain vector generation');
+    expect(migration).toContain(
+      'revoke all on public.brain_vector_outbox from public, anon, authenticated, app_ledger',
+    );
+  });
+
+  it('returns reconcile generation and reports canonical org while rejecting oversized filters', () => {
+    expect(migration).toContain('g.generation, k.source_id');
+    expect(migration).toContain(
+      'filter_existing_brain_vector_chunks accepts at most 1000 chunk IDs',
+    );
+    expect(migration).toContain("using errcode = '22023'");
+    expect(migration).toContain('select k.id, k.org_id, k.content_hash, k.embedding_model');
+  });
+});

--- a/src/server/services/brain-vector-client.ts
+++ b/src/server/services/brain-vector-client.ts
@@ -1,0 +1,353 @@
+import { createHash, createHmac, createPrivateKey, randomUUID } from 'node:crypto';
+import { env } from '$env/dynamic/private';
+import { SignJWT, importJWK, importPKCS8, type JWK } from 'jose';
+import { EMBEDDING_DIMENSIONS } from './embeddings';
+
+export const BRAIN_VECTOR_CONTRACT_VERSION = 1 as const;
+export const BRAIN_VECTOR_GENERATION_DEFAULT = 'openai_te3s_1536_g1';
+export const BRAIN_VECTOR_MAX_SOURCE_IDS = 512;
+export const BRAIN_VECTOR_MAX_CANDIDATES = 200;
+export const BRAIN_VECTOR_MAX_KINDS = 32;
+export const BRAIN_VECTOR_MAX_KIND_LENGTH = 64;
+export const BRAIN_VECTOR_SOURCE_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/u;
+export const BRAIN_VECTOR_GENERATION_PATTERN = /^[a-z0-9_]{1,64}$/u;
+export const BRAIN_VECTOR_COLLECTION_PREFIX = 'minion_brains_v1' as const;
+export const BRAIN_VECTOR_CAPABILITY_ALG = 'EdDSA' as const;
+export const BRAIN_VECTOR_CAPABILITY_CURVE = 'Ed25519' as const;
+const CAPABILITY_TTL_SECONDS = 60;
+const REQUEST_TIMEOUT_MS = 800;
+
+interface BrainVectorSearchFilterBaseV1 {
+  kinds?: string[];
+  occurredAfter?: string | null;
+  occurredBefore?: string | null;
+}
+
+export type BrainVectorSearchFilters = BrainVectorSearchFilterBaseV1 &
+  ({ scopeMode: 'source_list'; sourceIds: string[] } | { scopeMode: 'org_all'; sourceIds?: never });
+
+export interface BrainVectorCandidate {
+  chunkId: string;
+  score: number;
+  indexedFingerprint: string;
+}
+
+export interface BrainVectorSearchResponse {
+  contractVersion: typeof BRAIN_VECTOR_CONTRACT_VERSION;
+  generation: string;
+  collection: string;
+  tookMs: number;
+  candidates: BrainVectorCandidate[];
+}
+
+export interface BrainVectorClientConfig {
+  url: string;
+  signingPrivateKey: string;
+  signingKid: string;
+  fingerprintKey: string;
+  generation: string;
+  issuer: string;
+  audience: string;
+  timeoutMs: number;
+}
+
+export interface BrainVectorSearchInput {
+  orgId: string;
+  brainId: string;
+  subject: string;
+  vector: number[];
+  limit: number;
+  filters: BrainVectorSearchFilters;
+}
+
+export function brainVectorCollectionName(generation: string): string {
+  if (!BRAIN_VECTOR_GENERATION_PATTERN.test(generation)) {
+    throw new Error('generation must be 1-64 lowercase ASCII letters, digits, or underscores');
+  }
+  return `${BRAIN_VECTOR_COLLECTION_PREFIX}__${generation}`;
+}
+
+function base64url(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64url');
+}
+
+export function canonicalizeBrainVectorSourceIds(sourceIds: readonly string[]): string[] {
+  if (sourceIds.some((sourceId) => !BRAIN_VECTOR_SOURCE_ID_PATTERN.test(sourceId))) {
+    throw new Error(
+      'source IDs must use only ASCII letters, digits, dot, underscore, colon, or hyphen (1-128 chars)',
+    );
+  }
+  return [...new Set(sourceIds)].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+}
+
+/** Versioned shared-contract fixture. Never replace this with delimiter joining. */
+export function brainVectorSourceScopeHash(sourceIds: readonly string[]): string {
+  const canonical = JSON.stringify([
+    'minion-source-scope-v1',
+    ...canonicalizeBrainVectorSourceIds(sourceIds),
+  ]);
+  return `sha256:v1:${base64url(createHash('sha256').update(canonical, 'utf8').digest())}`;
+}
+
+/** Versioned keyed stale-point fingerprint. No chunk text enters Qdrant. */
+export function brainVectorContentFingerprint(
+  key: string,
+  chunkId: string,
+  contentHash: string,
+  generation: string,
+): string {
+  const keyBytes = Buffer.from(key, 'utf8');
+  if (keyBytes.byteLength < 32) {
+    throw new Error('BRAIN_VECTOR_FINGERPRINT_KEY must contain at least 32 UTF-8 bytes');
+  }
+  for (const [field, value] of [
+    ['chunkId', chunkId],
+    ['contentHash', contentHash],
+    ['generation', generation],
+  ] as const) {
+    if (value.length === 0) throw new Error(`${field} must be non-empty`);
+  }
+  const canonical = JSON.stringify([
+    'minion-content-fingerprint-v1',
+    chunkId,
+    contentHash,
+    generation,
+  ]);
+  return `hmac-sha256:v1:${base64url(createHmac('sha256', keyBytes).update(canonical, 'utf8').digest())}`;
+}
+
+export function brainVectorServingEnabled(): boolean {
+  return env.BRAIN_VECTOR_ENABLED === 'true';
+}
+
+function positiveInt(value: string | undefined, fallback: number, max: number): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(parsed) ? Math.min(Math.max(parsed, 1), max) : fallback;
+}
+
+function isUtcInstant(value: string | null | undefined): boolean {
+  if (value === undefined || value === null) return true;
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?Z$/u.exec(value);
+  if (!match) return false;
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return (
+    month >= 1 &&
+    month <= 12 &&
+    day >= 1 &&
+    day <= daysInMonth[month - 1]! &&
+    hour <= 23 &&
+    minute <= 59 &&
+    second <= 59
+  );
+}
+
+export function brainVectorClientConfig(): BrainVectorClientConfig {
+  const config = {
+    url: env.BRAIN_VECTOR_URL?.trim() || env.BRAIN_VECTOR_API_URL?.trim() || '',
+    signingPrivateKey: env.BRAIN_VECTOR_SIGNING_PRIVATE_KEY?.trim() ?? '',
+    signingKid: env.BRAIN_VECTOR_SIGNING_KID?.trim() ?? '',
+    // The shared v1 contract treats this as raw UTF-8 key material. Do not
+    // normalize it: the worker and Hub must HMAC the exact same bytes.
+    fingerprintKey: env.BRAIN_VECTOR_FINGERPRINT_KEY ?? '',
+    generation: env.BRAIN_VECTOR_GENERATION?.trim() || BRAIN_VECTOR_GENERATION_DEFAULT,
+    issuer: env.BRAIN_VECTOR_JWT_ISSUER?.trim() || 'minion-hub',
+    audience: env.BRAIN_VECTOR_JWT_AUDIENCE?.trim() || 'minion-brain-vector',
+    timeoutMs: positiveInt(env.BRAIN_VECTOR_TIMEOUT_MS, REQUEST_TIMEOUT_MS, 5_000),
+  };
+  if (!config.url || !config.signingPrivateKey || !config.signingKid || !config.fingerprintKey) {
+    throw new Error(
+      'Brain vector serving is enabled but its URL/signing/fingerprint config is incomplete',
+    );
+  }
+  if (Buffer.byteLength(config.fingerprintKey, 'utf8') < 32) {
+    throw new Error('BRAIN_VECTOR_FINGERPRINT_KEY must contain at least 32 UTF-8 bytes');
+  }
+  if (config.issuer !== 'minion-hub' || config.audience !== 'minion-brain-vector') {
+    throw new Error('Brain vector v1 issuer and audience are fixed by the shared contract');
+  }
+  brainVectorCollectionName(config.generation);
+  const url = new URL(config.url);
+  const local =
+    url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '::1';
+  if (url.protocol !== 'https:' && !(local && url.protocol === 'http:')) {
+    throw new Error('BRAIN_VECTOR_URL must use HTTPS outside localhost');
+  }
+  return config;
+}
+
+type SigningKey = Awaited<ReturnType<typeof importPKCS8>> | Awaited<ReturnType<typeof importJWK>>;
+let cachedPrivateKey: { encoded: string; key: SigningKey } | null = null;
+
+function decodeConfiguredKey(encoded: string): string {
+  if (encoded.startsWith('{') || encoded.startsWith('-----BEGIN')) return encoded;
+  return Buffer.from(encoded, 'base64').toString('utf8').trim();
+}
+
+async function importSigningKey(encoded: string): Promise<SigningKey> {
+  if (cachedPrivateKey?.encoded === encoded) return cachedPrivateKey.key;
+  const decoded = decodeConfiguredKey(encoded);
+  let key: SigningKey;
+  if (decoded.startsWith('{')) {
+    const jwk = JSON.parse(decoded) as JWK;
+    if (jwk.kty !== 'OKP' || jwk.crv !== BRAIN_VECTOR_CAPABILITY_CURVE) {
+      throw new Error('Brain vector signing JWK must be an Ed25519 private key');
+    }
+    key = await importJWK(jwk, BRAIN_VECTOR_CAPABILITY_ALG);
+  } else {
+    if (createPrivateKey(decoded).asymmetricKeyType !== 'ed25519') {
+      throw new Error('Brain vector signing PEM must be an Ed25519 private key');
+    }
+    key = await importPKCS8(decoded, BRAIN_VECTOR_CAPABILITY_ALG);
+  }
+  cachedPrivateKey = { encoded, key };
+  return key;
+}
+
+export async function mintBrainVectorCapability(
+  config: BrainVectorClientConfig,
+  input: Pick<BrainVectorSearchInput, 'orgId' | 'brainId' | 'subject'> & { sourceIds: string[] },
+  nowSeconds = Math.floor(Date.now() / 1000),
+): Promise<string> {
+  const sourceIds = canonicalizeBrainVectorSourceIds(input.sourceIds);
+  if (sourceIds.length === 0 || sourceIds.length > BRAIN_VECTOR_MAX_SOURCE_IDS) {
+    throw new Error(`Brain vector capability requires 1-${BRAIN_VECTOR_MAX_SOURCE_IDS} sources`);
+  }
+  if (
+    !input.orgId ||
+    !input.brainId ||
+    !input.subject ||
+    !BRAIN_VECTOR_GENERATION_PATTERN.test(config.generation)
+  ) {
+    throw new Error('Brain vector capability identity or generation is invalid');
+  }
+  const privateKey = await importSigningKey(config.signingPrivateKey);
+  return new SignJWT({
+    org_id: input.orgId,
+    brain_id: input.brainId,
+    generation: config.generation,
+    source_scope_mode: 'source_list',
+    source_scope_hash: brainVectorSourceScopeHash(sourceIds),
+    op: 'search',
+  })
+    .setProtectedHeader({ alg: BRAIN_VECTOR_CAPABILITY_ALG, typ: 'JWT', kid: config.signingKid })
+    .setIssuer(config.issuer)
+    .setAudience(config.audience)
+    .setSubject(input.subject)
+    .setJti(randomUUID())
+    .setIssuedAt(nowSeconds)
+    .setExpirationTime(nowSeconds + CAPABILITY_TTL_SECONDS)
+    .sign(privateKey);
+}
+
+function parseResponse(
+  value: unknown,
+  generation: string,
+  requestLimit: number,
+): BrainVectorSearchResponse {
+  if (!value || typeof value !== 'object')
+    throw new Error('Vector API returned a malformed response');
+  const row = value as Record<string, unknown>;
+  if (
+    row.contractVersion !== BRAIN_VECTOR_CONTRACT_VERSION ||
+    row.generation !== generation ||
+    row.collection !== brainVectorCollectionName(generation)
+  ) {
+    throw new Error('Vector API returned a mismatched generation or collection');
+  }
+  if (
+    !Number.isFinite(row.tookMs) ||
+    (row.tookMs as number) < 0 ||
+    !Array.isArray(row.candidates)
+  ) {
+    throw new Error('Vector API returned malformed diagnostics or candidates');
+  }
+  if (row.candidates.length > requestLimit || row.candidates.length > BRAIN_VECTOR_MAX_CANDIDATES) {
+    throw new Error('Vector API returned too many candidates');
+  }
+  const candidates = row.candidates.map((candidate) => {
+    if (!candidate || typeof candidate !== 'object') throw new Error('Malformed vector candidate');
+    const item = candidate as Record<string, unknown>;
+    if (
+      typeof item.chunkId !== 'string' ||
+      item.chunkId.length === 0 ||
+      !Number.isFinite(item.score) ||
+      typeof item.indexedFingerprint !== 'string' ||
+      item.indexedFingerprint.length === 0
+    ) {
+      throw new Error('Vector API returned an invalid candidate');
+    }
+    return {
+      chunkId: item.chunkId,
+      score: item.score as number,
+      indexedFingerprint: item.indexedFingerprint,
+    };
+  });
+  return {
+    contractVersion: BRAIN_VECTOR_CONTRACT_VERSION,
+    generation,
+    collection: row.collection,
+    tookMs: row.tookMs as number,
+    candidates,
+  };
+}
+
+export async function searchBrainVectorApi(
+  config: BrainVectorClientConfig,
+  input: BrainVectorSearchInput,
+  fetchImpl: typeof fetch = fetch,
+): Promise<BrainVectorSearchResponse> {
+  if (input.filters.scopeMode !== 'source_list') {
+    throw new Error('org_all vector scope is not implemented by the Hub');
+  }
+  const sourceIds = canonicalizeBrainVectorSourceIds(input.filters.sourceIds);
+  if (sourceIds.length === 0 || sourceIds.length > BRAIN_VECTOR_MAX_SOURCE_IDS) {
+    throw new Error(`Vector search requires 1-${BRAIN_VECTOR_MAX_SOURCE_IDS} scoped sources`);
+  }
+  if (
+    input.vector.length !== EMBEDDING_DIMENSIONS ||
+    !input.vector.every(Number.isFinite) ||
+    !Number.isInteger(input.limit) ||
+    input.limit < 1 ||
+    input.limit > BRAIN_VECTOR_MAX_CANDIDATES
+  ) {
+    throw new Error('Vector search dimensions or limit are invalid');
+  }
+  if (
+    input.filters.kinds !== undefined &&
+    (input.filters.kinds.length > BRAIN_VECTOR_MAX_KINDS ||
+      input.filters.kinds.some(
+        (kind) => kind.length === 0 || kind.length > BRAIN_VECTOR_MAX_KIND_LENGTH,
+      ))
+  ) {
+    throw new Error('Vector search kinds are invalid');
+  }
+  if (!isUtcInstant(input.filters.occurredAfter) || !isUtcInstant(input.filters.occurredBefore)) {
+    throw new Error('Vector search dates must be RFC 3339 UTC instants ending in Z');
+  }
+  const token = await mintBrainVectorCapability(config, { ...input, sourceIds });
+  const baseUrl = config.url.endsWith('/') ? config.url : `${config.url}/`;
+  const response = await fetchImpl(new URL('v1/search', baseUrl), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contractVersion: BRAIN_VECTOR_CONTRACT_VERSION,
+      generation: config.generation,
+      vector: input.vector,
+      limit: input.limit,
+      filters: { ...input.filters, scopeMode: 'source_list', sourceIds },
+    }),
+    signal: AbortSignal.timeout(config.timeoutMs),
+  });
+  if (!response.ok) {
+    throw new Error(`Vector API search failed (${response.status})`);
+  }
+  return parseResponse(await response.json(), config.generation, input.limit);
+}

--- a/supabase/migrations/20260723010000_brain_vector_outbox.sql
+++ b/supabase/migrations/20260723010000_brain_vector_outbox.sql
@@ -1,0 +1,591 @@
+-- Durable, forward-safe serving-index outbox for Unified Brains.
+--
+-- Supabase remains canonical. The trigger is deliberately inert until an
+-- operator enables the generation control row after the private worker and
+-- Qdrant collection have passed readiness checks.
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+create table if not exists public.brain_vector_generations (
+  generation text primary key,
+  embedding_model text not null,
+  dimensions integer not null,
+  enqueue_enabled boolean not null default false,
+  is_active boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint brain_vector_generations_dimensions_check check (dimensions > 0),
+  constraint brain_vector_generations_name_check check (generation ~ '^[a-z0-9_]{1,64}$')
+);
+
+create unique index if not exists brain_vector_generations_one_active_uniq
+  on public.brain_vector_generations (is_active) where is_active;
+
+insert into public.brain_vector_generations
+  (generation, embedding_model, dimensions, enqueue_enabled, is_active)
+values ('openai_te3s_1536_g1', 'text-embedding-3-small', 1536, false, true)
+on conflict (generation) do nothing;
+
+create table if not exists public.brain_vector_outbox (
+  chunk_id uuid not null,
+  org_id text not null,
+  collection_generation text not null,
+  desired_operation text not null,
+  desired_content_hash text,
+  revision bigint not null default 1,
+  status text not null default 'queued',
+  attempts integer not null default 0,
+  available_at timestamptz not null default now(),
+  lease_owner text,
+  lease_until timestamptz,
+  last_error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (chunk_id, collection_generation),
+  constraint brain_vector_outbox_generation_fk foreign key (collection_generation)
+    references public.brain_vector_generations (generation),
+  constraint brain_vector_outbox_operation_check check (desired_operation in ('upsert', 'delete')),
+  constraint brain_vector_outbox_status_check check (status in ('queued', 'running', 'dead')),
+  constraint brain_vector_outbox_revision_check check (revision > 0),
+  constraint brain_vector_outbox_attempts_check check (attempts >= 0)
+);
+
+create index if not exists brain_vector_outbox_claim_idx
+  on public.brain_vector_outbox (available_at, updated_at)
+  where status = 'queued';
+create index if not exists brain_vector_outbox_expired_lease_idx
+  on public.brain_vector_outbox (lease_until)
+  where status = 'running';
+create index if not exists brain_vector_outbox_org_idx
+  on public.brain_vector_outbox (org_id, collection_generation);
+
+create table if not exists public.brain_vector_reconcile_state (
+  collection_generation text primary key references public.brain_vector_generations (generation),
+  after_chunk_id uuid,
+  cycle_started_at timestamptz,
+  last_completed_at timestamptz,
+  scanned bigint not null default 0,
+  repaired bigint not null default 0,
+  orphaned bigint not null default 0,
+  failed bigint not null default 0,
+  updated_at timestamptz not null default now()
+);
+
+insert into public.brain_vector_reconcile_state (collection_generation)
+values ('openai_te3s_1536_g1')
+on conflict (collection_generation) do nothing;
+
+alter table public.brain_vector_generations enable row level security;
+alter table public.brain_vector_generations force row level security;
+alter table public.brain_vector_outbox enable row level security;
+alter table public.brain_vector_outbox force row level security;
+alter table public.brain_vector_reconcile_state enable row level security;
+alter table public.brain_vector_reconcile_state force row level security;
+
+-- No app_ledger policy or table grant is intentional: Hub users and ordinary
+-- application transactions cannot inspect or mutate worker coordination state.
+revoke all on public.brain_vector_generations from public, anon, authenticated, app_ledger;
+revoke all on public.brain_vector_outbox from public, anon, authenticated, app_ledger;
+revoke all on public.brain_vector_reconcile_state from public, anon, authenticated, app_ledger;
+
+create or replace function public.enqueue_brain_vector_chunk()
+returns trigger
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  target public.brain_vector_generations%rowtype;
+  operation text;
+  chunk_uuid uuid;
+  chunk_org text;
+  chunk_hash text;
+begin
+  select * into target
+  from public.brain_vector_generations
+  where is_active and enqueue_enabled
+  limit 1;
+
+  if not found then
+    if tg_op = 'DELETE' then return old; else return new; end if;
+  end if;
+
+  if tg_op = 'DELETE' then
+    operation := 'delete';
+    chunk_uuid := old.id;
+    chunk_org := old.org_id;
+    chunk_hash := old.content_hash;
+  elsif tg_op = 'INSERT' and (
+    new.embedding is null or new.embedding_model is distinct from target.embedding_model
+  ) then
+    return new;
+  elsif new.embedding is null or new.embedding_model is distinct from target.embedding_model then
+    -- An incomplete canonical chunk has no valid serving-index state. If a
+    -- prior point exists, delete wins over a formerly queued upsert.
+    operation := 'delete';
+    chunk_uuid := new.id;
+    chunk_org := new.org_id;
+    chunk_hash := new.content_hash;
+  else
+    operation := 'upsert';
+    chunk_uuid := new.id;
+    chunk_org := new.org_id;
+    chunk_hash := new.content_hash;
+  end if;
+
+  if tg_op = 'UPDATE'
+     and new.content_hash is not distinct from old.content_hash
+     and new.embedding_model is not distinct from old.embedding_model
+     and new.embedding is not distinct from old.embedding
+     and new.org_id is not distinct from old.org_id
+     and new.source_id is not distinct from old.source_id
+     and new.document_id is not distinct from old.document_id
+     and new.kind is not distinct from old.kind
+     and new.occurred_at is not distinct from old.occurred_at then
+    return new;
+  end if;
+
+  insert into public.brain_vector_outbox (
+    chunk_id, org_id, collection_generation, desired_operation,
+    desired_content_hash, revision, status, attempts, available_at,
+    lease_owner, lease_until, last_error, updated_at
+  ) values (
+    chunk_uuid, chunk_org, target.generation, operation,
+    chunk_hash, 1, 'queued', 0, now(), null, null, null, now()
+  )
+  on conflict (chunk_id, collection_generation) do update set
+    org_id = excluded.org_id,
+    desired_operation = excluded.desired_operation,
+    desired_content_hash = excluded.desired_content_hash,
+    revision = public.brain_vector_outbox.revision + 1,
+    status = 'queued',
+    attempts = 0,
+    available_at = now(),
+    lease_owner = null,
+    lease_until = null,
+    last_error = null,
+    updated_at = now();
+
+  if tg_op = 'DELETE' then return old; else return new; end if;
+end;
+$$;
+
+drop trigger if exists knowledge_chunks_vector_outbox on public.knowledge_chunks;
+create trigger knowledge_chunks_vector_outbox
+after insert or update of content_hash, embedding_model, embedding, org_id, source_id, document_id, kind, occurred_at or delete
+on public.knowledge_chunks
+for each row execute function public.enqueue_brain_vector_chunk();
+
+-- A NOLOGIN group role is safe to install through migrations. Production
+-- provisioning creates a LOGIN role with a rotated password and grants this
+-- role to it; no broad service-role credential is required by the worker.
+do $$
+begin
+  if not exists (select 1 from pg_roles where rolname = 'brain_vector_worker') then
+    create role brain_vector_worker nologin noinherit nobypassrls;
+  end if;
+end
+$$;
+
+create or replace function public.claim_brain_vector_jobs(
+  worker_id text,
+  job_limit integer default 100,
+  lease_seconds integer default 60
+)
+returns table (
+  chunk_id uuid,
+  org_id text,
+  generation text,
+  operation text,
+  revision bigint,
+  attempts integer,
+  source_id uuid,
+  document_id uuid,
+  kind text,
+  occurred_at timestamptz,
+  content_hash text,
+  embedding_model text,
+  embedding text
+)
+language sql
+security definer
+set search_path = pg_catalog, public
+set statement_timeout = '15s'
+as $$
+  with claimed as (
+    select o.chunk_id, o.collection_generation
+    from public.brain_vector_outbox o
+    where (
+      (o.status = 'queued' and o.available_at <= now())
+      or (o.status = 'running' and o.lease_until < now())
+    )
+    order by o.available_at, o.updated_at, o.chunk_id
+    for update skip locked
+    limit least(greatest(job_limit, 1), 500)
+  ), leased as (
+    update public.brain_vector_outbox o
+    set status = 'running',
+        attempts = o.attempts + 1,
+        lease_owner = left(worker_id, 200),
+        lease_until = now() + make_interval(secs => least(greatest(lease_seconds, 10), 900)),
+        updated_at = now()
+    from claimed c
+    where o.chunk_id = c.chunk_id
+      and o.collection_generation = c.collection_generation
+    returning o.*
+  )
+  select
+    l.chunk_id,
+    l.org_id,
+    l.collection_generation as generation,
+    case when k.id is null then 'delete' else l.desired_operation end as operation,
+    l.revision,
+    l.attempts,
+    k.source_id,
+    k.document_id,
+    k.kind,
+    k.occurred_at,
+    k.content_hash,
+    k.embedding_model,
+    k.embedding::text
+  from leased l
+  left join public.knowledge_chunks k
+    on k.id = l.chunk_id and k.org_id = l.org_id;
+$$;
+
+create or replace function public.ack_brain_vector_job(
+  chunk_id uuid,
+  generation text,
+  revision bigint
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+begin
+  delete from public.brain_vector_outbox o
+  where o.chunk_id = ack_brain_vector_job.chunk_id
+    and o.collection_generation = ack_brain_vector_job.generation
+    and o.revision = ack_brain_vector_job.revision
+    and o.status = 'running';
+  return found;
+end;
+$$;
+
+create or replace function public.retry_brain_vector_job(
+  chunk_id uuid,
+  generation text,
+  revision bigint,
+  error text,
+  available_at timestamptz
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+begin
+  update public.brain_vector_outbox o
+  set status = case when o.attempts >= 8 then 'dead' else 'queued' end,
+      available_at = least(greatest(retry_brain_vector_job.available_at, now() + interval '1 second'), now() + interval '24 hours'),
+      lease_owner = null,
+      lease_until = null,
+      last_error = left(retry_brain_vector_job.error, 2000),
+      updated_at = now()
+  where o.chunk_id = retry_brain_vector_job.chunk_id
+    and o.collection_generation = retry_brain_vector_job.generation
+    and o.revision = retry_brain_vector_job.revision
+    and o.status = 'running';
+  return found;
+end;
+$$;
+
+create or replace function public.dead_letter_brain_vector_job(
+  chunk_id uuid,
+  generation text,
+  revision bigint,
+  error text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+begin
+  update public.brain_vector_outbox o
+  set status = 'dead',
+      lease_owner = null,
+      lease_until = null,
+      last_error = left(dead_letter_brain_vector_job.error, 2000),
+      updated_at = now()
+  where o.chunk_id = dead_letter_brain_vector_job.chunk_id
+    and o.collection_generation = dead_letter_brain_vector_job.generation
+    and o.revision = dead_letter_brain_vector_job.revision
+    and o.status = 'running';
+  return found;
+end;
+$$;
+
+create or replace function public.list_brain_vector_chunks(
+  after_chunk_id uuid default null,
+  row_limit integer default 500,
+  generation text default 'openai_te3s_1536_g1'
+)
+returns table (
+  chunk_id uuid,
+  org_id text,
+  generation text,
+  source_id uuid,
+  document_id uuid,
+  kind text,
+  occurred_at timestamptz,
+  content_hash text,
+  embedding_model text,
+  embedding text
+)
+language sql
+security definer
+set search_path = pg_catalog, public
+set statement_timeout = '15s'
+as $$
+  select k.id, k.org_id, g.generation, k.source_id, k.document_id, k.kind, k.occurred_at,
+         k.content_hash, k.embedding_model, k.embedding::text
+  from public.knowledge_chunks k
+  join public.brain_vector_generations g
+    on g.generation = list_brain_vector_chunks.generation
+   and g.embedding_model = k.embedding_model
+  where k.embedding is not null
+    and (after_chunk_id is null or k.id > after_chunk_id)
+  order by k.id
+  limit least(greatest(row_limit, 1), 1000);
+$$;
+
+create or replace function public.filter_existing_brain_vector_chunks(
+  chunk_ids uuid[],
+  generation text
+)
+returns table (
+  chunk_id uuid,
+  org_id text,
+  content_hash text,
+  embedding_model text
+)
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+set statement_timeout = '10s'
+as $$
+begin
+  if cardinality(chunk_ids) > 1000 then
+    raise exception 'filter_existing_brain_vector_chunks accepts at most 1000 chunk IDs'
+      using errcode = '22023';
+  end if;
+
+  return query
+  select k.id, k.org_id, k.content_hash, k.embedding_model
+  from public.knowledge_chunks k
+  join public.brain_vector_generations g
+    on g.generation = filter_existing_brain_vector_chunks.generation
+   and g.embedding_model = k.embedding_model
+  where cardinality(chunk_ids) >= 1
+    and k.id = any(chunk_ids)
+    and k.embedding is not null
+  order by k.id;
+end;
+$$;
+
+create or replace function public.enqueue_brain_vector_backfill(
+  generation text,
+  after_chunk_id uuid default null,
+  row_limit integer default 500
+)
+returns table (enqueued integer, next_chunk_id uuid)
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+set statement_timeout = '20s'
+as $$
+declare
+  changed integer := 0;
+  cursor_id uuid;
+begin
+  with page as materialized (
+    select k.id, k.org_id, k.content_hash
+    from public.knowledge_chunks k
+    join public.brain_vector_generations g
+      on g.generation = enqueue_brain_vector_backfill.generation
+     and g.embedding_model = k.embedding_model
+     and g.enqueue_enabled
+    where k.embedding is not null
+      and (after_chunk_id is null or k.id > after_chunk_id)
+    order by k.id
+    limit least(greatest(row_limit, 1), 1000)
+  )
+  insert into public.brain_vector_outbox (
+    chunk_id, org_id, collection_generation, desired_operation,
+    desired_content_hash, revision, status, attempts, available_at,
+    lease_owner, lease_until, last_error, updated_at
+  )
+  select id, org_id, generation, 'upsert', content_hash, 1, 'queued', 0,
+         now(), null, null, null, now()
+  from page
+  on conflict (chunk_id, collection_generation) do update set
+    org_id = excluded.org_id,
+    desired_operation = 'upsert',
+    desired_content_hash = excluded.desired_content_hash,
+    revision = public.brain_vector_outbox.revision + 1,
+    status = 'queued', attempts = 0, available_at = now(),
+    lease_owner = null, lease_until = null, last_error = null, updated_at = now()
+  where public.brain_vector_outbox.desired_operation <> 'upsert'
+     or public.brain_vector_outbox.desired_content_hash is distinct from excluded.desired_content_hash;
+  get diagnostics changed = row_count;
+
+  select page.id into cursor_id
+  from (
+    select k.id
+    from public.knowledge_chunks k
+    join public.brain_vector_generations g
+      on g.generation = enqueue_brain_vector_backfill.generation
+     and g.embedding_model = k.embedding_model
+     and g.enqueue_enabled
+    where k.embedding is not null
+      and (after_chunk_id is null or k.id > after_chunk_id)
+    order by k.id
+    limit least(greatest(row_limit, 1), 1000)
+  ) page
+  order by page.id desc
+  limit 1;
+
+  return query select changed, cursor_id;
+end;
+$$;
+
+create or replace function public.load_brain_vector_reconcile_cursor(generation text)
+returns table (
+  after_chunk_id uuid,
+  cycle_started_at timestamptz,
+  last_completed_at timestamptz,
+  scanned bigint,
+  repaired bigint,
+  orphaned bigint,
+  failed bigint
+)
+language sql
+security definer
+set search_path = pg_catalog, public
+as $$
+  select s.after_chunk_id, s.cycle_started_at, s.last_completed_at,
+         s.scanned, s.repaired, s.orphaned, s.failed
+  from public.brain_vector_reconcile_state s
+  where s.collection_generation = load_brain_vector_reconcile_cursor.generation;
+$$;
+
+create or replace function public.save_brain_vector_reconcile_cursor(
+  generation text,
+  next_chunk_id uuid,
+  scanned_delta integer default 0,
+  repaired_delta integer default 0,
+  orphaned_delta integer default 0,
+  failed_delta integer default 0,
+  cycle_complete boolean default false
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+begin
+  update public.brain_vector_reconcile_state s
+  set after_chunk_id = case when cycle_complete then null else next_chunk_id end,
+      cycle_started_at = case
+        when cycle_complete then null
+        else coalesce(s.cycle_started_at, now())
+      end,
+      last_completed_at = case when cycle_complete then now() else s.last_completed_at end,
+      scanned = case when cycle_complete then 0 else s.scanned + greatest(scanned_delta, 0) end,
+      repaired = case when cycle_complete then 0 else s.repaired + greatest(repaired_delta, 0) end,
+      orphaned = case when cycle_complete then 0 else s.orphaned + greatest(orphaned_delta, 0) end,
+      failed = case when cycle_complete then 0 else s.failed + greatest(failed_delta, 0) end,
+      updated_at = now()
+  where s.collection_generation = save_brain_vector_reconcile_cursor.generation;
+  return found;
+end;
+$$;
+
+create or replace function public.brain_vector_worker_status(p_generation text)
+returns table (
+  queued bigint,
+  running bigint,
+  dead bigint,
+  oldest_queued_at timestamptz,
+  canonical_chunks bigint,
+  last_reconcile_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+set statement_timeout = '15s'
+as $$
+begin
+  if not exists (
+    select 1
+    from public.brain_vector_generations g
+    where g.generation = p_generation
+  ) then
+    raise exception 'unknown brain vector generation: %', p_generation
+      using errcode = '22023';
+  end if;
+
+  return query
+  select
+    count(*) filter (where o.status = 'queued')::bigint,
+    count(*) filter (where o.status = 'running')::bigint,
+    count(*) filter (where o.status = 'dead')::bigint,
+    min(o.available_at) filter (where o.status = 'queued'),
+    (
+      select count(*)::bigint
+      from public.knowledge_chunks k
+      join public.brain_vector_generations g
+        on g.generation = p_generation
+       and g.embedding_model = k.embedding_model
+      where k.embedding is not null
+    ),
+    (
+      select s.last_completed_at
+      from public.brain_vector_reconcile_state s
+      where s.collection_generation = p_generation
+    )
+  from public.brain_vector_outbox o
+  where o.collection_generation = p_generation;
+end;
+$$;
+
+revoke all on function public.enqueue_brain_vector_chunk() from public, anon, authenticated, app_ledger;
+revoke all on function public.claim_brain_vector_jobs(text, integer, integer) from public, anon, authenticated, app_ledger;
+revoke all on function public.ack_brain_vector_job(uuid, text, bigint) from public, anon, authenticated, app_ledger;
+revoke all on function public.retry_brain_vector_job(uuid, text, bigint, text, timestamptz) from public, anon, authenticated, app_ledger;
+revoke all on function public.dead_letter_brain_vector_job(uuid, text, bigint, text) from public, anon, authenticated, app_ledger;
+revoke all on function public.list_brain_vector_chunks(uuid, integer, text) from public, anon, authenticated, app_ledger;
+revoke all on function public.filter_existing_brain_vector_chunks(uuid[], text) from public, anon, authenticated, app_ledger;
+revoke all on function public.enqueue_brain_vector_backfill(text, uuid, integer) from public, anon, authenticated, app_ledger;
+revoke all on function public.load_brain_vector_reconcile_cursor(text) from public, anon, authenticated, app_ledger;
+revoke all on function public.save_brain_vector_reconcile_cursor(text, uuid, integer, integer, integer, integer, boolean) from public, anon, authenticated, app_ledger;
+revoke all on function public.brain_vector_worker_status(text) from public, anon, authenticated, app_ledger;
+
+grant execute on function public.claim_brain_vector_jobs(text, integer, integer) to brain_vector_worker;
+grant execute on function public.ack_brain_vector_job(uuid, text, bigint) to brain_vector_worker;
+grant execute on function public.retry_brain_vector_job(uuid, text, bigint, text, timestamptz) to brain_vector_worker;
+grant execute on function public.dead_letter_brain_vector_job(uuid, text, bigint, text) to brain_vector_worker;
+grant execute on function public.list_brain_vector_chunks(uuid, integer, text) to brain_vector_worker;
+grant execute on function public.filter_existing_brain_vector_chunks(uuid[], text) to brain_vector_worker;
+grant execute on function public.enqueue_brain_vector_backfill(text, uuid, integer) to brain_vector_worker;
+grant execute on function public.load_brain_vector_reconcile_cursor(text) to brain_vector_worker;
+grant execute on function public.save_brain_vector_reconcile_cursor(text, uuid, integer, integer, integer, integer, boolean) to brain_vector_worker;
+grant execute on function public.brain_vector_worker_status(text) to brain_vector_worker;
+
+comment on table public.brain_vector_outbox is
+  'Latest desired Qdrant serving-index state. Empty is not proof of canonical/index parity.';
+comment on table public.brain_vector_generations is
+  'Vector generation control. enqueue_enabled defaults false so infrastructure migrations are inert.';


### PR DESCRIPTION
Adds the Supabase-canonical Qdrant serving bridge for Unified Brains: inert generation controls, revisioned outbox and restricted SECURITY DEFINER worker RPCs, generation-aware reconciliation, worker status counters, fail-closed Ed25519 search client, authorization-preserving Supabase rehydration, stale fingerprint rejection, and exact-vector fallback. The migration keeps enqueue disabled by default. Validation: 2,332 Hub tests, svelte-check 0/0, focused 15 tests, and the disposable pgvector/Postgres FORCE-RLS trigger/claim/ACK/status canary all pass. Fable 5 implementation findings were incorporated.