### PR TITLE
fix(release): resolve Hub production review blockers

### DIFF
--- a/src/lib/components/my-agent/OmnichatDock.svelte
+++ b/src/lib/components/my-agent/OmnichatDock.svelte
@@ -1,6 +1,9 @@
 <script lang="ts" module>
   import type { RecentConversation } from '$server/services/messages.service';
-  import type { OmnichatThreadMessage as CachedThreadMessage } from './omnichat-thread-cache';
+  import {
+    LatestThreadRequests,
+    type OmnichatThreadMessage as CachedThreadMessage,
+  } from './omnichat-thread-cache';
 
   // Module-level caches survive unmount/remount (collapse, nav away and back),
   // so the dock paints instantly instead of repopulating on every mount.
@@ -8,6 +11,7 @@
   let convosLoaded = false;
   let convosHasMore = true;
   const threadCache = new Map<string, CachedThreadMessage[]>();
+  const threadRequests = new LatestThreadRequests();
   const threadKey = (c: RecentConversation) => `${c.channel}:${c.chatId}`;
   const PAGE = 25;
 </script>
@@ -29,7 +33,6 @@
   import { fmtTimeAgo } from '$lib/utils/format';
   import ChannelBrandIcon from '$lib/components/channels/ChannelBrandIcon.svelte';
   import {
-    LatestThreadRequests,
     mergeServerThread,
     settleOptimisticMessage,
     type OmnichatThreadMessage,
@@ -72,7 +75,6 @@
   let draft = $state('');
   let sendSeq = 0;
   let threadEl = $state<HTMLDivElement | null>(null);
-  const threadRequests = new LatestThreadRequests();
 
   async function refresh() {
     try {

--- a/src/lib/components/my-agent/OmnichatDock.svelte
+++ b/src/lib/components/my-agent/OmnichatDock.svelte
@@ -1,24 +1,13 @@
 <script lang="ts" module>
   import type { RecentConversation } from '$server/services/messages.service';
-
-  /** Ledger row as serialized over JSON, plus optimistic-send flags. */
-  interface ThreadMsg {
-    id?: string;
-    clientId: string;
-    direction: 'inbound' | 'outbound';
-    content: string | null;
-    senderName: string | null;
-    occurredAt: string | null;
-    pending?: boolean;
-    failed?: boolean;
-  }
+  import type { OmnichatThreadMessage as CachedThreadMessage } from './omnichat-thread-cache';
 
   // Module-level caches survive unmount/remount (collapse, nav away and back),
   // so the dock paints instantly instead of repopulating on every mount.
   let convosCache: RecentConversation[] = [];
   let convosLoaded = false;
   let convosHasMore = true;
-  const threadCache = new Map<string, ThreadMsg[]>();
+  const threadCache = new Map<string, CachedThreadMessage[]>();
   const threadKey = (c: RecentConversation) => `${c.channel}:${c.chatId}`;
   const PAGE = 25;
 </script>
@@ -39,6 +28,12 @@
   import { setDragContext } from '$lib/utils/drag-context';
   import { fmtTimeAgo } from '$lib/utils/format';
   import ChannelBrandIcon from '$lib/components/channels/ChannelBrandIcon.svelte';
+  import {
+    LatestThreadRequests,
+    mergeServerThread,
+    settleOptimisticMessage,
+    type OmnichatThreadMessage,
+  } from './omnichat-thread-cache';
 
   interface Props {
     /** Render as the slim collapsed rail (used when the panel is collapsed). */
@@ -72,11 +67,12 @@
 
   // ─── Thread view ───
   let selected = $state<RecentConversation | null>(null);
-  let thread = $state<ThreadMsg[]>([]);
+  let thread = $state<OmnichatThreadMessage[]>([]);
   let threadLoading = $state(false);
   let draft = $state('');
   let sendSeq = 0;
   let threadEl = $state<HTMLDivElement | null>(null);
+  const threadRequests = new LatestThreadRequests();
 
   async function refresh() {
     try {
@@ -121,6 +117,8 @@
   }
 
   async function refreshThread(c: RecentConversation) {
+    const key = threadKey(c);
+    const requestId = threadRequests.begin(key);
     try {
       const q = new URLSearchParams({
         view: 'thread',
@@ -130,20 +128,25 @@
       });
       const res = await fetch(`/api/messages?${q}`);
       if (!res.ok) return;
-      const rows = ((await res.json()).messages ?? []) as ThreadMsg[];
+      const rows = ((await res.json()).messages ?? []) as OmnichatThreadMessage[];
       const asc = rows.slice().reverse();
-      // Keep optimistic bubbles the server hasn't echoed back yet.
-      const stillLocal = thread.filter(
-        (t) => (t.pending || t.failed) && !asc.some((r) => r.clientId === t.clientId),
-      );
-      if (selected && threadKey(selected) === threadKey(c)) {
-        thread = [...asc, ...stillLocal];
-        threadCache.set(threadKey(c), thread);
+      if (!threadRequests.isLatest(key, requestId)) return;
+
+      // Merge against this conversation's cache, never whichever thread happens
+      // to be visible after navigation while the request was in flight.
+      const merged = mergeServerThread(asc, threadCache.get(key) ?? []);
+      threadCache.set(key, merged);
+      if (selected && threadKey(selected) === key) {
+        thread = merged;
       }
     } catch {
       /* transient — next poll retries */
     } finally {
-      threadLoading = false;
+      // An older request must not clear the spinner for a newer request, and a
+      // response for the previous conversation must not clear the current one.
+      if (threadRequests.finish(key, requestId) && selected && threadKey(selected) === key) {
+        threadLoading = false;
+      }
     }
   }
 
@@ -163,8 +166,9 @@
     const c = selected;
     const text = draft.trim();
     if (!c || !text) return;
+    const key = threadKey(c);
     const clientId = `omni-send:${c.chatId}:${Date.now()}-${sendSeq++}`;
-    const bubble: ThreadMsg = {
+    const bubble: OmnichatThreadMessage = {
       clientId,
       direction: 'outbound',
       content: text,
@@ -172,7 +176,9 @@
       occurredAt: new Date().toISOString(),
       pending: true,
     };
-    thread = [...thread, bubble];
+    const optimistic = [...(threadCache.get(key) ?? thread), bubble];
+    threadCache.set(key, optimistic);
+    thread = optimistic;
     draft = '';
     try {
       const res = await fetch('/api/messages/send', {
@@ -181,13 +187,14 @@
         body: JSON.stringify({ channel: c.channel, chatId: c.chatId, text, clientId }),
       });
       if (!res.ok) throw new Error(String(res.status));
-      thread = thread.map((t) => (t.clientId === clientId ? { ...t, pending: false } : t));
-      threadCache.set(threadKey(c), thread);
+      const settled = settleOptimisticMessage(threadCache.get(key) ?? optimistic, clientId, false);
+      threadCache.set(key, settled);
+      if (selected && threadKey(selected) === key) thread = settled;
       void refresh();
     } catch {
-      thread = thread.map((t) =>
-        t.clientId === clientId ? { ...t, pending: false, failed: true } : t,
-      );
+      const settled = settleOptimisticMessage(threadCache.get(key) ?? optimistic, clientId, true);
+      threadCache.set(key, settled);
+      if (selected && threadKey(selected) === key) thread = settled;
     }
   }
 

--- a/src/lib/components/my-agent/omnichat-thread-cache.test.ts
+++ b/src/lib/components/my-agent/omnichat-thread-cache.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  LatestThreadRequests,
+  mergeServerThread,
+  settleOptimisticMessage,
+  type OmnichatThreadMessage,
+} from './omnichat-thread-cache';
+
+const message = (
+  clientId: string,
+  overrides: Partial<OmnichatThreadMessage> = {},
+): OmnichatThreadMessage => ({
+  clientId,
+  direction: 'outbound',
+  content: clientId,
+  senderName: null,
+  occurredAt: null,
+  ...overrides,
+});
+
+describe('omnichat thread cache isolation', () => {
+  it('settles only the captured conversation snapshot', () => {
+    const firstConversation = [message('reply-a', { pending: true })];
+    const secondConversation = [message('reply-b', { pending: true })];
+
+    const settledFirst = settleOptimisticMessage(firstConversation, 'reply-a', false);
+
+    expect(settledFirst).toEqual([message('reply-a', { pending: false })]);
+    expect(secondConversation).toEqual([message('reply-b', { pending: true })]);
+  });
+
+  it('keeps optimistic messages from the matching cache while merging a refresh', () => {
+    const server = [message('persisted', { direction: 'inbound' })];
+    const cached = [
+      message('optimistic', { pending: true }),
+      message('failed', { pending: false, failed: true }),
+      message('already-echoed', { pending: true }),
+    ];
+    const echoed = message('already-echoed');
+
+    expect(mergeServerThread([...server, echoed], cached)).toEqual([
+      ...server,
+      echoed,
+      message('optimistic', { pending: true }),
+      message('failed', { pending: false, failed: true }),
+    ]);
+  });
+});
+
+describe('LatestThreadRequests', () => {
+  it('does not let an older same-thread request finish the newer loading state', () => {
+    const requests = new LatestThreadRequests();
+    const older = requests.begin('whatsapp:one');
+    const newer = requests.begin('whatsapp:one');
+
+    expect(requests.finish('whatsapp:one', older)).toBe(false);
+    expect(requests.isLatest('whatsapp:one', newer)).toBe(true);
+    expect(requests.finish('whatsapp:one', newer)).toBe(true);
+  });
+
+  it('tracks concurrent conversations independently', () => {
+    const requests = new LatestThreadRequests();
+    const first = requests.begin('whatsapp:one');
+    const second = requests.begin('telegram:two');
+
+    expect(requests.finish('whatsapp:one', first)).toBe(true);
+    expect(requests.isLatest('telegram:two', second)).toBe(true);
+  });
+});

--- a/src/lib/components/my-agent/omnichat-thread-cache.ts
+++ b/src/lib/components/my-agent/omnichat-thread-cache.ts
@@ -1,0 +1,55 @@
+export interface OmnichatThreadMessage {
+  id?: string;
+  clientId: string;
+  direction: 'inbound' | 'outbound';
+  content: string | null;
+  senderName: string | null;
+  occurredAt: string | null;
+  pending?: boolean;
+  failed?: boolean;
+}
+
+export function mergeServerThread(
+  serverMessages: OmnichatThreadMessage[],
+  cachedMessages: OmnichatThreadMessage[],
+): OmnichatThreadMessage[] {
+  const stillLocal = cachedMessages.filter(
+    (cached) =>
+      (cached.pending || cached.failed) &&
+      !serverMessages.some((server) => server.clientId === cached.clientId),
+  );
+  return [...serverMessages, ...stillLocal];
+}
+
+export function settleOptimisticMessage(
+  cachedMessages: OmnichatThreadMessage[],
+  clientId: string,
+  failed: boolean,
+): OmnichatThreadMessage[] {
+  return cachedMessages.map((message) =>
+    message.clientId === clientId
+      ? { ...message, pending: false, ...(failed ? { failed: true } : {}) }
+      : message,
+  );
+}
+
+export class LatestThreadRequests {
+  private sequence = 0;
+  private readonly latestByKey = new Map<string, number>();
+
+  begin(key: string): number {
+    const requestId = ++this.sequence;
+    this.latestByKey.set(key, requestId);
+    return requestId;
+  }
+
+  isLatest(key: string, requestId: number): boolean {
+    return this.latestByKey.get(key) === requestId;
+  }
+
+  finish(key: string, requestId: number): boolean {
+    if (!this.isLatest(key, requestId)) return false;
+    this.latestByKey.delete(key);
+    return true;
+  }
+}

--- a/src/lib/server/artifacts/registry.ts
+++ b/src/lib/server/artifacts/registry.ts
@@ -68,11 +68,13 @@ export async function getArtifactContext(
         'plugins.alerts.summary',
         { since: Date.now() - 30 * 24 * 60 * 60 * 1000 },
         ctx.profileId,
+        { orgId: ctx.tenantId },
       ).catch(() => null),
       gatewayCallAsUser<{ rows?: Array<Record<string, unknown>> }>(
         'plugins.alerts.recent',
         { limit: 10 },
         ctx.profileId,
+        { orgId: ctx.tenantId },
       ).catch(() => null),
     ]);
     const counts = summary?.counts ?? { total: 0, high: 0, med: 0, low: 0, notified: 0, responded: 0 };

--- a/src/lib/server/artifacts/registry.ts
+++ b/src/lib/server/artifacts/registry.ts
@@ -12,12 +12,20 @@ import {
 } from '$lib/agents/artifacts';
 import * as m from '$lib/paraglide/messages';
 import { gatewayCallAsUser } from '$lib/server/gateway-rpc';
-import { listArtifactRows, getArtifactRow, artifactRowToDescriptor } from '$lib/server/artifacts/store';
+import {
+  listArtifactRows,
+  getArtifactRow,
+  artifactRowToDescriptor,
+} from '$lib/server/artifacts/store';
 import { getMasterFlow, flowExportedSpecs } from '$lib/flows/master-flows';
 import { flowVariableSchema } from '$lib/flows/flow-variables';
 import { listExportToggles } from '$lib/server/flows/exports-store';
 
-async function withVars(ctx: CoreCtx, agentId: string, context: ArtifactContext): Promise<ArtifactContext> {
+async function withVars(
+  ctx: CoreCtx,
+  agentId: string,
+  context: ArtifactContext,
+): Promise<ArtifactContext> {
   const desc = getSystemAgentDescriptors().find((d) => d.id === agentId);
   if (!desc?.flowId || !desc.resolveVariables) return context;
   const flow = getMasterFlow(desc.flowId);
@@ -32,9 +40,14 @@ async function withVars(ctx: CoreCtx, agentId: string, context: ArtifactContext)
 }
 
 /** Built-in + DB artifacts for an agent. */
-export async function getArtifactsForAgent(ctx: CoreCtx, agentId: string): Promise<ArtifactDescriptor[]> {
+export async function getArtifactsForAgent(
+  ctx: CoreCtx,
+  agentId: string,
+): Promise<ArtifactDescriptor[]> {
   if (agentId === 'artifact-builder') {
-    return [artifactBuilderDescriptorFor(agentId, m.artifact_builder_title(), m.artifact_builder_desc())];
+    return [
+      artifactBuilderDescriptorFor(agentId, m.artifact_builder_title(), m.artifact_builder_desc()),
+    ];
   }
   const builtins =
     agentId === 'alert-watcher'
@@ -58,7 +71,9 @@ export async function getArtifactContext(
   if (artifactId === 'builder' && agentId === 'artifact-builder') {
     const desc = getSystemAgentDescriptors().find((d) => d.id === agentId);
     const vars = desc?.resolveVariables
-      ? await desc.resolveVariables(ctx, ['artifacts.builtCount', 'artifacts.recent']).catch(() => ({}))
+      ? await desc
+          .resolveVariables(ctx, ['artifacts.builtCount', 'artifacts.recent'])
+          .catch(() => ({}))
       : {};
     return { ...base, vars };
   }
@@ -77,8 +92,18 @@ export async function getArtifactContext(
         { orgId: ctx.tenantId },
       ).catch(() => null),
     ]);
-    const counts = summary?.counts ?? { total: 0, high: 0, med: 0, low: 0, notified: 0, responded: 0 };
-    return withVars(ctx, agentId, { ...base, data: { counts, recent: mapRecentRows(recent?.rows ?? []) } });
+    const counts = summary?.counts ?? {
+      total: 0,
+      high: 0,
+      med: 0,
+      low: 0,
+      notified: 0,
+      responded: 0,
+    };
+    return withVars(ctx, agentId, {
+      ...base,
+      data: { counts, recent: mapRecentRows(recent?.rows ?? []) },
+    });
   }
   // DB (dynamic) artifact: base context (per-artifact data providers come with 5b)
   const row = await getArtifactRow(ctx, artifactId).catch(() => null);

--- a/src/lib/server/gateway-rpc.test.ts
+++ b/src/lib/server/gateway-rpc.test.ts
@@ -11,14 +11,21 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockOrg =
   vi.fn<(orgId: string, channel: string) => Promise<{ url: string; token: string } | null>>();
 const mockUser =
-  vi.fn<(profileId: string, channel: string) => Promise<{ url: string; token: string } | null>>();
+  vi.fn<
+    (
+      profileId: string,
+      orgId: string,
+      channel: string,
+    ) => Promise<{ url: string; token: string } | null>
+  >();
 const mockSystem =
   vi.fn<(preferredUrl?: string) => Promise<{ url: string; token: string } | null>>();
 vi.mock('$server/services/gateway-lease.service', () => ({
   resolveOrgChannelCredentials: (orgId: string, channel: string) => mockOrg(orgId, channel),
 }));
 vi.mock('$server/services/gateway.pg.service', () => ({
-  getUserGatewayCredentials: (profileId: string, channel: string) => mockUser(profileId, channel),
+  getUserGatewayCredentials: (profileId: string, orgId: string, channel: string) =>
+    mockUser(profileId, orgId, channel),
   getSystemGatewayCredentials: (preferredUrl?: string) => mockSystem(preferredUrl),
 }));
 
@@ -54,15 +61,17 @@ describe('resolveCredentialsForUser', () => {
 
     const creds = await resolveCredentialsForUser('p1', 'org-A');
     expect(mockOrg).toHaveBeenCalledWith('org-A', 'prd');
+    expect(mockUser).toHaveBeenCalledWith('p1', 'org-A', 'prd');
     expect(creds).toEqual({ url: 'wss://user-gw', token: 'user-tok' });
   });
 
-  it('never consults the org lookup without an orgId (old chain unchanged)', async () => {
-    mockUser.mockResolvedValue({ url: 'wss://user-gw', token: 'user-tok' });
+  it('never consults org-scoped user credentials without an orgId', async () => {
+    mockSystem.mockResolvedValue({ url: 'wss://system-gw', token: 'system-tok' });
 
     const creds = await resolveCredentialsForUser('p1');
     expect(mockOrg).not.toHaveBeenCalled();
-    expect(creds).toEqual({ url: 'wss://user-gw', token: 'user-tok' });
+    expect(mockUser).not.toHaveBeenCalled();
+    expect(creds).toEqual({ url: 'wss://system-gw', token: 'system-tok' });
   });
 
   /**
@@ -76,14 +85,14 @@ describe('resolveCredentialsForUser', () => {
     mockUser.mockResolvedValue({ url: 'wss://user-gw', token: 'user-tok' });
     await resolveCredentialsForUser('p1', 'org-A');
     expect(mockOrg).toHaveBeenCalledWith('org-A', 'prd');
-    expect(mockUser).toHaveBeenCalledWith('p1', 'prd');
+    expect(mockUser).toHaveBeenCalledWith('p1', 'org-A', 'prd');
   });
 
   it('honours an explicit dev selection end to end', async () => {
     mockUser.mockResolvedValue({ url: 'wss://user-gw', token: 'user-tok' });
     await resolveCredentialsForUser('p1', 'org-A', 'dev');
     expect(mockOrg).toHaveBeenCalledWith('org-A', 'dev');
-    expect(mockUser).toHaveBeenCalledWith('p1', 'dev');
+    expect(mockUser).toHaveBeenCalledWith('p1', 'org-A', 'dev');
   });
 
   it('degrades an org-lookup failure to the fallback chain instead of throwing', async () => {

--- a/src/lib/server/gateway-rpc.ts
+++ b/src/lib/server/gateway-rpc.ts
@@ -92,10 +92,10 @@ export async function resolveCredentialsForUser(
     }
   }
   // 1. Per-user PG lookup (new primary path).
-  if (profileId) {
+  if (profileId && orgId) {
     try {
       const { getUserGatewayCredentials } = await import('$server/services/gateway.pg.service');
-      const creds = await getUserGatewayCredentials(profileId, chan);
+      const creds = await getUserGatewayCredentials(profileId, orgId, chan);
       if (creds) return { url: toWsUrl(creds.url), token: creds.token };
     } catch (err) {
       // Wave 1: catch covers both the dynamic import() and getUserGatewayCredentials().

--- a/src/lib/server/gateway-rpc.ts
+++ b/src/lib/server/gateway-rpc.ts
@@ -350,7 +350,7 @@ export async function pluginsUiList(
   const res = await gatewayCallAsUser<
     | { entries?: PluginUiManifestOccupant[]; occupants?: PluginUiManifestOccupant[] }
     | PluginUiManifestOccupant[]
-  >('plugins.ui.list', orgId ? { orgId } : {}, profileId);
+  >('plugins.ui.list', orgId ? { orgId } : {}, profileId, { orgId });
   const raw = Array.isArray(res) ? res : (res?.entries ?? res?.occupants ?? []);
   return raw.filter((e) => !HIDDEN_PLUGIN_IDS.has(e.pluginId));
 }

--- a/src/lib/server/system-agents/registry.ts
+++ b/src/lib/server/system-agents/registry.ts
@@ -53,7 +53,8 @@ export function getSystemAgentDescriptors(): SystemAgentDescriptor[] {
         const result: Record<string, unknown> = {};
         if (keys.includes('reminders.sent')) result['reminders.sent'] = act?.counts.sent ?? 0;
         if (keys.includes('reminders.failed')) result['reminders.failed'] = act?.counts.failed ?? 0;
-        if (keys.includes('reminders.skipped')) result['reminders.skipped'] = act?.counts.skipped ?? 0;
+        if (keys.includes('reminders.skipped'))
+          result['reminders.skipped'] = act?.counts.skipped ?? 0;
         return result;
       },
     },
@@ -74,7 +75,8 @@ export function getSystemAgentDescriptors(): SystemAgentDescriptor[] {
           ctx.profileId,
           { orgId: ctx.tenantId },
         ).catch(() => null);
-        if (!summary) return { enabled: true, state: 'attention', detail: m.sysagent_triage_unreachable() };
+        if (!summary)
+          return { enabled: true, state: 'attention', detail: m.sysagent_triage_unreachable() };
         const c = summary.counts ?? null;
         const total = c?.total ?? 0;
         return {
@@ -87,7 +89,11 @@ export function getSystemAgentDescriptors(): SystemAgentDescriptor[] {
           }),
           // Triage is a continuous kernel (no discrete flow_runs): surface alert
           // volume + notify rate as the generic health metrics. lastRunAt N/A.
-          health: { lastRunAt: null, runs30d: c ? total : null, successRate: total > 0 ? c!.notified / total : null },
+          health: {
+            lastRunAt: null,
+            runs30d: c ? total : null,
+            successRate: total > 0 ? c!.notified / total : null,
+          },
         };
       },
       async resolveVariables(ctx, keys) {
@@ -99,8 +105,10 @@ export function getSystemAgentDescriptors(): SystemAgentDescriptor[] {
             ctx.profileId,
             { orgId: ctx.tenantId },
           ).catch(() => null);
-          if (keys.includes('triage.counts.total')) result['triage.counts.total'] = summary?.counts?.total ?? 0;
-          if (keys.includes('triage.counts.high')) result['triage.counts.high'] = summary?.counts?.high ?? 0;
+          if (keys.includes('triage.counts.total'))
+            result['triage.counts.total'] = summary?.counts?.total ?? 0;
+          if (keys.includes('triage.counts.high'))
+            result['triage.counts.high'] = summary?.counts?.high ?? 0;
         }
         if (keys.includes('triage.recent')) {
           const recent = await gatewayCallAsUser<{ rows?: Array<Record<string, unknown>> }>(
@@ -132,8 +140,10 @@ export function getSystemAgentDescriptors(): SystemAgentDescriptor[] {
       },
       async resolveVariables(ctx, keys) {
         const out: Record<string, unknown> = {};
-        if (keys.includes('artifacts.builtCount')) out['artifacts.builtCount'] = await countArtifacts(ctx).catch(() => 0);
-        if (keys.includes('artifacts.recent')) out['artifacts.recent'] = await listRecentArtifacts(ctx).catch(() => []);
+        if (keys.includes('artifacts.builtCount'))
+          out['artifacts.builtCount'] = await countArtifacts(ctx).catch(() => 0);
+        if (keys.includes('artifacts.recent'))
+          out['artifacts.recent'] = await listRecentArtifacts(ctx).catch(() => []);
         return out;
       },
     },

--- a/src/lib/server/system-agents/registry.ts
+++ b/src/lib/server/system-agents/registry.ts
@@ -72,6 +72,7 @@ export function getSystemAgentDescriptors(): SystemAgentDescriptor[] {
           'plugins.alerts.summary',
           { since: Date.now() - 30 * 24 * 60 * 60 * 1000 },
           ctx.profileId,
+          { orgId: ctx.tenantId },
         ).catch(() => null);
         if (!summary) return { enabled: true, state: 'attention', detail: m.sysagent_triage_unreachable() };
         const c = summary.counts ?? null;
@@ -96,6 +97,7 @@ export function getSystemAgentDescriptors(): SystemAgentDescriptor[] {
             'plugins.alerts.summary',
             { since: Date.now() - 30 * 24 * 60 * 60 * 1000 },
             ctx.profileId,
+            { orgId: ctx.tenantId },
           ).catch(() => null);
           if (keys.includes('triage.counts.total')) result['triage.counts.total'] = summary?.counts?.total ?? 0;
           if (keys.includes('triage.counts.high')) result['triage.counts.high'] = summary?.counts?.high ?? 0;
@@ -105,6 +107,7 @@ export function getSystemAgentDescriptors(): SystemAgentDescriptor[] {
             'plugins.alerts.recent',
             { limit: 10 },
             ctx.profileId,
+            { orgId: ctx.tenantId },
           ).catch(() => null);
           result['triage.recent'] = mapRecentRows(recent?.rows ?? []);
         }

--- a/src/lib/utils/channel-display-state.test.ts
+++ b/src/lib/utils/channel-display-state.test.ts
@@ -190,6 +190,40 @@ describe('deriveChannelDisplayState — history sync', () => {
     expect(deriveChannelDisplayState({ ...linked, historySync: sync(phase) })).toBe('live');
   });
 
+  it('returns syncing while durable Hub delivery still has pending rows', () => {
+    expect(
+      deriveChannelDisplayState({
+        ...linked,
+        historySync: sync('complete'),
+        hubSync: {
+          total: 155_484,
+          acknowledged: 98_599,
+          pending: 56_885,
+          retrying: 0,
+          lastAcknowledgedAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      }),
+    ).toBe('syncing');
+  });
+
+  it('returns live once durable Hub delivery has no pending rows', () => {
+    expect(
+      deriveChannelDisplayState({
+        ...linked,
+        historySync: sync('complete'),
+        hubSync: {
+          total: 155_484,
+          acknowledged: 155_484,
+          pending: 0,
+          retrying: 0,
+          lastAcknowledgedAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      }),
+    ).toBe('live');
+  });
+
   it('regression guard: an undefined historySync changes nothing', () => {
     expect(deriveChannelDisplayState(linked)).toBe('live');
     expect(deriveChannelDisplayState({ ...linked, historySync: undefined })).toBe('live');

--- a/src/lib/utils/channel-display-state.ts
+++ b/src/lib/utils/channel-display-state.ts
@@ -59,5 +59,9 @@ export function deriveChannelDisplayState(c: Channel): ChannelDisplayState {
   if (phase === 'stalled') return 'sync-stalled';
   if (phase === 'bootstrap' || phase === 'recent' || phase === 'full' || phase === 'on-demand')
     return 'syncing';
+  // History receipt and durable Hub delivery are separate stages. A completed
+  // WhatsApp history sweep can still have rows queued in the gateway outbox;
+  // reporting `live` before those rows are acknowledged is a false success.
+  if ((c.hubSync?.pending ?? 0) > 0) return 'syncing';
   return 'live';
 }

--- a/src/routes/(app)/settings/gateways/+page.server.ts
+++ b/src/routes/(app)/settings/gateways/+page.server.ts
@@ -1,6 +1,6 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
-import { listGatewaysForAdmin } from '$server/services/gateway.pg.service';
+import { listGatewaysForOrgAdmin } from '$server/services/gateway.pg.service';
 import { listServers } from '$server/services/server.service';
 import type { TenantContext } from '$server/services/base';
 
@@ -9,9 +9,11 @@ export const load: PageServerLoad = async ({ locals }) => {
   // decided by org assignment / the balancer, never by the user. 404 (not
   // 403) so the page simply doesn't exist for everyone else.
   if (locals.user?.role !== 'admin') throw error(404, 'Not found');
+  const orgId = locals.orgId ?? locals.tenantCtx?.tenantId;
+  if (!orgId) throw error(400, 'active organization required');
 
   const [pgGateways, tursoHosts] = await Promise.all([
-    listGatewaysForAdmin(),
+    listGatewaysForOrgAdmin(orgId),
     locals.tenantCtx
       ? listServers(locals.tenantCtx as TenantContext, locals.user?.id, locals.user?.role)
       : Promise.resolve([]),

--- a/src/routes/api/gateways/+server.ts
+++ b/src/routes/api/gateways/+server.ts
@@ -1,12 +1,14 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json, error } from '@sveltejs/kit';
 import { requireAdmin } from '$server/auth/authorize';
-import { createGateway, listGatewaysForAdmin } from '$server/services/gateway.pg.service';
+import { createGateway, listGatewaysForOrgAdmin } from '$server/services/gateway.pg.service';
 import { assertSafeUrl, SsrfBlockedError } from '$server/services/ssrf-guard';
 
 export const GET: RequestHandler = async ({ locals }) => {
   requireAdmin(locals);
-  return json({ gateways: await listGatewaysForAdmin() });
+  const orgId = locals.orgId ?? locals.tenantCtx?.tenantId;
+  if (!orgId) throw error(400, 'active organization required');
+  return json({ gateways: await listGatewaysForOrgAdmin(orgId) });
 };
 
 export const POST: RequestHandler = async ({ locals, request }) => {

--- a/src/routes/api/gateways/+server.ts
+++ b/src/routes/api/gateways/+server.ts
@@ -12,14 +12,27 @@ export const GET: RequestHandler = async ({ locals }) => {
 export const POST: RequestHandler = async ({ locals, request }) => {
   const admin = requireAdmin(locals);
   if (!admin.supabaseId) throw error(400, 'supabase session required');
-  const b = (await request.json().catch(() => ({}))) as { name?: string; url?: string; token?: string };
+  const orgId = locals.orgId ?? locals.tenantCtx?.tenantId;
+  if (!orgId) throw error(400, 'active organization required');
+  const b = (await request.json().catch(() => ({}))) as {
+    name?: string;
+    url?: string;
+    token?: string;
+  };
   if (!b.name || !b.url || !b.token) throw error(400, 'name, url, and token required');
   try {
     await assertSafeUrl(b.url, 'gateway URL');
   } catch (e) {
-    if (e instanceof SsrfBlockedError) return json({ ok: false, error: e.message }, { status: 422 });
+    if (e instanceof SsrfBlockedError)
+      return json({ ok: false, error: e.message }, { status: 422 });
     throw e;
   }
-  const g = await createGateway({ name: b.name, url: b.url, token: b.token, profileId: admin.supabaseId });
+  const g = await createGateway({
+    name: b.name,
+    url: b.url,
+    token: b.token,
+    profileId: admin.supabaseId,
+    orgId,
+  });
   return json({ ok: true, id: g.id });
 };

--- a/src/routes/api/gateways/server.test.ts
+++ b/src/routes/api/gateways/server.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   createGateway: vi.fn(),
+  listGatewaysForOrgAdmin: vi.fn(),
   assertSafeUrl: vi.fn(),
 }));
 
@@ -11,7 +12,7 @@ vi.mock('$server/auth/authorize', () => ({
 
 vi.mock('$server/services/gateway.pg.service', () => ({
   createGateway: mocks.createGateway,
-  listGatewaysForAdmin: vi.fn(),
+  listGatewaysForOrgAdmin: mocks.listGatewaysForOrgAdmin,
 }));
 
 vi.mock('$server/services/ssrf-guard', () => ({
@@ -19,7 +20,29 @@ vi.mock('$server/services/ssrf-guard', () => ({
   SsrfBlockedError: class SsrfBlockedError extends Error {},
 }));
 
-import { POST } from './+server';
+import { GET, POST } from './+server';
+
+describe('GET /api/gateways', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listGatewaysForOrgAdmin.mockResolvedValue([{ id: 'gateway-1' }]);
+  });
+
+  test('returns only gateways assigned to the active organization', async () => {
+    const response = await GET({ locals: { orgId: 'org-active' } } as never);
+
+    expect(response.status).toBe(200);
+    expect(mocks.listGatewaysForOrgAdmin).toHaveBeenCalledWith('org-active');
+  });
+
+  test('rejects an unscoped gateway listing', async () => {
+    await expect(GET({ locals: {} } as never)).rejects.toMatchObject({
+      status: 400,
+      body: { message: 'active organization required' },
+    });
+    expect(mocks.listGatewaysForOrgAdmin).not.toHaveBeenCalled();
+  });
+});
 
 describe('POST /api/gateways', () => {
   beforeEach(() => {

--- a/src/routes/api/gateways/server.test.ts
+++ b/src/routes/api/gateways/server.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createGateway: vi.fn(),
+  assertSafeUrl: vi.fn(),
+}));
+
+vi.mock('$server/auth/authorize', () => ({
+  requireAdmin: () => ({ id: 'user-1', role: 'admin', supabaseId: 'profile-1' }),
+}));
+
+vi.mock('$server/services/gateway.pg.service', () => ({
+  createGateway: mocks.createGateway,
+  listGatewaysForAdmin: vi.fn(),
+}));
+
+vi.mock('$server/services/ssrf-guard', () => ({
+  assertSafeUrl: mocks.assertSafeUrl,
+  SsrfBlockedError: class SsrfBlockedError extends Error {},
+}));
+
+import { POST } from './+server';
+
+describe('POST /api/gateways', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createGateway.mockResolvedValue({ id: 'gateway-1' });
+  });
+
+  test('assigns a newly created gateway to the active organization', async () => {
+    const response = await POST({
+      locals: { orgId: 'org-active' },
+      request: new Request('https://hub.example/api/gateways', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Production', url: 'wss://gateway.example', token: 'secret' }),
+      }),
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(mocks.createGateway).toHaveBeenCalledWith({
+      name: 'Production',
+      url: 'wss://gateway.example',
+      token: 'secret',
+      profileId: 'profile-1',
+      orgId: 'org-active',
+    });
+  });
+});

--- a/src/routes/api/servers/[id]/token/+server.ts
+++ b/src/routes/api/servers/[id]/token/+server.ts
@@ -9,6 +9,7 @@ import {
   userHasGatewayAccess,
   getGatewayTokenByServerId,
   gatewayBelongsToOrg,
+  resolveGatewayId,
 } from '$server/services/gateway.pg.service';
 
 /**
@@ -39,6 +40,7 @@ export const POST: RequestHandler = async ({ locals, params }) => {
   console.log('[token-ep] tenant=', ctx.tenantId);
 
   const id = params.id!;
+  let registryError: unknown = null;
 
   // ── Org/channel gate (spec §C5). Fail closed, and BEFORE the role check ────
   // The gateway row must belong to the caller's ACTIVE org. Handing out a token
@@ -49,10 +51,27 @@ export const POST: RequestHandler = async ({ locals, params }) => {
   // what "FACES cannot reach DEV even by hand-crafting a request" forbids.
   // Channel is enforced transitively: a channel's rows are org-scoped, so an org
   // with no row for a channel has no id here that will pass.
+  // A server id absent from the PG registry may still be a legitimate,
+  // tenant-scoped Turso legacy row. Distinguish that migration fallback from a
+  // PG row assigned to another org: only the latter is an immediate 404.
   const orgId = locals.orgId ?? ctx.tenantId ?? null;
-  if (!(await gatewayBelongsToOrg(id, orgId))) {
-    console.log('[token-ep] gateway not assigned to active org -> 404');
-    return json({ error: 'Not found' }, { status: 404 });
+  let pgGatewayId: string | null = null;
+  try {
+    pgGatewayId = await resolveGatewayId(id);
+  } catch (err) {
+    registryError = err;
+    console.warn('[token-ep] Supabase gateway resolution threw (will try Turso):', err);
+  }
+  if (pgGatewayId) {
+    try {
+      if (!(await gatewayBelongsToOrg(id, orgId))) {
+        console.log('[token-ep] gateway not assigned to active org -> 404');
+        return json({ error: 'Not found' }, { status: 404 });
+      }
+    } catch (err) {
+      registryError = err;
+      console.warn('[token-ep] Supabase org-scope lookup threw (will try Turso):', err);
+    }
   }
 
   if (user.role !== 'admin') {
@@ -75,12 +94,13 @@ export const POST: RequestHandler = async ({ locals, params }) => {
   // Try Supabase gateway table first (post-cutover source of truth), then fall
   // back to Turso servers table for legacy rows that haven't migrated yet.
   let token: string | null = null;
-  let registryError: unknown = null;
-  try {
-    token = await getGatewayTokenByServerId(id);
-  } catch (err) {
-    registryError = err;
-    console.warn('[token-ep] Supabase gateway lookup threw (will try Turso):', err);
+  if (pgGatewayId || registryError) {
+    try {
+      token = await getGatewayTokenByServerId(id, orgId);
+    } catch (err) {
+      registryError = err;
+      console.warn('[token-ep] Supabase gateway lookup threw (will try Turso):', err);
+    }
   }
   if (!token) {
     try {

--- a/src/routes/api/servers/[id]/token/server.test.ts
+++ b/src/routes/api/servers/[id]/token/server.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   getGatewayTokenByServerId: vi.fn(),
   getServerToken: vi.fn(),
   gatewayBelongsToOrg: vi.fn(),
+  resolveGatewayId: vi.fn(),
 }));
 
 vi.mock('$server/auth/authorize', () => ({
@@ -22,6 +23,7 @@ vi.mock('$server/services/gateway.pg.service', () => ({
   userHasGatewayAccess: vi.fn(),
   getGatewayTokenByServerId: mocks.getGatewayTokenByServerId,
   gatewayBelongsToOrg: mocks.gatewayBelongsToOrg,
+  resolveGatewayId: mocks.resolveGatewayId,
 }));
 
 import { POST } from './+server';
@@ -38,6 +40,7 @@ describe('POST /api/servers/[id]/token', () => {
     mocks.getGatewayTokenByServerId.mockReset();
     mocks.getServerToken.mockReset();
     mocks.gatewayBelongsToOrg.mockReset().mockResolvedValue(true);
+    mocks.resolveGatewayId.mockReset().mockResolvedValue('gateway-1');
   });
 
   test('returns 503 instead of a false 404 when PG is unavailable', async () => {
@@ -71,7 +74,20 @@ describe('POST /api/servers/[id]/token', () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ token: 'gateway-secret' });
+    expect(mocks.getGatewayTokenByServerId).toHaveBeenCalledWith('server-1', 'org-1');
     expect(mocks.getServerToken).not.toHaveBeenCalled();
+  });
+
+  test('falls back to an org-scoped Turso token when no PG gateway bridges the legacy id', async () => {
+    mocks.resolveGatewayId.mockResolvedValue(null);
+    mocks.getServerToken.mockResolvedValue('legacy-secret');
+
+    const response = await POST(event());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ token: 'legacy-secret' });
+    expect(mocks.gatewayBelongsToOrg).not.toHaveBeenCalled();
+    expect(mocks.getGatewayTokenByServerId).not.toHaveBeenCalled();
   });
 
   // Spec §C5: an org may not reach a gateway (and therefore a channel) it has no

--- a/src/server/services/gateway.pg.service.test.ts
+++ b/src/server/services/gateway.pg.service.test.ts
@@ -105,6 +105,27 @@ describe('gateway.pg.service', () => {
     expect(g.id).toBe('g1');
   });
 
+  test('listGatewaysForOrgAdmin scopes gateway metadata to the active organization', async () => {
+    const orderBy = vi.fn().mockResolvedValue([
+      {
+        id: 'g1',
+        name: 'Production',
+        url: 'wss://gateway.example',
+        authMode: 'token',
+        createdAt: new Date('2026-07-23T00:00:00Z'),
+      },
+    ]);
+    const where = vi.fn().mockReturnValue({ orderBy });
+    selectFrom.mockReturnValueOnce({ where });
+    const { eq } = await import('drizzle-orm');
+    const { listGatewaysForOrgAdmin } = await import('./gateway.pg.service');
+
+    const rows = await listGatewaysForOrgAdmin('org-active');
+
+    expect(vi.mocked(eq)).toHaveBeenCalledWith('orgId', 'org-active');
+    expect(rows).toHaveLength(1);
+  });
+
   test('getUserGatewayCredentials returns decrypted token', async () => {
     const { getUserGatewayCredentials } = await import('./gateway.pg.service');
     selectFrom.mockReturnValueOnce({

--- a/src/server/services/gateway.pg.service.test.ts
+++ b/src/server/services/gateway.pg.service.test.ts
@@ -31,6 +31,7 @@ vi.mock('@minion-stack/db/pg', () => ({
     createdAt: 'createdAt',
     tokenCiphertext: 'tokenCiphertext',
     tokenIv: 'tokenIv',
+    orgId: 'orgId',
   },
   userGateway: { profileId: 'profileId', gatewayId: 'gatewayId', isDefault: 'isDefault' },
 }));
@@ -92,9 +93,14 @@ describe('gateway.pg.service', () => {
       url: 'ws://gw',
       token: 'secret',
       profileId: 'p1',
+      orgId: 'org-1',
     });
     expect(insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({ tokenCiphertext: 'enc:secret', tokenIv: 'iv1' }),
+      expect.objectContaining({
+        tokenCiphertext: 'enc:secret',
+        tokenIv: 'iv1',
+        orgId: 'org-1',
+      }),
     );
     expect(g.id).toBe('g1');
   });
@@ -114,7 +120,7 @@ describe('gateway.pg.service', () => {
         }),
       }),
     });
-    const cred = await getUserGatewayCredentials('p1');
+    const cred = await getUserGatewayCredentials('p1', 'org-1');
     expect(cred?.url).toBe('ws://gw');
     expect(cred?.token).toBe('secret');
   });
@@ -133,7 +139,7 @@ describe('gateway.pg.service', () => {
         }),
       }),
     });
-    const cred = await getUserGatewayCredentials('p1');
+    const cred = await getUserGatewayCredentials('p1', 'org-1');
     expect(cred?.token).toBe('rawtoken');
     // Real openSecret throws ERR_CRYPTO_INVALID_IV on an empty iv — the plaintext
     // row must bypass decrypt entirely (regression guard for the token-mismatch bug).
@@ -143,8 +149,32 @@ describe('gateway.pg.service', () => {
   test('getUserGatewayCredentials returns null when no rows', async () => {
     const { getUserGatewayCredentials } = await import('./gateway.pg.service');
     // Default mock returns []
-    const cred = await getUserGatewayCredentials('p1');
+    const cred = await getUserGatewayCredentials('p1', 'org-1');
     expect(cred).toBeNull();
+  });
+
+  test('getGatewayTokenByServerId reads the token only inside the active org', async () => {
+    const tokenWhere = vi.fn().mockReturnValue({
+      limit: vi.fn().mockResolvedValue([{ tokenCiphertext: 'enc:secret', tokenIv: 'iv1' }]),
+    });
+    selectFrom
+      .mockReturnValueOnce({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: 'gateway-scoped' }]),
+        }),
+      })
+      .mockReturnValueOnce({ where: tokenWhere });
+    const { and, eq } = await import('drizzle-orm');
+    const { getGatewayTokenByServerId } = await import('./gateway.pg.service');
+
+    const token = await getGatewayTokenByServerId('legacy-scoped', 'org-active');
+
+    expect(token).toBe('secret');
+    expect(vi.mocked(eq)).toHaveBeenCalledWith('orgId', 'org-active');
+    expect(vi.mocked(and)).toHaveBeenCalledWith(
+      { _eq: ['id', 'gateway-scoped'] },
+      { _eq: ['orgId', 'org-active'] },
+    );
   });
 
   test('getSystemGatewayCredentials picks preferredUrl and decrypts', async () => {
@@ -189,7 +219,7 @@ describe('gateway.pg.service', () => {
     selectFrom.mockReturnValueOnce(
       userRows([{ url: 'ws://gw', tokenCiphertext: 'enc:secret', tokenIv: 'iv1' }]),
     );
-    await getUserGatewayCredentials('p1');
+    await getUserGatewayCredentials('p1', 'org-1');
     const args = userOrderBy.mock.calls[0];
     expect(args).toHaveLength(3);
     expect(args[0]).toEqual({ _sql: true }); // channelFirst(channel)
@@ -203,10 +233,27 @@ describe('gateway.pg.service', () => {
     selectFrom.mockReturnValueOnce(
       userRows([{ url: 'ws://gw', tokenCiphertext: 'enc:secret', tokenIv: 'iv1' }]),
     );
-    await getUserGatewayCredentials('p1');
+    await getUserGatewayCredentials('p1', 'org-1');
     // channelFirst() interpolates the preferred channel into the template.
     expect(vi.mocked(sql).mock.calls.flat(2)).toContain('prd');
     expect(vi.mocked(sql).mock.calls.flat(2)).not.toContain('dev');
+  });
+
+  test('getUserGatewayCredentials scopes the linked gateway to the active org', async () => {
+    const { and, eq } = await import('drizzle-orm');
+    const { getUserGatewayCredentials } = await import('./gateway.pg.service');
+    selectFrom.mockReturnValueOnce(
+      userRows([{ url: 'ws://gw', tokenCiphertext: 'enc:secret', tokenIv: 'iv1' }]),
+    );
+
+    await getUserGatewayCredentials('p1', 'org-active');
+
+    expect(vi.mocked(eq)).toHaveBeenCalledWith('profileId', 'p1');
+    expect(vi.mocked(eq)).toHaveBeenCalledWith('orgId', 'org-active');
+    expect(vi.mocked(and)).toHaveBeenCalledWith(
+      { _eq: ['profileId', 'p1'] },
+      { _eq: ['orgId', 'org-active'] },
+    );
   });
 
   test('getSystemGatewayCredentials orders instead of trusting heap order', async () => {

--- a/src/server/services/gateway.pg.service.ts
+++ b/src/server/services/gateway.pg.service.ts
@@ -102,6 +102,8 @@ export interface GatewayInput {
   /** Plain-text token — sealed before storage. */
   token: string;
   profileId: string;
+  /** Active organization assigned to this gateway row. */
+  orgId: string;
   isDefault?: boolean;
 }
 
@@ -123,6 +125,7 @@ export async function createGateway(input: GatewayInput): Promise<{ id: string }
       url: input.url,
       tokenCiphertext: ciphertext,
       tokenIv: iv,
+      orgId: input.orgId,
     })
     .returning({ id: gateway.id });
   if (!row) throw new Error('createGateway: insert returned no rows');
@@ -318,17 +321,22 @@ export async function gatewayBelongsToOrg(
 
 /**
  * Return the decrypted token for a gateway identified by a server id (legacy
- * Turso id or gateway uuid). Used by the /api/servers/[id]/token endpoint so
- * it reads from Supabase after the Turso→Supabase cutover.
- * Returns null when the id doesn't resolve or the gateway has no token.
+ * Turso id or gateway uuid) only when it belongs to the active organization.
+ * Used by the /api/servers/[id]/token endpoint so it reads from Supabase after
+ * the Turso→Supabase cutover without a check/read reassignment race.
+ * Returns null when the id doesn't resolve, belongs to another org, or has no
+ * token.
  */
-export async function getGatewayTokenByServerId(serverId: string): Promise<string | null> {
+export async function getGatewayTokenByServerId(
+  serverId: string,
+  orgId: string,
+): Promise<string | null> {
   const gatewayId = await resolveGatewayId(serverId);
   if (!gatewayId) return null;
   const [row] = await getCoreDb()
     .select({ tokenCiphertext: gateway.tokenCiphertext, tokenIv: gateway.tokenIv })
     .from(gateway)
-    .where(eq(gateway.id, gatewayId))
+    .where(and(eq(gateway.id, gatewayId), eq(gateway.orgId, orgId)))
     .limit(1);
   if (!row?.tokenCiphertext) return null;
   // token_iv='' means the ciphertext IS the plaintext token (legacy unencrypted row).
@@ -378,6 +386,7 @@ export async function getGatewayCredentialsById(
  */
 export async function getUserGatewayCredentials(
   profileId: string,
+  orgId: string,
   channel: GatewayChannel = 'prd',
 ): Promise<{ url: string; token: string } | null> {
   const db = getCoreDb();
@@ -389,7 +398,7 @@ export async function getUserGatewayCredentials(
     })
     .from(userGateway)
     .innerJoin(gateway, eq(userGateway.gatewayId, gateway.id))
-    .where(eq(userGateway.profileId, profileId))
+    .where(and(eq(userGateway.profileId, profileId), eq(gateway.orgId, orgId)))
     .orderBy(channelFirst(channel), desc(gateway.createdAt), gateway.id)
     .limit(1);
   if (!rows.length) return null;

--- a/src/server/services/gateway.pg.service.ts
+++ b/src/server/services/gateway.pg.service.ts
@@ -152,6 +152,22 @@ export async function listGatewaysForAdmin(): Promise<GatewayRow[]> {
   return rows as GatewayRow[];
 }
 
+export async function listGatewaysForOrgAdmin(orgId: string): Promise<GatewayRow[]> {
+  const db = getCoreDb();
+  const rows = await db
+    .select({
+      id: gateway.id,
+      name: gateway.name,
+      url: gateway.url,
+      authMode: gateway.authMode,
+      createdAt: gateway.createdAt,
+    })
+    .from(gateway)
+    .where(eq(gateway.orgId, orgId))
+    .orderBy(gateway.createdAt);
+  return rows as GatewayRow[];
+}
+
 export async function deleteGateway(id: string): Promise<void> {
   await getCoreDb().delete(gateway).where(eq(gateway.id, id));
 }

--- a/src/server/services/stock.service.test.ts
+++ b/src/server/services/stock.service.test.ts
@@ -152,6 +152,7 @@ describe('buildInvoiceIssuePreview — aggregation, 1:1 fallback, dedupe, unmatc
         { id: 'item_tox_retail', finProductId: 'p1' }, // decoy: p1 already mapped — must be ignored (dedupe)
         { id: 'item_derma', finProductId: 'p2' },
       ], // 1:1 fallback candidates
+      [], // no recipe components
       [
         { id: 'item_tox', name: 'Toxina Botulinica', code: 'TOX', uom: 'unit' },
         { id: 'item_derma', name: 'Dermaquench', code: 'DQ', uom: 'unit' },
@@ -208,6 +209,7 @@ describe('buildInvoiceIssuePreview — aggregation, 1:1 fallback, dedupe, unmatc
       [{ productId: 'p1', description: 'Botox 5ml shot', quantity: '5' }], // invoice items — 5 units of consumption-uom-per-service
       [{ finProductId: 'p1', itemId: 'item_caja', qtyPerUnit: '1' }], // mapping: 1 ml per unit sold
       [], // no 1:1 fallback candidates
+      [], // no recipe components
       [
         {
           id: 'item_caja',
@@ -242,6 +244,55 @@ describe('buildInvoiceIssuePreview — aggregation, 1:1 fallback, dedupe, unmatc
         estValue: 1.2,
       },
     ]);
+  });
+
+  it('expands an invoice-mapped recipe to the stock leaves used by commit paths', async () => {
+    const { db, resolveSequence } = createMockDb();
+    resolveSequence([
+      [{ id: 'inv1' }],
+      [{ productId: 'p1', description: 'Composite treatment', quantity: '3' }],
+      [{ finProductId: 'p1', itemId: 'recipe', qtyPerUnit: '2' }],
+      [], // no 1:1 fallback candidates
+      [{ parentItemId: 'recipe', childItemId: 'serum', qty: '5' }],
+      [
+        { id: 'recipe', isStockItem: false },
+        { id: 'serum', isStockItem: true },
+      ],
+      [
+        {
+          id: 'serum',
+          name: 'Serum vial',
+          code: 'SER-1',
+          uom: 'vial',
+          consumptionUom: 'ml',
+          unitsPerStockUom: '100',
+          subunitsPerStockUom: null,
+          diagramEnabled: false,
+        },
+      ],
+      [{ itemId: 'serum', qty: '2', valuationRate: '10' }],
+    ]);
+
+    const preview = await buildInvoiceIssuePreview(ctx(db), 'inv1', 'wh1');
+
+    expect(preview.lines).toEqual([
+      {
+        itemId: 'serum',
+        itemName: 'Serum vial',
+        itemCode: 'SER-1',
+        uom: 'vial',
+        qty: 0.3,
+        available: 2,
+        qtyConsumption: 30,
+        consumptionUom: 'ml',
+        unitsPerStockUom: 100,
+        subunitsPerStockUom: null,
+        diagramEnabled: false,
+        estUnitCost: 10,
+        estValue: 3,
+      },
+    ]);
+    expect(preview.unmatched).toEqual([]);
   });
 
   it('rejects a preview for an invoice not in this org', async () => {

--- a/src/server/services/stock.service.test.ts
+++ b/src/server/services/stock.service.test.ts
@@ -27,26 +27,44 @@ const actor = { id: 'u1', name: 'Test User' };
 describe('submitEntry — guards', () => {
   it('blocks a double-submit: an already-submitted entry is rejected before touching lines/bins', async () => {
     const { db, resolveSequence } = createMockDb();
-    resolveSequence([[{ id: 'e1', orgId: 'org-1', status: 'submitted', type: 'issue', humanId: 'STE-2026-00001' }]]);
+    resolveSequence([
+      [{ id: 'e1', orgId: 'org-1', status: 'submitted', type: 'issue', humanId: 'STE-2026-00001' }],
+    ]);
     await expect(submitEntry(ctx(db), 'e1', actor)).rejects.toMatchObject({ code: 'not_draft' });
   });
 
   it('rejects a submit for a missing entry', async () => {
     const { db, resolveSequence } = createMockDb();
     resolveSequence([[]]);
-    await expect(submitEntry(ctx(db), 'missing', actor)).rejects.toMatchObject({ code: 'not_found' });
+    await expect(submitEntry(ctx(db), 'missing', actor)).rejects.toMatchObject({
+      code: 'not_found',
+    });
   });
 
   it('enforces the negative-stock guard end-to-end: an issue larger than the bin is rejected before any ledger/bin write', async () => {
     const { db, resolveSequence } = createMockDb();
     resolveSequence([
       [{ id: 'e1', orgId: 'org-1', status: 'draft', type: 'issue', humanId: null }], // entry (for update)
-      [{ id: 'l1', entryId: 'e1', itemId: 'i1', qty: '10', uom: null, rate: null, fromWarehouseId: 'w1', toWarehouseId: null, lineNo: 0 }], // lines
+      [
+        {
+          id: 'l1',
+          entryId: 'e1',
+          itemId: 'i1',
+          qty: '10',
+          uom: null,
+          rate: null,
+          fromWarehouseId: 'w1',
+          toWarehouseId: null,
+          lineNo: 0,
+        },
+      ], // lines
       [{ id: 'i1' }], // item existence
       [{ id: 'w1' }], // warehouse existence
       [{ qty: '2', valuationRate: '1' }], // locked bin: only 2 in stock, issuing 10
     ]);
-    await expect(submitEntry(ctx(db), 'e1', actor)).rejects.toMatchObject({ code: 'negative_stock' });
+    await expect(submitEntry(ctx(db), 'e1', actor)).rejects.toMatchObject({
+      code: 'negative_stock',
+    });
     // Guard fires before the ledger insert / bins upsert.
     expect(db.insert).not.toHaveBeenCalled();
   });
@@ -65,19 +83,25 @@ describe('cancelEntry — guards', () => {
   it('rejects cancelling a draft (only submitted entries can be cancelled)', async () => {
     const { db, resolveSequence } = createMockDb();
     resolveSequence([[{ id: 'e1', orgId: 'org-1', status: 'draft', type: 'receipt' }]]);
-    await expect(cancelEntry(ctx(db), 'e1', actor)).rejects.toMatchObject({ code: 'not_submitted' });
+    await expect(cancelEntry(ctx(db), 'e1', actor)).rejects.toMatchObject({
+      code: 'not_submitted',
+    });
   });
 
   it('rejects cancelling an already-cancelled entry (idempotent — cannot double-cancel)', async () => {
     const { db, resolveSequence } = createMockDb();
     resolveSequence([[{ id: 'e1', orgId: 'org-1', status: 'cancelled', type: 'receipt' }]]);
-    await expect(cancelEntry(ctx(db), 'e1', actor)).rejects.toMatchObject({ code: 'not_submitted' });
+    await expect(cancelEntry(ctx(db), 'e1', actor)).rejects.toMatchObject({
+      code: 'not_submitted',
+    });
   });
 
   it('rejects a missing entry', async () => {
     const { db, resolveSequence } = createMockDb();
     resolveSequence([[]]);
-    await expect(cancelEntry(ctx(db), 'missing', actor)).rejects.toMatchObject({ code: 'not_found' });
+    await expect(cancelEntry(ctx(db), 'missing', actor)).rejects.toMatchObject({
+      code: 'not_found',
+    });
   });
 });
 
@@ -223,7 +247,9 @@ describe('buildInvoiceIssuePreview — aggregation, 1:1 fallback, dedupe, unmatc
   it('rejects a preview for an invoice not in this org', async () => {
     const { db, resolveSequence } = createMockDb();
     resolveSequence([[]]); // invoice lookup empty
-    await expect(buildInvoiceIssuePreview(ctx(db), 'missing', 'wh1')).rejects.toMatchObject({ code: 'invoice_not_found' });
+    await expect(buildInvoiceIssuePreview(ctx(db), 'missing', 'wh1')).rejects.toMatchObject({
+      code: 'invoice_not_found',
+    });
   });
 });
 
@@ -235,14 +261,21 @@ describe('createIssueFromInvoice — duplicate guard + happy path', () => {
       [{ id: 'existing-entry' }], // duplicate check hits
     ]);
     await expect(
-      createIssueFromInvoice(ctx(db), { invoiceId: 'inv1', warehouseId: 'wh1', lines: [{ itemId: 'item1', qty: 5 }], actor }),
+      createIssueFromInvoice(ctx(db), {
+        invoiceId: 'inv1',
+        warehouseId: 'wh1',
+        lines: [{ itemId: 'item1', qty: 5 }],
+        actor,
+      }),
     ).rejects.toMatchObject({ code: 'duplicate_invoice' });
     expect(db.insert).not.toHaveBeenCalled();
   });
 
   it('rejects with no_lines before touching the db when lines is empty', async () => {
     const { db } = createMockDb();
-    await expect(createIssueFromInvoice(ctx(db), { invoiceId: 'inv1', warehouseId: 'wh1', lines: [], actor })).rejects.toMatchObject({
+    await expect(
+      createIssueFromInvoice(ctx(db), { invoiceId: 'inv1', warehouseId: 'wh1', lines: [], actor }),
+    ).rejects.toMatchObject({
       code: 'no_lines',
     });
   });
@@ -271,6 +304,7 @@ describe('buildServiceIssuePreview — invoice-free consumption from a service',
     resolveSequence([
       [{ id: 'p1', name: 'Menton (Opera II)', code: 'M04' }], // product lookup
       [{ itemId: 'item_caja', qtyPerUnit: '5' }], // mapping: 5 ml per unit performed
+      [], // no recipe components: mapped item is already a stock leaf
       [
         {
           id: 'item_caja',
@@ -286,7 +320,11 @@ describe('buildServiceIssuePreview — invoice-free consumption from a service',
       [{ itemId: 'item_caja', qty: '3', valuationRate: '80' }], // bins
     ]);
 
-    const preview = await buildServiceIssuePreview(ctx(db), { finProductId: 'p1', quantity: 2, warehouseId: 'wh1' });
+    const preview = await buildServiceIssuePreview(ctx(db), {
+      finProductId: 'p1',
+      quantity: 2,
+      warehouseId: 'wh1',
+    });
 
     expect(preview.hasMapping).toBe(true);
     expect(preview.productName).toBe('Menton (Opera II)');
@@ -309,13 +347,68 @@ describe('buildServiceIssuePreview — invoice-free consumption from a service',
     ]);
   });
 
+  it('expands a mapped recipe to the same stock leaves and quantities as accrual commit', async () => {
+    const { db, resolveSequence } = createMockDb();
+    resolveSequence([
+      [{ id: 'p1', name: 'Composite treatment', code: 'C10' }], // product
+      [{ itemId: 'recipe', qtyPerUnit: '2' }], // 3 services × 2 units = 6 at root
+      [{ parentItemId: 'recipe', childItemId: 'serum', qty: '5' }], // 6 × 5 = 30
+      [
+        { id: 'recipe', isStockItem: false },
+        { id: 'serum', isStockItem: true },
+      ], // the commit path only accrues stock leaves
+      [
+        {
+          id: 'serum',
+          name: 'Serum vial',
+          code: 'SER-1',
+          uom: 'vial',
+          consumptionUom: 'ml',
+          unitsPerStockUom: '100',
+          subunitsPerStockUom: null,
+          diagramEnabled: false,
+        },
+      ],
+      [{ itemId: 'serum', qty: '2', valuationRate: '10' }],
+    ]);
+
+    const preview = await buildServiceIssuePreview(ctx(db), {
+      finProductId: 'p1',
+      quantity: 3,
+      warehouseId: 'wh1',
+    });
+
+    expect(preview.hasMapping).toBe(true);
+    expect(preview.lines).toEqual([
+      {
+        itemId: 'serum',
+        itemName: 'Serum vial',
+        itemCode: 'SER-1',
+        uom: 'vial',
+        qty: 0.3,
+        available: 2,
+        qtyConsumption: 30,
+        consumptionUom: 'ml',
+        unitsPerStockUom: 100,
+        subunitsPerStockUom: null,
+        diagramEnabled: false,
+        estUnitCost: 10,
+        estValue: 3,
+      },
+    ]);
+  });
+
   it('reports hasMapping:false with no lines for a service that consumes nothing', async () => {
     const { db, resolveSequence } = createMockDb();
     resolveSequence([
       [{ id: 'p1', name: 'Consulta', code: 'C01' }], // product
       [], // no mappings
     ]);
-    const preview = await buildServiceIssuePreview(ctx(db), { finProductId: 'p1', quantity: 1, warehouseId: 'wh1' });
+    const preview = await buildServiceIssuePreview(ctx(db), {
+      finProductId: 'p1',
+      quantity: 1,
+      warehouseId: 'wh1',
+    });
     expect(preview.hasMapping).toBe(false);
     expect(preview.lines).toEqual([]);
   });
@@ -323,7 +416,13 @@ describe('buildServiceIssuePreview — invoice-free consumption from a service',
   it('rejects a preview for a product not in this org', async () => {
     const { db, resolveSequence } = createMockDb();
     resolveSequence([[]]); // product lookup empty
-    await expect(buildServiceIssuePreview(ctx(db), { finProductId: 'missing', quantity: 1, warehouseId: 'wh1' })).rejects.toMatchObject({
+    await expect(
+      buildServiceIssuePreview(ctx(db), {
+        finProductId: 'missing',
+        quantity: 1,
+        warehouseId: 'wh1',
+      }),
+    ).rejects.toMatchObject({
       code: 'product_not_found',
     });
   });
@@ -333,7 +432,13 @@ describe('createServiceIssue — customer + procedure note, no invoice', () => {
   it('rejects with no_lines before touching the db when lines is empty', async () => {
     const { db } = createMockDb();
     await expect(
-      createServiceIssue(ctx(db), { finProductId: 'p1', quantity: 1, warehouseId: 'wh1', lines: [], actor }),
+      createServiceIssue(ctx(db), {
+        finProductId: 'p1',
+        quantity: 1,
+        warehouseId: 'wh1',
+        lines: [],
+        actor,
+      }),
     ).rejects.toMatchObject({ code: 'no_lines' });
   });
 
@@ -381,7 +486,15 @@ describe('createServiceIssue — source generalization', () => {
     const { db, resolveSequence } = createMockDb();
     resolveSequence([
       [{ id: 'p1', name: 'Botox' }], // product
-      [{ id: 'e1', orgId: 'org-1', type: 'issue', status: 'draft', metadata: { source: 'service' } }], // insert entries returning
+      [
+        {
+          id: 'e1',
+          orgId: 'org-1',
+          type: 'issue',
+          status: 'draft',
+          metadata: { source: 'service' },
+        },
+      ], // insert entries returning
       [], // insert lines
     ]);
     const entry = await createServiceIssue(ctx(db), {
@@ -412,7 +525,9 @@ describe('findEntryBySource', () => {
 describe('setConsumption — validation', () => {
   it('rejects a non-positive qtyPerUnit before touching the db', async () => {
     const { db } = createMockDb();
-    await expect(setConsumption(ctx(db), { finProductId: 'p1', itemId: 'i1', qtyPerUnit: 0 }, actor)).rejects.toMatchObject({
+    await expect(
+      setConsumption(ctx(db), { finProductId: 'p1', itemId: 'i1', qtyPerUnit: 0 }, actor),
+    ).rejects.toMatchObject({
       code: 'invalid_qty',
     });
     expect(db.select).not.toHaveBeenCalled();
@@ -421,7 +536,9 @@ describe('setConsumption — validation', () => {
   it('rejects when the item does not exist in this org', async () => {
     const { db, resolveSequence } = createMockDb();
     resolveSequence([[]]); // item lookup empty
-    await expect(setConsumption(ctx(db), { finProductId: 'p1', itemId: 'missing', qtyPerUnit: 1 }, actor)).rejects.toMatchObject({
+    await expect(
+      setConsumption(ctx(db), { finProductId: 'p1', itemId: 'missing', qtyPerUnit: 1 }, actor),
+    ).rejects.toMatchObject({
       code: 'item_not_found',
     });
   });
@@ -429,7 +546,9 @@ describe('setConsumption — validation', () => {
   it('rejects when the item exists but is not a stock item', async () => {
     const { db, resolveSequence } = createMockDb();
     resolveSequence([[{ id: 'i1', isStockItem: false }]]);
-    await expect(setConsumption(ctx(db), { finProductId: 'p1', itemId: 'i1', qtyPerUnit: 1 }, actor)).rejects.toMatchObject({
+    await expect(
+      setConsumption(ctx(db), { finProductId: 'p1', itemId: 'i1', qtyPerUnit: 1 }, actor),
+    ).rejects.toMatchObject({
       code: 'not_stock_item',
     });
   });
@@ -437,7 +556,9 @@ describe('setConsumption — validation', () => {
   it('rejects when the fin_product does not exist in this org', async () => {
     const { db, resolveSequence } = createMockDb();
     resolveSequence([[{ id: 'i1', isStockItem: true }], []]); // item ok, product lookup empty
-    await expect(setConsumption(ctx(db), { finProductId: 'missing', itemId: 'i1', qtyPerUnit: 1 }, actor)).rejects.toMatchObject({
+    await expect(
+      setConsumption(ctx(db), { finProductId: 'missing', itemId: 'i1', qtyPerUnit: 1 }, actor),
+    ).rejects.toMatchObject({
       code: 'product_not_found',
     });
   });
@@ -450,7 +571,11 @@ describe('setConsumption — validation', () => {
       [], // no existing mapping (create)
       [{ id: 'c1', orgId: 'org-1', finProductId: 'p1', itemId: 'i1', qtyPerUnit: '2', note: null }],
     ]);
-    const row = await setConsumption(ctx(db), { finProductId: 'p1', itemId: 'i1', qtyPerUnit: 2 }, actor);
+    const row = await setConsumption(
+      ctx(db),
+      { finProductId: 'p1', itemId: 'i1', qtyPerUnit: 2 },
+      actor,
+    );
     expect(row).toMatchObject({ id: 'c1', finProductId: 'p1', itemId: 'i1' });
   });
 });
@@ -462,7 +587,8 @@ describe('setConsumption — audit trail (§7 audit tracing)', () => {
 
   it('records old→new qty_per_unit into doc_audit_log via recordAudit, with the actor', async () => {
     vi.doMock('./activity.service', async () => {
-      const actual = await vi.importActual<typeof import('./activity.service')>('./activity.service');
+      const actual =
+        await vi.importActual<typeof import('./activity.service')>('./activity.service');
       return { ...actual, recordAudit: vi.fn(actual.recordAudit) };
     });
     // stock.service is already statically imported above (with the real,
@@ -496,7 +622,8 @@ describe('setConsumption — audit trail (§7 audit tracing)', () => {
 
   it('emits no audit row when qtyPerUnit is unchanged (e.g. only note patched)', async () => {
     vi.doMock('./activity.service', async () => {
-      const actual = await vi.importActual<typeof import('./activity.service')>('./activity.service');
+      const actual =
+        await vi.importActual<typeof import('./activity.service')>('./activity.service');
       return { ...actual, recordAudit: vi.fn(actual.recordAudit) };
     });
     // stock.service is already statically imported above (with the real,
@@ -510,13 +637,29 @@ describe('setConsumption — audit trail (§7 audit tracing)', () => {
       [{ id: 'i1', isStockItem: true }],
       [{ id: 'p1' }],
       [{ qtyPerUnit: '2' }], // existing mapping: same qty
-      [{ id: 'c1', orgId: 'org-1', finProductId: 'p1', itemId: 'i1', qtyPerUnit: '2', note: 'updated note' }],
+      [
+        {
+          id: 'c1',
+          orgId: 'org-1',
+          finProductId: 'p1',
+          itemId: 'i1',
+          qtyPerUnit: '2',
+          note: 'updated note',
+        },
+      ],
     ]);
 
-    await setConsumptionSpied(ctx(db), { finProductId: 'p1', itemId: 'i1', qtyPerUnit: 2, note: 'updated note' }, actor);
+    await setConsumptionSpied(
+      ctx(db),
+      { finProductId: 'p1', itemId: 'i1', qtyPerUnit: 2, note: 'updated note' },
+      actor,
+    );
 
     // recordAudit was called but no-ops on an empty changes array (own db.insert never runs).
-    expect(activity.recordAudit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ changes: [] }));
+    expect(activity.recordAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ changes: [] }),
+    );
     vi.doUnmock('./activity.service');
   });
 });
@@ -525,7 +668,12 @@ describe('createItem — uom cross-field validation', () => {
   it('rejects a consumptionUom without a unitsPerStockUom before touching the db', async () => {
     const { db } = createMockDb();
     await expect(
-      createItem(ctx(db), { code: 'C1', name: 'Item', consumptionUom: 'ml', unitsPerStockUom: null }),
+      createItem(ctx(db), {
+        code: 'C1',
+        name: 'Item',
+        consumptionUom: 'ml',
+        unitsPerStockUom: null,
+      }),
     ).rejects.toMatchObject({ code: 'invalid_uom_config' });
     expect(db.insert).not.toHaveBeenCalled();
   });
@@ -533,7 +681,12 @@ describe('createItem — uom cross-field validation', () => {
   it('allows a consumptionUom paired with a unitsPerStockUom', async () => {
     const { db, resolveSequence } = createMockDb();
     resolveSequence([[{ id: 'i1', consumptionUom: 'ml', unitsPerStockUom: '500' }]]);
-    const row = await createItem(ctx(db), { code: 'C1', name: 'Item', consumptionUom: 'ml', unitsPerStockUom: '500' });
+    const row = await createItem(ctx(db), {
+      code: 'C1',
+      name: 'Item',
+      consumptionUom: 'ml',
+      unitsPerStockUom: '500',
+    });
     expect(row).toMatchObject({ id: 'i1' });
   });
 });
@@ -542,7 +695,9 @@ describe('updateItem — uom cross-field validation (merged against the current 
   it('rejects setting consumptionUom via PATCH when neither the patch nor the current row has unitsPerStockUom', async () => {
     const { db, resolveSequence } = createMockDb();
     resolveSequence([[{ id: 'i1', orgId: 'org-1', consumptionUom: null, unitsPerStockUom: null }]]); // current row
-    await expect(updateItem(ctx(db), 'i1', { consumptionUom: 'ml' })).rejects.toMatchObject({ code: 'invalid_uom_config' });
+    await expect(updateItem(ctx(db), 'i1', { consumptionUom: 'ml' })).rejects.toMatchObject({
+      code: 'invalid_uom_config',
+    });
   });
 
   it('allows setting consumptionUom via PATCH when the current row already has a unitsPerStockUom', async () => {

--- a/src/server/services/stock.service.ts
+++ b/src/server/services/stock.service.ts
@@ -1259,9 +1259,57 @@ export async function buildInvoiceIssuePreview(
 }
 
 /**
- * Shared preview tail for both the invoice and the service paths: given a
- * per-item aggregate in each item's CONSUMPTION uom (identity when the item has
- * no consumptionUom), joins item metadata + warehouse bins and builds the
+ * Expand mapped recipe parents to the stock leaves that the accrual/issue
+ * commit paths actually move. A direct stock-leaf mapping remains an identity.
+ */
+async function expandPreviewQtyToStockLeaves(
+  tx: CoreTx,
+  orgId: string,
+  qtyByItem: Map<string, number>,
+): Promise<Map<string, number>> {
+  if (!qtyByItem.size) return qtyByItem;
+  const edgeRows = await tx
+    .select({
+      parentItemId: stkItemComponents.parentItemId,
+      childItemId: stkItemComponents.childItemId,
+      qty: stkItemComponents.qty,
+    })
+    .from(stkItemComponents)
+    .where(eq(stkItemComponents.orgId, orgId));
+  if (!edgeRows.length) return qtyByItem;
+
+  const byParent = edgesByParent(
+    edgeRows.map((edge) => ({
+      parentItemId: edge.parentItemId,
+      childItemId: edge.childItemId,
+      qty: Number(edge.qty),
+    })),
+  );
+  const involved = new Set<string>([
+    ...qtyByItem.keys(),
+    ...edgeRows.flatMap((edge) => [edge.parentItemId, edge.childItemId]),
+  ]);
+  const flagRows = await tx
+    .select({ id: stkItems.id, isStockItem: stkItems.isStockItem })
+    .from(stkItems)
+    .where(and(eq(stkItems.orgId, orgId), inArray(stkItems.id, [...involved])));
+  const stockFlag = new Map(flagRows.map((row) => [row.id, row.isStockItem]));
+  const expanded = new Map<string, number>();
+  for (const [itemId, qtyConsumption] of qtyByItem) {
+    explodeToStockLeaves(
+      itemId,
+      qtyConsumption,
+      byParent,
+      (id) => stockFlag.get(id) ?? true,
+      expanded,
+    );
+  }
+  return expanded;
+}
+
+/**
+ * Shared preview tail for both invoice and service paths: expands any recipe
+ * parents, then joins stock-leaf metadata + warehouse bins and builds the
  * gauge-ready lines (stock-uom `qty` converted authoritatively, plus the raw
  * consumption qty and UOM fields the ConsumptionGauge needs).
  */
@@ -1271,7 +1319,8 @@ async function previewLinesForItemQtys(
   qtyByItem: Map<string, number>,
   warehouseId: string,
 ): Promise<InvoicePreviewLine[]> {
-  const itemIds = [...qtyByItem.keys()];
+  const previewQtyByItem = await expandPreviewQtyToStockLeaves(tx, orgId, qtyByItem);
+  const itemIds = [...previewQtyByItem.keys()];
   if (!itemIds.length) return [];
   const itemRows = await tx
     .select({
@@ -1303,7 +1352,7 @@ async function previewLinesForItemQtys(
 
   return itemIds.map((itemId) => {
     const item = itemById.get(itemId);
-    const qtyConsumption = qtyByItem.get(itemId)!;
+    const qtyConsumption = previewQtyByItem.get(itemId)!;
     const unitsPerStockUom = item?.unitsPerStockUom == null ? null : Number(item.unitsPerStockUom);
     const qty = round4(consumptionToStockQty({ unitsPerStockUom }, qtyConsumption));
     return {
@@ -1404,56 +1453,7 @@ export async function buildServiceIssuePreview(
     for (const m of mappingRows)
       qtyByItem.set(m.itemId, (qtyByItem.get(m.itemId) ?? 0) + quantity * Number(m.qtyPerUnit));
 
-    // Keep this in lockstep with accrueConsumption's commit path: a mapped
-    // item can be a recipe parent, so the preview must show the stock leaves
-    // that will actually be committed rather than the non-stock parent.
-    let previewQtyByItem = qtyByItem;
-    if (qtyByItem.size) {
-      const edgeRows = await tx
-        .select({
-          parentItemId: stkItemComponents.parentItemId,
-          childItemId: stkItemComponents.childItemId,
-          qty: stkItemComponents.qty,
-        })
-        .from(stkItemComponents)
-        .where(eq(stkItemComponents.orgId, ctx.tenantId));
-      if (edgeRows.length) {
-        const byParent = edgesByParent(
-          edgeRows.map((edge) => ({
-            parentItemId: edge.parentItemId,
-            childItemId: edge.childItemId,
-            qty: Number(edge.qty),
-          })),
-        );
-        const involved = new Set<string>([
-          ...qtyByItem.keys(),
-          ...edgeRows.flatMap((edge) => [edge.parentItemId, edge.childItemId]),
-        ]);
-        const flagRows = await tx
-          .select({ id: stkItems.id, isStockItem: stkItems.isStockItem })
-          .from(stkItems)
-          .where(and(eq(stkItems.orgId, ctx.tenantId), inArray(stkItems.id, [...involved])));
-        const stockFlag = new Map(flagRows.map((row) => [row.id, row.isStockItem]));
-        const expanded = new Map<string, number>();
-        for (const [itemId, qtyConsumption] of qtyByItem) {
-          explodeToStockLeaves(
-            itemId,
-            qtyConsumption,
-            byParent,
-            (id) => stockFlag.get(id) ?? true,
-            expanded,
-          );
-        }
-        previewQtyByItem = expanded;
-      }
-    }
-
-    const lines = await previewLinesForItemQtys(
-      tx,
-      ctx.tenantId,
-      previewQtyByItem,
-      input.warehouseId,
-    );
+    const lines = await previewLinesForItemQtys(tx, ctx.tenantId, qtyByItem, input.warehouseId);
     return {
       productName: product.name ?? input.finProductId,
       productCode: product.code ?? null,

--- a/src/server/services/stock.service.ts
+++ b/src/server/services/stock.service.ts
@@ -38,6 +38,8 @@ import {
   replayBins,
   binKey,
   consumptionToStockQty,
+  edgesByParent,
+  explodeToStockLeaves,
   round4,
   validateItemUomConfig,
   wouldCreateComponentCycle,
@@ -1402,7 +1404,56 @@ export async function buildServiceIssuePreview(
     for (const m of mappingRows)
       qtyByItem.set(m.itemId, (qtyByItem.get(m.itemId) ?? 0) + quantity * Number(m.qtyPerUnit));
 
-    const lines = await previewLinesForItemQtys(tx, ctx.tenantId, qtyByItem, input.warehouseId);
+    // Keep this in lockstep with accrueConsumption's commit path: a mapped
+    // item can be a recipe parent, so the preview must show the stock leaves
+    // that will actually be committed rather than the non-stock parent.
+    let previewQtyByItem = qtyByItem;
+    if (qtyByItem.size) {
+      const edgeRows = await tx
+        .select({
+          parentItemId: stkItemComponents.parentItemId,
+          childItemId: stkItemComponents.childItemId,
+          qty: stkItemComponents.qty,
+        })
+        .from(stkItemComponents)
+        .where(eq(stkItemComponents.orgId, ctx.tenantId));
+      if (edgeRows.length) {
+        const byParent = edgesByParent(
+          edgeRows.map((edge) => ({
+            parentItemId: edge.parentItemId,
+            childItemId: edge.childItemId,
+            qty: Number(edge.qty),
+          })),
+        );
+        const involved = new Set<string>([
+          ...qtyByItem.keys(),
+          ...edgeRows.flatMap((edge) => [edge.parentItemId, edge.childItemId]),
+        ]);
+        const flagRows = await tx
+          .select({ id: stkItems.id, isStockItem: stkItems.isStockItem })
+          .from(stkItems)
+          .where(and(eq(stkItems.orgId, ctx.tenantId), inArray(stkItems.id, [...involved])));
+        const stockFlag = new Map(flagRows.map((row) => [row.id, row.isStockItem]));
+        const expanded = new Map<string, number>();
+        for (const [itemId, qtyConsumption] of qtyByItem) {
+          explodeToStockLeaves(
+            itemId,
+            qtyConsumption,
+            byParent,
+            (id) => stockFlag.get(id) ?? true,
+            expanded,
+          );
+        }
+        previewQtyByItem = expanded;
+      }
+    }
+
+    const lines = await previewLinesForItemQtys(
+      tx,
+      ctx.tenantId,
+      previewQtyByItem,
+      input.warehouseId,
+    );
     return {
       productName: product.name ?? input.finProductId,
       productCode: product.code ?? null,

--- a/supabase/migrations/20260722153000_whatsapp_month_segments.sql
+++ b/supabase/migrations/20260722153000_whatsapp_month_segments.sql
@@ -2,20 +2,61 @@
 -- by stable UTC-calendar-month segments. Remove legacy chunks immediately so
 -- retrieval cannot return stale duplicate lifetime documents; the bounded
 -- reconciliation job repopulates monthly documents idempotently.
-with legacy as (
-  update public.knowledge_documents document
-  set status = 'deleted', ingested_at = now(), updated_at = now()
-  from public.knowledge_sources source
-  where source.id = document.source_id
-    and source.org_id = document.org_id
-    and source.connector = 'whatsapp'
-    and document.status <> 'deleted'
-    and not (document.metadata ? 'segmentMonth')
-  returning document.id
-)
-delete from public.knowledge_chunks chunk
-using legacy
-where chunk.document_id = legacy.id;
+set local lock_timeout = '5s';
+set local statement_timeout = '10min';
+
+do $$
+declare
+  affected integer;
+begin
+  loop
+    with batch as (
+      select document.id
+      from public.knowledge_documents document
+      join public.knowledge_sources source
+        on source.id = document.source_id
+       and source.org_id = document.org_id
+      where source.connector = 'whatsapp'
+        and document.status <> 'deleted'
+        and not (document.metadata ? 'segmentMonth')
+      order by document.id
+      limit 500
+    )
+    update public.knowledge_documents document
+    set status = 'deleted', ingested_at = now(), updated_at = now()
+    from batch
+    where document.id = batch.id;
+
+    get diagnostics affected = row_count;
+    exit when affected = 0;
+  end loop;
+
+  -- Chunk fan-out can be much larger than the document set, so bound it
+  -- independently. A retry also reaches this phase when documents were
+  -- already tombstoned by an earlier run.
+  loop
+    with batch as (
+      select chunk.id
+      from public.knowledge_chunks chunk
+      join public.knowledge_documents document on document.id = chunk.document_id
+      join public.knowledge_sources source
+        on source.id = document.source_id
+       and source.org_id = document.org_id
+      where source.connector = 'whatsapp'
+        and document.status = 'deleted'
+        and not (document.metadata ? 'segmentMonth')
+      order by chunk.id
+      limit 5000
+    )
+    delete from public.knowledge_chunks chunk
+    using batch
+    where chunk.id = batch.id;
+
+    get diagnostics affected = row_count;
+    exit when affected = 0;
+  end loop;
+end
+$$;
 
 -- Retrieval authorization will intersect this safe module key with caller
 -- capabilities. Merge rather than replace account/channel config.

--- a/supabase/migrations/20260722154000_business_parent_aggregates.sql
+++ b/supabase/migrations/20260722154000_business_parent_aggregates.sql
@@ -2,25 +2,71 @@
 -- stable parent documents. Tombstone prior standalone documents before the
 -- bounded reconcile recreates parent aggregates, preventing duplicate search
 -- evidence during rollout.
-with obsolete as (
-  update public.knowledge_documents document
-  set status = 'deleted', ingested_at = now(), updated_at = now()
-  from public.knowledge_sources source
-  where source.id = document.source_id
-    and source.org_id = document.org_id
-    and source.connector = 'hub-business'
-    and document.status <> 'deleted'
-    and (
-      document.external_id like 'stk_entry_lines:%'
-      or document.external_id like 'fin_invoice_items:%'
-      or document.external_id like 'fin_payments:%'
-      or document.external_id like 'pos_ticket_lines:%'
-      or document.external_id like 'pos_payments:%'
-      or document.external_id like 'meta_ad_posts:%'
-      or document.metadata->>'recordType' in ('meta_post_insights', 'meta_ad_insights')
+set local lock_timeout = '5s';
+set local statement_timeout = '10min';
+
+do $$
+declare
+  affected integer;
+begin
+  loop
+    with batch as (
+      select document.id
+      from public.knowledge_documents document
+      join public.knowledge_sources source
+        on source.id = document.source_id
+       and source.org_id = document.org_id
+      where source.connector = 'hub-business'
+        and document.status <> 'deleted'
+        and (
+          document.external_id like 'stk_entry_lines:%'
+          or document.external_id like 'fin_invoice_items:%'
+          or document.external_id like 'fin_payments:%'
+          or document.external_id like 'pos_ticket_lines:%'
+          or document.external_id like 'pos_payments:%'
+          or document.external_id like 'meta_ad_posts:%'
+          or document.metadata->>'recordType' in ('meta_post_insights', 'meta_ad_insights')
+        )
+      order by document.id
+      limit 500
     )
-  returning document.id
-)
-delete from public.knowledge_chunks chunk
-using obsolete
-where chunk.document_id = obsolete.id;
+    update public.knowledge_documents document
+    set status = 'deleted', ingested_at = now(), updated_at = now()
+    from batch
+    where document.id = batch.id;
+
+    get diagnostics affected = row_count;
+    exit when affected = 0;
+  end loop;
+
+  loop
+    with batch as (
+      select chunk.id
+      from public.knowledge_chunks chunk
+      join public.knowledge_documents document on document.id = chunk.document_id
+      join public.knowledge_sources source
+        on source.id = document.source_id
+       and source.org_id = document.org_id
+      where source.connector = 'hub-business'
+        and document.status = 'deleted'
+        and (
+          document.external_id like 'stk_entry_lines:%'
+          or document.external_id like 'fin_invoice_items:%'
+          or document.external_id like 'fin_payments:%'
+          or document.external_id like 'pos_ticket_lines:%'
+          or document.external_id like 'pos_payments:%'
+          or document.external_id like 'meta_ad_posts:%'
+          or document.metadata->>'recordType' in ('meta_post_insights', 'meta_ad_insights')
+        )
+      order by chunk.id
+      limit 5000
+    )
+    delete from public.knowledge_chunks chunk
+    using batch
+    where chunk.id = batch.id;
+
+    get diagnostics affected = row_count;
+    exit when affected = 0;
+  end loop;
+end
+$$;


### PR DESCRIPTION
Resolves every High finding from the adversarial review on production PR #74: organization-scoped gateway credentials and creation; tenant-safe legacy token fallback; truthful Hub backlog state; omnichat thread race isolation; stock preview recipe parity; and bounded timeout-guarded corpus cleanup migrations. Also fixes the related thread-loading race.\n\nValidation: Svelte check 0/0; 119 integrated focused tests; design lint no changed-file debt increase; token integrity zero violations; changed-file Prettier and git diff checks; production build; disposable PostgreSQL batch/idempotency validation on 501 documents and 5,511 chunks.