### PR TITLE
fix(home): scope brain chat to active org

### DIFF
--- a/src/lib/services/gateway/chat-rpc.ts
+++ b/src/lib/services/gateway/chat-rpc.ts
@@ -133,7 +133,10 @@ export function stripVoiceTurnPrefix(text: string): string {
  * so a bracket-balanced match would stop early.
  */
 export function stripAssistantContext(text: string): string {
-  return text.replace(/^\s*\[In-app assistant context[\s\S]*?Don't restate this context\.\]\s*/, '');
+  return text.replace(
+    /^\s*\[In-app assistant context[\s\S]*?Don't restate this context\.\]\s*/,
+    '',
+  );
 }
 
 /** A dragged-context block parsed back out of a sent user message. */
@@ -185,7 +188,7 @@ const INBOUND_CONTEXT_BLOCKS: RegExp[] = [
  */
 export function cleanInboundForDisplay(text: string): string {
   let t = text;
-  for (let changed = true; changed; ) {
+  for (let changed = true; changed;) {
     changed = false;
     for (const re of INBOUND_CONTEXT_BLOCKS) {
       const next = t.replace(re, '');
@@ -199,19 +202,25 @@ export function cleanInboundForDisplay(text: string): string {
 }
 
 /**
- * Floating-assistant equivalent of sendChatMsg. Same agent + main session, but the
- * message the gateway sees is prefixed with a page-context envelope (route, focus,
- * navigation instructions) so the assistant is situationally aware. The clean user
- * text — not the envelope — is what's stored in the visible transcript, exactly like
- * the voice-turn path. `context` is built by buildAssistantContext() at the callsite
- * (it needs `$app/state` page, which only resolves in the component tree).
+ * Context-aware equivalent of sendChatMsg. Floating surfaces use the default
+ * main session; `/home` passes its selected conversation key explicitly. The
+ * message the gateway sees is prefixed with a page-context envelope (route,
+ * focus, navigation instructions) so the assistant is situationally aware.
+ * The clean user text — not the envelope — is what's stored in the visible
+ * transcript, exactly like the voice-turn path. `context` is built by
+ * buildAssistantContext() at the callsite (it needs `$app/state` page, which
+ * only resolves in the component tree).
  */
-export function sendAssistantTurn(agentId: string, text: string, context: string) {
+export function sendAssistantTurn(
+  agentId: string,
+  text: string,
+  context: string,
+  sessionKey = `agent:${agentId}:main`,
+) {
   const chat = ensureAgentChat(agentId);
   const clean = text.trim();
   if (!clean || chat.sending || !conn.connected) return;
 
-  const sessionKey = `agent:${agentId}:main`;
   const runId = uuid();
 
   pushChatMessage(chat, {

--- a/src/lib/state/features/assistant-context.test.ts
+++ b/src/lib/state/features/assistant-context.test.ts
@@ -3,80 +3,103 @@ import { describe, test, expect, vi, beforeEach } from 'vitest';
 // Mutable mock — buildAssistantContext reads page.url + page.data at call time,
 // so reassigning these between calls exercises each route/focus branch.
 const page = {
-	url: new URL('https://hub/'),
-	data: {} as Record<string, unknown>,
+  url: new URL('https://hub/'),
+  data: {} as Record<string, unknown>,
 };
-vi.mock('$app/state', () => ({ get page() { return page; } }));
+vi.mock('$app/state', () => ({
+  get page() {
+    return page;
+  },
+}));
 
 const { buildAssistantContext } = await import('./assistant-context');
 
 function at(path: string, data: Record<string, unknown> = {}) {
-	page.url = new URL(`https://hub${path}`);
-	page.data = data;
-	return buildAssistantContext();
+  page.url = new URL(`https://hub${path}`);
+  page.data = data;
+  return buildAssistantContext();
 }
 
 describe('buildAssistantContext', () => {
-	beforeEach(() => {
-		page.data = {};
-	});
+  beforeEach(() => {
+    page.data = {};
+  });
 
-	test('describes the current route', () => {
-		expect(at('/finances/invoices')).toContain('Current page: /finances/invoices');
-		expect(at('/finances/invoices')).toContain('Invoices list');
-	});
+  test('describes the current route', () => {
+    expect(at('/finances/invoices')).toContain('Current page: /finances/invoices');
+    expect(at('/finances/invoices')).toContain('Invoices list');
+  });
 
-	test('longest-prefix wins (/crm/customers vs /crm/{id} vs /crm)', () => {
-		expect(at('/crm/customers')).toContain('customers grid');
-		expect(at('/crm/abc-123')).toContain("customer's CRM profile");
-		expect(at('/crm')).toContain('CRM dashboard');
-	});
+  test('longest-prefix wins (/crm/customers vs /crm/{id} vs /crm)', () => {
+    expect(at('/crm/customers')).toContain('customers grid');
+    expect(at('/crm/abc-123')).toContain("customer's CRM profile");
+    expect(at('/crm')).toContain('CRM dashboard');
+  });
 
-	test('surfaces a focused customer id from the path', () => {
-		const ctx = at('/crm/abc-123');
-		expect(ctx).toContain('focused on customer id abc-123');
-		expect(ctx).toContain('/crm/abc-123');
-	});
+  test('surfaces a focused customer id from the path', () => {
+    const ctx = at('/crm/abc-123');
+    expect(ctx).toContain('focused on customer id abc-123');
+    expect(ctx).toContain('/crm/abc-123');
+  });
 
-	test('surfaces ?contact= filter as a linkable focus', () => {
-		const ctx = at('/finances/invoices?contact=p-9');
-		expect(ctx).toContain('filtered to customer id p-9');
-		expect(ctx).toContain('/crm/p-9');
-	});
+  test('surfaces ?contact= filter as a linkable focus', () => {
+    const ctx = at('/finances/invoices?contact=p-9');
+    expect(ctx).toContain('filtered to customer id p-9');
+    expect(ctx).toContain('/crm/p-9');
+  });
 
-	test('includes the active org name when resolvable', () => {
-		const ctx = at('/crm', {
-			organizations: [{ id: 'o1', name: 'FACES' }, { id: 'o2', name: 'MINION' }],
-			activeOrgId: 'o2',
-		});
-		expect(ctx).toContain('for MINION');
-	});
+  test('includes the active org name when resolvable', () => {
+    const ctx = at('/crm', {
+      organizations: [
+        { id: 'o1', name: 'FACES' },
+        { id: 'o2', name: 'MINION' },
+      ],
+      activeOrgId: 'o2',
+    });
+    expect(ctx).toContain('for MINION');
+  });
 
-	test('multi-org user gets a machine-readable active_org_id for data tools', () => {
-		const ctx = at('/crm', {
-			organizations: [{ id: 'o1', name: 'FACES' }, { id: 'o2', name: 'MINION' }],
-			activeOrgId: 'o2',
-		});
-		expect(ctx).toContain('active_org_id: o2');
-	});
+  test('multi-org user gets a machine-readable active_org_id for data tools', () => {
+    const ctx = at('/crm', {
+      organizations: [
+        { id: 'o1', name: 'FACES' },
+        { id: 'o2', name: 'MINION' },
+      ],
+      activeOrgId: 'o2',
+    });
+    expect(ctx).toContain('active_org_id: o2');
+  });
 
-	test('single-org user gets NO active_org_id line (endpoint defaults)', () => {
-		const ctx = at('/crm', {
-			organizations: [{ id: 'o1', name: 'FACES' }],
-			activeOrgId: 'o1',
-		});
-		expect(ctx).toContain('for FACES');
-		expect(ctx).not.toContain('active_org_id');
-	});
+  test('single-org user gets NO active_org_id line (endpoint defaults)', () => {
+    const ctx = at('/crm', {
+      organizations: [{ id: 'o1', name: 'FACES' }],
+      activeOrgId: 'o1',
+    });
+    expect(ctx).toContain('for FACES');
+    expect(ctx).not.toContain('active_org_id');
+  });
 
-	test('always teaches the in-app-link navigation convention', () => {
-		const ctx = at('/');
-		expect(ctx).toContain('[label](/path)');
-		expect(ctx).toContain('click is the user');
-	});
+  test('routes organization knowledge through the active org Master Brain', () => {
+    const ctx = at('/home', {
+      organizations: [
+        { id: 'o1', name: 'FACES' },
+        { id: 'o2', name: 'MINION' },
+      ],
+      activeOrgId: 'o2',
+    });
+    expect(ctx).toContain('call brains_list with the active orgId');
+    expect(ctx).toContain("select that organization's Master Brain");
+    expect(ctx).toContain('Never guess or reuse a brainId from another organization');
+  });
 
-	test('no focus clause when nothing is focused', () => {
-		const ctx = at('/sessions');
-		expect(ctx).not.toContain('Focus:');
-	});
+  test('always teaches the in-app-link navigation convention', () => {
+    const ctx = at('/');
+    expect(ctx).toContain('[label](/path)');
+    expect(ctx).toContain('click is the user');
+  });
+
+  test('no focus clause when nothing is focused', () => {
+    const ctx = at('/sessions');
+    expect(ctx).not.toContain('Focus:');
+  });
 });

--- a/src/lib/state/features/assistant-context.ts
+++ b/src/lib/state/features/assistant-context.ts
@@ -16,44 +16,47 @@
  */
 
 import { page } from '$app/state';
-import { HUB_ROUTE_MAP, HUB_NOTABLE_PARAMS } from '../../../routes/api/gateway/_shared/hub-route-map';
+import {
+  HUB_ROUTE_MAP,
+  HUB_NOTABLE_PARAMS,
+} from '../../../routes/api/gateway/_shared/hub-route-map';
 
 function describeRoute(pathname: string): string {
-	for (const [prefix, desc] of HUB_ROUTE_MAP) {
-		if (prefix === '/' ? pathname === '/' : pathname.startsWith(prefix)) return desc;
-	}
-	return 'A page in the dashboard.';
+  for (const [prefix, desc] of HUB_ROUTE_MAP) {
+    if (prefix === '/' ? pathname === '/' : pathname.startsWith(prefix)) return desc;
+  }
+  return 'A page in the dashboard.';
 }
 
 /** A short "what's focused" clause from dynamic id segments + notable query params. */
 function describeFocus(pathname: string, params: URLSearchParams): string {
-	const bits: string[] = [];
+  const bits: string[] = [];
 
-	// A trailing id segment after a known collection (e.g. /crm/<id>) = a focused record.
-	const seg = pathname.split('/').filter(Boolean);
-	if (seg[0] === 'crm' && seg[1] && seg[1] !== 'customers') {
-		bits.push(`focused on customer id ${seg[1]} (link as /crm/${seg[1]})`);
-	}
+  // A trailing id segment after a known collection (e.g. /crm/<id>) = a focused record.
+  const seg = pathname.split('/').filter(Boolean);
+  if (seg[0] === 'crm' && seg[1] && seg[1] !== 'customers') {
+    bits.push(`focused on customer id ${seg[1]} (link as /crm/${seg[1]})`);
+  }
 
-	for (const k of HUB_NOTABLE_PARAMS) {
-		const v = params.get(k);
-		if (!v) continue;
-		if (k === 'contact') bits.push(`filtered to customer id ${v} (link as /crm/${v})`);
-		else if (k === 'new') bits.push('a create/new form is open');
-		else bits.push(`${k}=${v}`);
-	}
+  for (const k of HUB_NOTABLE_PARAMS) {
+    const v = params.get(k);
+    if (!v) continue;
+    if (k === 'contact') bits.push(`filtered to customer id ${v} (link as /crm/${v})`);
+    else if (k === 'new') bits.push('a create/new form is open');
+    else bits.push(`${k}=${v}`);
+  }
 
-	return bits.join('; ');
+  return bits.join('; ');
 }
 
 function activeOrg(): { name: string | null; id: string | null; multi: boolean } {
-	const data = page.data as
-		| { organizations?: Array<{ id: string; name?: string }>; activeOrgId?: string | null }
-		| undefined;
-	const orgs = data?.organizations ?? [];
-	const id = data?.activeOrgId ?? null;
-	const name = id ? (orgs.find((o) => o.id === id)?.name ?? null) : null;
-	return { name, id, multi: orgs.length > 1 };
+  const data = page.data as
+    | { organizations?: Array<{ id: string; name?: string }>; activeOrgId?: string | null }
+    | undefined;
+  const orgs = data?.organizations ?? [];
+  const id = data?.activeOrgId ?? null;
+  const name = id ? (orgs.find((o) => o.id === id)?.name ?? null) : null;
+  return { name, id, multi: orgs.length > 1 };
 }
 
 /**
@@ -61,38 +64,43 @@ function activeOrg(): { name: string | null; id: string | null; multi: boolean }
  * Returns '' when there's nothing useful to add (the agent still works plainly).
  */
 export function buildAssistantContext(): string {
-	const pathname = page.url?.pathname ?? '/';
-	const params = page.url?.searchParams ?? new URLSearchParams();
+  const pathname = page.url?.pathname ?? '/';
+  const params = page.url?.searchParams ?? new URLSearchParams();
 
-	const org = activeOrg();
-	const focus = describeFocus(pathname, params);
+  const org = activeOrg();
+  const focus = describeFocus(pathname, params);
 
-	const lines = [
-		`[In-app assistant context — the user is in the Minion dashboard${org.name ? ` for ${org.name}` : ''}.`,
-		`Current page: ${pathname} — ${describeRoute(pathname)}`,
-		focus ? `Focus: ${focus}.` : '',
-		// Only when the user belongs to >1 org: hand the active org id to data
-		// tools (crm_insight) so they scope to what's on screen, not the default org.
-		org.multi && org.id ? `active_org_id: ${org.id} (pass to data tools as orgId).` : '',
-		// Site-wide data access: the agent has read tools over the whole org DB, so it
-		// should answer from live data on ANY page rather than "I can't see the screen".
-		`You can read this org's live data — customers, invoices, payments, sales, ` +
-			`bookings, support tickets, memberships, projects, messages — with your tools ` +
-			`(crm_insight for top/recent customers, crm_query for any other sorting/grouping/ ` +
-			`date-range/percentage question, crm_search for a specific named person, ` +
-			`search_crm_conversations for what customers said about a topic across chat ` +
-			`history, crm_conversation_themes for pain-point/intent/over-explaining census ` +
-			`questions). When the ` +
-			`user asks about anything on this or any page, look it up and answer with specifics; ` +
-			`don't say you can't see the page.`,
-		`To take the user somewhere or cite evidence, write in-app markdown links [label](/path). ` +
-			`They render as clickable navigation — a click is the user's confirmation. ` +
-			`Always link a customer's name to /crm/{id}, and back up any figure with a link to the ` +
-			`filtered view that proves it (e.g. [3 invoices](/finances/invoices?contact={id})).`,
-		`Keep replies tight. Don't restate this context.]`,
-	].filter(Boolean);
+  const lines = [
+    `[In-app assistant context — the user is in the Minion dashboard${org.name ? ` for ${org.name}` : ''}.`,
+    `Current page: ${pathname} — ${describeRoute(pathname)}`,
+    focus ? `Focus: ${focus}.` : '',
+    // Only when the user belongs to >1 org: hand the active org id to data
+    // tools (crm_insight) so they scope to what's on screen, not the default org.
+    org.multi && org.id ? `active_org_id: ${org.id} (pass to data tools as orgId).` : '',
+    `For organization knowledge questions, call brains_list with the active orgId (when present), ` +
+      `select that organization's Master Brain, then call brain_search with the same orgId. Never ` +
+      `guess or reuse a brainId from another organization. Use the Master Brain for semantic or ` +
+      `historical questions across messages and business sources; use the dedicated module query ` +
+      `tools when the user needs an exact current metric or record.`,
+    // Site-wide data access: the agent has read tools over the whole org DB, so it
+    // should answer from live data on ANY page rather than "I can't see the screen".
+    `You can read this org's live data — customers, invoices, payments, sales, ` +
+      `bookings, support tickets, memberships, projects, messages — with your tools ` +
+      `(crm_insight for top/recent customers, crm_query for any other sorting/grouping/ ` +
+      `date-range/percentage question, crm_search for a specific named person, ` +
+      `search_crm_conversations for what customers said about a topic across chat ` +
+      `history, crm_conversation_themes for pain-point/intent/over-explaining census ` +
+      `questions). When the ` +
+      `user asks about anything on this or any page, look it up and answer with specifics; ` +
+      `don't say you can't see the page.`,
+    `To take the user somewhere or cite evidence, write in-app markdown links [label](/path). ` +
+      `They render as clickable navigation — a click is the user's confirmation. ` +
+      `Always link a customer's name to /crm/{id}, and back up any figure with a link to the ` +
+      `filtered view that proves it (e.g. [3 invoices](/finances/invoices?contact={id})).`,
+    `Keep replies tight. Don't restate this context.]`,
+  ].filter(Boolean);
 
-	return lines.join('\n') + '\n\n';
+  return lines.join('\n') + '\n\n';
 }
 
 /**
@@ -107,21 +115,21 @@ export function buildAssistantContext(): string {
  * (see CrmInsightsChat.svelte for why), so this just swaps the framing.
  */
 export function buildInsightsContext(): string {
-	const org = activeOrg();
+  const org = activeOrg();
 
-	const lines = [
-		`[In-app assistant context — the user is on the CRM Insights page` +
-			`${org.name ? ` for ${org.name}` : ''}, talking to you as a CRM conversation analyst.`,
-		`Use \`search_crm_conversations\` for targeted lookups (e.g. "what did people say about ` +
-			`pricing?") and \`crm_conversation_themes\` for aggregate questions (pain-point census, ` +
-			`over-explaining rate, intent distribution). If a tool isn't available yet, say so plainly ` +
-			`instead of guessing at data you can't see.`,
-		org.multi && org.id ? `active_org_id: ${org.id} (pass to data tools as orgId).` : '',
-		`Always cite how many conversations/messages back a claim, and support it with an in-app ` +
-			`markdown link [label](/crm/...) — e.g. a customer name links to /crm/{id}. Links render as ` +
-			`clickable navigation.`,
-		`Keep replies tight. Don't restate this context.]`,
-	].filter(Boolean);
+  const lines = [
+    `[In-app assistant context — the user is on the CRM Insights page` +
+      `${org.name ? ` for ${org.name}` : ''}, talking to you as a CRM conversation analyst.`,
+    `Use \`search_crm_conversations\` for targeted lookups (e.g. "what did people say about ` +
+      `pricing?") and \`crm_conversation_themes\` for aggregate questions (pain-point census, ` +
+      `over-explaining rate, intent distribution). If a tool isn't available yet, say so plainly ` +
+      `instead of guessing at data you can't see.`,
+    org.multi && org.id ? `active_org_id: ${org.id} (pass to data tools as orgId).` : '',
+    `Always cite how many conversations/messages back a claim, and support it with an in-app ` +
+      `markdown link [label](/crm/...) — e.g. a customer name links to /crm/{id}. Links render as ` +
+      `clickable navigation.`,
+    `Keep replies tight. Don't restate this context.]`,
+  ].filter(Boolean);
 
-	return lines.join('\n') + '\n\n';
+  return lines.join('\n') + '\n\n';
 }

--- a/src/routes/(app)/home/+page.svelte
+++ b/src/routes/(app)/home/+page.svelte
@@ -27,10 +27,10 @@
   } from '$lib/chat/blocks';
   import { notesState, loadNotes } from '$lib/state/features/agent-notes.svelte';
   import { conn } from '$lib/state/gateway';
-  import { agentChat, ensureAgentChat } from '$lib/state/chat/chat.svelte';
+  import { agentChat } from '$lib/state/chat/chat.svelte';
   import { assistant } from '$lib/state/features/assistant.svelte';
   import {
-    sendChatMsg,
+    sendAssistantTurn,
     resetChat,
     loadChatHistory,
     stripVoiceTurnPrefix,
@@ -38,6 +38,7 @@
     parseUserContext,
     type UserContextChip,
   } from '$lib/services/gateway.svelte';
+  import { buildAssistantContext } from '$lib/state/features/assistant-context';
   import {
     voiceCall,
     mouth,
@@ -587,9 +588,12 @@
       return;
     }
     if (!agentId || !conn.connected) return;
-    const c = ensureAgentChat(agentId);
-    c.inputText = text;
-    sendChatMsg(agentId);
+    sendAssistantTurn(
+      agentId,
+      text,
+      buildAssistantContext(),
+      chat?.sessionKey ?? `agent:${agentId}:main`,
+    );
   }
 
   // ─── Per-message actions (copy / reply / retry) ──────────────────────────────


### PR DESCRIPTION
## Summary
- send /home chat through the same context-aware path as the floating assistant
- include active-org Master Brain discovery/search guidance
- prevent brain IDs from being reused across organization contexts

## Verification
- focused assistant-context tests: 10 passed
- svelte-check: 0 errors, 0 warnings
- design-lint: changed-file debt did not increase
- token-integrity: 0 violations

Fable 5 consultation was attempted but its API returned ENOTIMP before a verdict; no review finding was suppressed.