### PR TITLE
feat(brains): keep Instagram conversations fresh in Qdrant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,6 +116,13 @@ BRAIN_VECTOR_GENERATION=openai_te3s_1536_g1
 BRAIN_VECTOR_JWT_ISSUER=minion-hub
 BRAIN_VECTOR_JWT_AUDIENCE=minion-brain-vector
 BRAIN_VECTOR_TIMEOUT_MS=800
+# Where knowledge-chunk vectors live. Default (unset/"pgvector"): Hub embeds
+# chunks itself and stores the vectors in Supabase. "qdrant": Hub stops calling
+# the embeddings provider and Qdrant owns the vectors — Postgres keeps only the
+# canonical text plus the durable outbox, and the serving-index worker embeds.
+# Flip this ONLY together with the matching active generation's storage_mode;
+# corpus writes hard-fail otherwise. See docs/runbooks/brain-vector-qdrant.md §4.
+BRAIN_VECTOR_STORAGE_MODE=pgvector
 
 # Supabase (Phase 1b dual-mode auth). Hub default = supabase (cloud);
 # set both to 'better-auth' to run the self-hosted fallback.

--- a/docs/runbooks/brain-vector-qdrant.md
+++ b/docs/runbooks/brain-vector-qdrant.md
@@ -1,8 +1,13 @@
 # Brain vector serving-index rollout
 
-Supabase is canonical; Qdrant is a rebuildable serving index. The migration
-installs the generation with `enqueue_enabled = false`. Do not enable enqueue
-until the vector API and worker are healthy and the checks below pass.
+Supabase is canonical for chunk text and outbox state; Qdrant is the serving
+index. Each generation declares who owns the vectors themselves through
+`brain_vector_generations.storage_mode` — `pgvector` (default) keeps them in
+Supabase and Qdrant stays rebuildable from Postgres alone; `qdrant` keeps only
+text and outbox metadata in Postgres, so the vectors are rebuilt by re-embedding
+rather than by copying (see §4). The migration installs the generation with
+`enqueue_enabled = false`. Do not enable enqueue until the vector API and worker
+are healthy and the checks below pass.
 
 ## 1. Disposable migration proof
 
@@ -146,3 +151,55 @@ order by generation;
 Every row must report `enqueue_enabled = false`. Only the controlled deployment
 step may enable the active generation after the real worker has passed health,
 Qdrant collection/alias checks, and this canary.
+
+## 4. Qdrant-owned vectors (`storage_mode = 'qdrant'`)
+
+In this mode Hub stops calling the embeddings provider for conversation-corpus
+chunks: it writes the canonical text and the worker produces the vectors.
+`knowledge_chunks.embedding` therefore stays null by design — "is the chunk
+served?" is answered by the ack receipt (`vector_indexed_hash` +
+`vector_indexed_generation`), not by the embedding column and not by an empty
+outbox. A receipt earned under a retired generation does not count, so a
+collection rotation reads as pending until its backfill reaches each chunk.
+
+Prerequisite: the outbox trigger installed by
+`20260723010000_brain_vector_outbox.sql` deliberately refuses to enqueue a
+null-embedding chunk (an incomplete pgvector chunk has no valid serving-index
+state). The worker deployment ships the trigger/RPC upgrade that makes a
+null embedding the _expected_ state for a Qdrant-owned generation. Do not flip
+`storage_mode` before that upgrade is applied, or newly written chunks will
+never reach Qdrant and every source will sit at `queued`.
+
+Two switches must then agree, and Hub enforces it: conversation-corpus writes
+abort with `BRAIN_VECTOR_STORAGE_MODE=qdrant requires one active Qdrant-owned
+vector generation` unless `public.brain_vector_app_generation_mode()` returns
+`qdrant`. Cut over database-first, revert app-first:
+
+1. As owner, set the active generation's mode and enable enqueue:
+
+   ```sql
+   update public.brain_vector_generations
+   set storage_mode = 'qdrant', enqueue_enabled = true
+   where generation = 'openai_te3s_1536_g1' and is_active;
+
+   select public.brain_vector_app_generation_mode();  -- must return 'qdrant'
+   ```
+
+2. Only then deploy Hub with `BRAIN_VECTOR_STORAGE_MODE=qdrant`.
+
+The business corpus (`brain-business-corpus.service.ts`) does not read this
+flag: it keeps embedding into Supabase regardless, so the pgvector lane stays
+live for those sources.
+
+To roll back, remove the env var (or set it to `pgvector`) and redeploy first,
+then move the generation back to `storage_mode = 'pgvector'` — the reverse order
+leaves the app failing every conversation-corpus write in between. Rolling back
+does not restore vectors: chunks written while Qdrant owned them have no
+Postgres embedding, so the pgvector lane must re-embed them.
+
+Brain source health in this mode comes from
+`public.brain_vector_app_source_state(source_id)` and
+`public.brain_vector_app_source_pending_count(source_id)` (both SECURITY
+DEFINER, `app_ledger`-only, org-scoped by the `app.current_org_id` GUC) rather
+than from counting null embeddings. A source that reports `queued` with a
+non-zero pending count is waiting on the worker, not on Hub.

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "vercel-build": "([ -f .env ] || cp .env.example .env) && bun scripts/db-migrate.ts && bun run build",
     "db:migrate": "bun scripts/db-migrate.ts",
     "db:status": "bun scripts/db-status.ts",
+    "db:conversation-index": "bun scripts/ensure-conversation-corpus-index.ts",
     "db:restore-brain-ann": "bun scripts/restore-brain-ann.ts",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/scripts/bootstrap-brain-corpus.ts
+++ b/scripts/bootstrap-brain-corpus.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env bun
 /**
- * Ensure Master/WhatsApp Focused brains, discover WhatsApp account sources,
- * and drain the deterministic conversation backfill for one org or all orgs.
+ * Ensure Master/All Conversations brains, discover every chat channel/account
+ * source, and drain the deterministic conversation backfill for one org or all orgs.
  *
  * This is safe to rerun: source/document/chunk identities and content hashes
  * are stable, so unchanged chunks are not sent to the embeddings provider.
  *
- *   bun scripts/bootstrap-brain-corpus.ts <orgId> [--batch=50]
+ *   bun scripts/bootstrap-brain-corpus.ts <orgId> [--batch=50] [--max-rounds=1]
  *   bun scripts/bootstrap-brain-corpus.ts --all [--batch=50]
  */
 import './_sveltekit-bun-shim.ts';
@@ -17,7 +17,11 @@ const args = process.argv.slice(2);
 const all = args.includes('--all');
 const orgArg = args.find((arg) => !arg.startsWith('--'));
 const batchArg = args.find((arg) => arg.startsWith('--batch='));
+const maxRoundsArg = args.find((arg) => arg.startsWith('--max-rounds='));
 const batch = Math.max(1, Math.min(500, Number(batchArg?.split('=')[1] ?? 50)));
+const maxRounds = maxRoundsArg
+  ? Math.max(1, Math.floor(Number(maxRoundsArg.split('=')[1]) || 1))
+  : Number.POSITIVE_INFINITY;
 if (!all && !orgArg) {
   throw new Error('Pass an orgId or --all');
 }
@@ -28,7 +32,7 @@ const client = postgres(url, { prepare: false, max: 5 });
 const db = drizzle(client);
 
 async function bootstrapOrg(orgId: string) {
-  const { bootstrapBrainCorpus, backfillWhatsAppConversations } =
+  const { bootstrapBrainCorpus, backfillConversations } =
     await import('../src/server/services/brain-corpus.service.ts');
   const ctx = { db, tenantId: orgId } as unknown as import('../src/server/auth/core-ctx').CoreCtx;
   let cursor: string | null = null;
@@ -47,8 +51,8 @@ async function bootstrapOrg(orgId: string) {
     `[${orgId}] round=${rounds} sources=${initial.sources.length} processed=${initial.backfill.processed} changed_chunks=${initial.backfill.changedChunks} embedded=${initial.backfill.embeddedChunks}`,
   );
 
-  while (cursor) {
-    const page = await backfillWhatsAppConversations(ctx, { cursor, limit: batch });
+  while (cursor && rounds < maxRounds) {
+    const page = await backfillConversations(ctx, { cursor, limit: batch });
     rounds += 1;
     processed += page.processed;
     changedChunks += page.changedChunks;
@@ -58,8 +62,9 @@ async function bootstrapOrg(orgId: string) {
       `[${orgId}] round=${rounds} processed=${page.processed} changed_chunks=${page.changedChunks} embedded=${page.embeddedChunks} has_more=${page.hasMore}`,
     );
   }
+  const state = cursor ? 'PAUSED' : 'DONE';
   console.log(
-    `[${orgId}] DONE rounds=${rounds} processed=${processed} changed_chunks=${changedChunks} embedded=${embeddedChunks}`,
+    `[${orgId}] ${state} rounds=${rounds} processed=${processed} changed_chunks=${changedChunks} embedded=${embeddedChunks}`,
   );
 }
 

--- a/scripts/ensure-conversation-corpus-index.ts
+++ b/scripts/ensure-conversation-corpus-index.ts
@@ -48,7 +48,9 @@ try {
 
   if (apply) {
     if (normalization?.dirty_channel !== 0 || normalization.dirty_account !== 0) {
-      throw new Error('message channel/account normalization gate failed');
+      throw new Error(
+        `message channel/account normalization gate failed: ${JSON.stringify(normalization ?? null)}`,
+      );
     }
     await sql`set lock_timeout = '5s'`;
     await sql`set statement_timeout = '15min'`;

--- a/scripts/ensure-conversation-corpus-index.ts
+++ b/scripts/ensure-conversation-corpus-index.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env bun
+/**
+ * Build the all-channel conversation corpus scan index without blocking
+ * message ingest. The Hub migration runner is transactional, while PostgreSQL
+ * requires CREATE INDEX CONCURRENTLY to run outside a transaction.
+ *
+ * Inspect: bun run db:conversation-index
+ * Apply:   bun run db:conversation-index --apply
+ */
+import postgres from 'postgres';
+
+const INDEX_NAME = 'messages_conversation_corpus_scan_idx';
+const apply = process.argv.includes('--apply');
+const url = process.env.SUPABASE_DB_URL?.trim();
+
+if (!url) throw new Error('SUPABASE_DB_URL is not set');
+
+const sql = postgres(url, {
+  prepare: false,
+  max: 1,
+  connect_timeout: 10,
+  idle_timeout: 5,
+  application_name: 'minion-conversation-corpus-index',
+  onnotice: () => {},
+});
+
+try {
+  const [normalization] = await sql<
+    Array<{ dirty_channel: number; dirty_account: number; rows: number }>
+  >`
+    select
+      count(*) filter (where channel is distinct from lower(trim(channel)))::int
+        as dirty_channel,
+      count(*) filter (
+        where account_id is not null and account_id is distinct from trim(account_id)
+      )::int as dirty_account,
+      count(*)::int as rows
+    from public.messages
+  `;
+  const [before] = await sql<Array<{ valid: boolean; ready: boolean; bytes: string }>>`
+    select index_meta.indisvalid as valid, index_meta.indisready as ready,
+      pg_relation_size(index_class.oid)::bigint::text as bytes
+    from pg_class index_class
+    join pg_index index_meta on index_meta.indexrelid = index_class.oid
+    join pg_namespace namespace on namespace.oid = index_class.relnamespace
+    where namespace.nspname = 'public' and index_class.relname = ${INDEX_NAME}
+  `;
+
+  if (apply) {
+    if (normalization?.dirty_channel !== 0 || normalization.dirty_account !== 0) {
+      throw new Error('message channel/account normalization gate failed');
+    }
+    await sql`set lock_timeout = '5s'`;
+    await sql`set statement_timeout = '15min'`;
+    await sql.unsafe(`
+      create index concurrently if not exists ${INDEX_NAME}
+      on public.messages (
+        org_id,
+        lower(trim(channel)),
+        coalesce(nullif(trim(account_id), ''), 'default'),
+        chat_id,
+        coalesce(occurred_at, created_at),
+        id
+      )
+      where nullif(trim(chat_id), '') is not null
+        and coalesce(is_group, false) = false
+        and is_bot is not true
+        and nullif(trim(content), '') is not null
+    `);
+  }
+
+  const [after] = await sql<Array<{ valid: boolean; ready: boolean; bytes: string }>>`
+    select index_meta.indisvalid as valid, index_meta.indisready as ready,
+      pg_relation_size(index_class.oid)::bigint::text as bytes
+    from pg_class index_class
+    join pg_index index_meta on index_meta.indexrelid = index_class.oid
+    join pg_namespace namespace on namespace.oid = index_class.relnamespace
+    where namespace.nspname = 'public' and index_class.relname = ${INDEX_NAME}
+  `;
+  console.log(
+    JSON.stringify({ apply, normalization, before: before ?? null, after: after ?? null }),
+  );
+} finally {
+  await sql.end({ timeout: 5 });
+}

--- a/specs/2026-07-24-chat-message-queue-spec.md
+++ b/specs/2026-07-24-chat-message-queue-spec.md
@@ -12,16 +12,16 @@ automatically (FIFO) when the turn completes.
 
 ## Current behavior (grounded)
 
-| Concern | Where | Note |
-|---|---|---|
-| Composer submit | `ChatInput.send` → `onsubmit(composed(text), mode)` (`ChatInput.svelte:67`) | clears its own `value`/`chips` immediately |
-| Page handler | `handleSubmit(text, mode)` (`home/+page.svelte:622`) | sets `chat.inputText = text` then `sendChatMsg(agentId)` |
-| Send + guard | `sendChatMsg` (`chat-rpc.ts:56`) | **`if (!msg \|\| chat.sending \|\| !conn.connected) return;`** — the drop |
-| In-flight turn | `chat.runId !== null` (`types/chat.ts:25`) | authoritative for the **whole** turn; `chat.sending` (`:26`) goes false after the first token |
-| Turn complete | `onChatEvent` `state==='final'` (`gateway.svelte.ts:1194`) | nulls `runId` (`:1208`), then after the smoother commits fires `notifyAgentReplyFinal` (`chat.svelte.ts:39`) |
-| Done pub/sub | `onAgentReplyFinal(cb)` / `notifyAgentReplyFinal` (`chat.svelte.ts:34,39`) | already used by the voice engine — reuse it |
-| Terminal (also) | `state==='aborted'` (`:1222`), `'error'` (`:1243`), send catch (`chat-rpc.ts:95`) | all null `runId` |
-| Transcript | `.thread` list (`home/+page.svelte:993–1099`), live stream turn (`:1101–1132`) | rows keyed by content `rowKey` (`:469`) |
+| Concern         | Where                                                                             | Note                                                                                                         |
+| --------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Composer submit | `ChatInput.send` → `onsubmit(composed(text), mode)` (`ChatInput.svelte:67`)       | clears its own `value`/`chips` immediately                                                                   |
+| Page handler    | `handleSubmit(text, mode)` (`home/+page.svelte:622`)                              | sets `chat.inputText = text` then `sendChatMsg(agentId)`                                                     |
+| Send + guard    | `sendChatMsg` (`chat-rpc.ts:56`)                                                  | **`if (!msg \|\| chat.sending \|\| !conn.connected) return;`** — the drop                                    |
+| In-flight turn  | `chat.runId !== null` (`types/chat.ts:25`)                                        | authoritative for the **whole** turn; `chat.sending` (`:26`) goes false after the first token                |
+| Turn complete   | `onChatEvent` `state==='final'` (`gateway.svelte.ts:1194`)                        | nulls `runId` (`:1208`), then after the smoother commits fires `notifyAgentReplyFinal` (`chat.svelte.ts:39`) |
+| Done pub/sub    | `onAgentReplyFinal(cb)` / `notifyAgentReplyFinal` (`chat.svelte.ts:34,39`)        | already used by the voice engine — reuse it                                                                  |
+| Terminal (also) | `state==='aborted'` (`:1222`), `'error'` (`:1243`), send catch (`chat-rpc.ts:95`) | all null `runId`                                                                                             |
+| Transcript      | `.thread` list (`home/+page.svelte:993–1099`), live stream turn (`:1101–1132`)    | rows keyed by content `rowKey` (`:469`)                                                                      |
 
 There is **no** existing queue, debounce, or pending-message concept in chat state.
 
@@ -33,42 +33,48 @@ it clears on the first delta while the agent keeps streaming.)
 ## Design (minimal — reuse state + the existing done-signal)
 
 ### Data model
+
 Add one field to `AgentChatState` (`src/lib/types/chat.ts`):
 
 ```ts
 /** Messages the user sent while runId != null, awaiting flush (FIFO). */
 queued: QueuedMessage[];
 ```
+
 ```ts
 export interface QueuedMessage {
-  id: string;      // client uuid — React-key + dequeue handle
-  text: string;    // already `composed()` (context blocks folded in)
+  id: string; // client uuid — React-key + dequeue handle
+  text: string; // already `composed()` (context blocks folded in)
   mode: 'ask' | 'capture';
 }
 ```
+
 Initialize `queued: []` in `ensureAgentChat` (`chat.svelte.ts:184`).
 
 > ponytail: no separate store, no generic job runner. It's an array on the state that
 > already exists, flushed by the pub/sub that already exists.
 
 ### Enqueue
+
 One chokepoint: **`sendChatMsg`** (`chat-rpc.ts:56`). Replace the silent drop with an enqueue
-so *every* caller (composer Enter, feed cards, retry/edit, voice) gets queuing for free:
+so _every_ caller (composer Enter, feed cards, retry/edit, voice) gets queuing for free:
 
 ```ts
 if (!msg || !conn.connected) return;
 if (chat.sending || chat.runId !== null) {
-  chat.queued.push({ id: uuid(), text: msg, mode });   // mode from chat.inputMode or param
+  chat.queued.push({ id: uuid(), text: msg, mode }); // mode from chat.inputMode or param
   chat.inputText = '';
   return;
 }
 // …existing send path…
 ```
+
 `ChatInput.send` and `handleSubmit` stay as-is — they already clear the composer optimistically,
 so the message visibly leaves the input and reappears as a queued row. No busy-gating in
 `ChatInput` (recon confirms it has none today).
 
 ### Flush (FIFO, one at a time)
+
 Subscribe once (module init in `chat.svelte.ts`, next to the voice subscriber):
 
 ```ts
@@ -79,7 +85,7 @@ function flushNextQueued(agentId: string) {
   if (!chat || chat.runId !== null || chat.queued.length === 0) return;
   const next = chat.queued.shift()!;
   chat.inputText = next.text;
-  sendChatMsg(agentId);          // its own guard re-queues if somehow still busy
+  sendChatMsg(agentId); // its own guard re-queues if somehow still busy
 }
 ```
 
@@ -93,6 +99,7 @@ Decision: on `aborted`/`error`, **do not auto-flush** — leave the queue intact
 into a just-errored agent would likely re-error the whole queue.
 
 ### Idempotency
+
 Each queued message gets its own `runId`/`idempotencyKey` at actual send time (unchanged —
 `sendChatMsg` mints it at `:70`). The `QueuedMessage.id` is client-only.
 
@@ -119,6 +126,7 @@ Queued messages render as pending rows **after** the live stream turn in `.threa
 All tokens semantic; no raw hex/z-index. Run `bun run lint:design && bun run lint:tokens`.
 
 ### Composer
+
 No disable. Optionally show a one-line hint under the input when `runId !== null` and the
 user is typing: “Will queue — agent is replying.” (caption type role). Enter still enqueues.
 
@@ -126,14 +134,14 @@ user is typing: “Will queue — agent is replying.” (caption type role). Ent
 
 ## Edge cases
 
-| Case | Behavior |
-|---|---|
-| Disconnected (`!conn.connected`) | Do **not** queue — keep today's return (nothing to flush into). Composer keeps the text. |
-| Capture mode (`#`) | `handleSubmit` capture branch is a no-op stub today (`+page.svelte:623`) — queue only `ask`. |
-| New-chat / switch agent mid-queue | Queue is per-agent (`agentChat[agentId]`), so it stays with its agent. Starting a *new* chat on the same agent: **clear** `queued` (the thread reset invalidates pending context). |
-| 2-min send-safety timeout fires (`chat-rpc.ts:84`) | It nulls `sending`/`runId`; treat like a terminal-non-final → paused state, don't auto-flush. |
-| Rapid multi-enqueue | FIFO array; flush pops one per `final`. Cap at e.g. **20** with a toast if exceeded (ponytail: hard cap, raise if anyone hits it). |
-| Reload | `queued` is in-memory `$state` — lost on reload (acceptable v1; persist to the chat draft store only if requested). |
+| Case                                               | Behavior                                                                                                                                                                           |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Disconnected (`!conn.connected`)                   | Do **not** queue — keep today's return (nothing to flush into). Composer keeps the text.                                                                                           |
+| Capture mode (`#`)                                 | `handleSubmit` capture branch is a no-op stub today (`+page.svelte:623`) — queue only `ask`.                                                                                       |
+| New-chat / switch agent mid-queue                  | Queue is per-agent (`agentChat[agentId]`), so it stays with its agent. Starting a _new_ chat on the same agent: **clear** `queued` (the thread reset invalidates pending context). |
+| 2-min send-safety timeout fires (`chat-rpc.ts:84`) | It nulls `sending`/`runId`; treat like a terminal-non-final → paused state, don't auto-flush.                                                                                      |
+| Rapid multi-enqueue                                | FIFO array; flush pops one per `final`. Cap at e.g. **20** with a toast if exceeded (ponytail: hard cap, raise if anyone hits it).                                                 |
+| Reload                                             | `queued` is in-memory `$state` — lost on reload (acceptable v1; persist to the chat draft store only if requested).                                                                |
 
 ---
 

--- a/specs/2026-07-24-chat-message-queue-spec.md
+++ b/specs/2026-07-24-chat-message-queue-spec.md
@@ -12,16 +12,16 @@ automatically (FIFO) when the turn completes.
 
 ## Current behavior (grounded)
 
-| Concern         | Where                                                                             | Note                                                                                                         |
-| --------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| Composer submit | `ChatInput.send` → `onsubmit(composed(text), mode)` (`ChatInput.svelte:67`)       | clears its own `value`/`chips` immediately                                                                   |
-| Page handler    | `handleSubmit(text, mode)` (`home/+page.svelte:622`)                              | sets `chat.inputText = text` then `sendChatMsg(agentId)`                                                     |
-| Send + guard    | `sendChatMsg` (`chat-rpc.ts:56`)                                                  | **`if (!msg \|\| chat.sending \|\| !conn.connected) return;`** — the drop                                    |
-| In-flight turn  | `chat.runId !== null` (`types/chat.ts:25`)                                        | authoritative for the **whole** turn; `chat.sending` (`:26`) goes false after the first token                |
-| Turn complete   | `onChatEvent` `state==='final'` (`gateway.svelte.ts:1194`)                        | nulls `runId` (`:1208`), then after the smoother commits fires `notifyAgentReplyFinal` (`chat.svelte.ts:39`) |
-| Done pub/sub    | `onAgentReplyFinal(cb)` / `notifyAgentReplyFinal` (`chat.svelte.ts:34,39`)        | already used by the voice engine — reuse it                                                                  |
-| Terminal (also) | `state==='aborted'` (`:1222`), `'error'` (`:1243`), send catch (`chat-rpc.ts:95`) | all null `runId`                                                                                             |
-| Transcript      | `.thread` list (`home/+page.svelte:993–1099`), live stream turn (`:1101–1132`)    | rows keyed by content `rowKey` (`:469`)                                                                      |
+| Concern | Where | Note |
+|---|---|---|
+| Composer submit | `ChatInput.send` → `onsubmit(composed(text), mode)` (`ChatInput.svelte:67`) | clears its own `value`/`chips` immediately |
+| Page handler | `handleSubmit(text, mode)` (`home/+page.svelte:622`) | sets `chat.inputText = text` then `sendChatMsg(agentId)` |
+| Send + guard | `sendChatMsg` (`chat-rpc.ts:56`) | **`if (!msg \|\| chat.sending \|\| !conn.connected) return;`** — the drop |
+| In-flight turn | `chat.runId !== null` (`types/chat.ts:25`) | authoritative for the **whole** turn; `chat.sending` (`:26`) goes false after the first token |
+| Turn complete | `onChatEvent` `state==='final'` (`gateway.svelte.ts:1194`) | nulls `runId` (`:1208`), then after the smoother commits fires `notifyAgentReplyFinal` (`chat.svelte.ts:39`) |
+| Done pub/sub | `onAgentReplyFinal(cb)` / `notifyAgentReplyFinal` (`chat.svelte.ts:34,39`) | already used by the voice engine — reuse it |
+| Terminal (also) | `state==='aborted'` (`:1222`), `'error'` (`:1243`), send catch (`chat-rpc.ts:95`) | all null `runId` |
+| Transcript | `.thread` list (`home/+page.svelte:993–1099`), live stream turn (`:1101–1132`) | rows keyed by content `rowKey` (`:469`) |
 
 There is **no** existing queue, debounce, or pending-message concept in chat state.
 
@@ -33,48 +33,42 @@ it clears on the first delta while the agent keeps streaming.)
 ## Design (minimal — reuse state + the existing done-signal)
 
 ### Data model
-
 Add one field to `AgentChatState` (`src/lib/types/chat.ts`):
 
 ```ts
 /** Messages the user sent while runId != null, awaiting flush (FIFO). */
 queued: QueuedMessage[];
 ```
-
 ```ts
 export interface QueuedMessage {
-  id: string; // client uuid — React-key + dequeue handle
-  text: string; // already `composed()` (context blocks folded in)
+  id: string;      // client uuid — React-key + dequeue handle
+  text: string;    // already `composed()` (context blocks folded in)
   mode: 'ask' | 'capture';
 }
 ```
-
 Initialize `queued: []` in `ensureAgentChat` (`chat.svelte.ts:184`).
 
 > ponytail: no separate store, no generic job runner. It's an array on the state that
 > already exists, flushed by the pub/sub that already exists.
 
 ### Enqueue
-
 One chokepoint: **`sendChatMsg`** (`chat-rpc.ts:56`). Replace the silent drop with an enqueue
-so _every_ caller (composer Enter, feed cards, retry/edit, voice) gets queuing for free:
+so *every* caller (composer Enter, feed cards, retry/edit, voice) gets queuing for free:
 
 ```ts
 if (!msg || !conn.connected) return;
 if (chat.sending || chat.runId !== null) {
-  chat.queued.push({ id: uuid(), text: msg, mode }); // mode from chat.inputMode or param
+  chat.queued.push({ id: uuid(), text: msg, mode });   // mode from chat.inputMode or param
   chat.inputText = '';
   return;
 }
 // …existing send path…
 ```
-
 `ChatInput.send` and `handleSubmit` stay as-is — they already clear the composer optimistically,
 so the message visibly leaves the input and reappears as a queued row. No busy-gating in
 `ChatInput` (recon confirms it has none today).
 
 ### Flush (FIFO, one at a time)
-
 Subscribe once (module init in `chat.svelte.ts`, next to the voice subscriber):
 
 ```ts
@@ -85,7 +79,7 @@ function flushNextQueued(agentId: string) {
   if (!chat || chat.runId !== null || chat.queued.length === 0) return;
   const next = chat.queued.shift()!;
   chat.inputText = next.text;
-  sendChatMsg(agentId); // its own guard re-queues if somehow still busy
+  sendChatMsg(agentId);          // its own guard re-queues if somehow still busy
 }
 ```
 
@@ -99,7 +93,6 @@ Decision: on `aborted`/`error`, **do not auto-flush** — leave the queue intact
 into a just-errored agent would likely re-error the whole queue.
 
 ### Idempotency
-
 Each queued message gets its own `runId`/`idempotencyKey` at actual send time (unchanged —
 `sendChatMsg` mints it at `:70`). The `QueuedMessage.id` is client-only.
 
@@ -126,7 +119,6 @@ Queued messages render as pending rows **after** the live stream turn in `.threa
 All tokens semantic; no raw hex/z-index. Run `bun run lint:design && bun run lint:tokens`.
 
 ### Composer
-
 No disable. Optionally show a one-line hint under the input when `runId !== null` and the
 user is typing: “Will queue — agent is replying.” (caption type role). Enter still enqueues.
 
@@ -134,14 +126,14 @@ user is typing: “Will queue — agent is replying.” (caption type role). Ent
 
 ## Edge cases
 
-| Case                                               | Behavior                                                                                                                                                                           |
-| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Disconnected (`!conn.connected`)                   | Do **not** queue — keep today's return (nothing to flush into). Composer keeps the text.                                                                                           |
-| Capture mode (`#`)                                 | `handleSubmit` capture branch is a no-op stub today (`+page.svelte:623`) — queue only `ask`.                                                                                       |
-| New-chat / switch agent mid-queue                  | Queue is per-agent (`agentChat[agentId]`), so it stays with its agent. Starting a _new_ chat on the same agent: **clear** `queued` (the thread reset invalidates pending context). |
-| 2-min send-safety timeout fires (`chat-rpc.ts:84`) | It nulls `sending`/`runId`; treat like a terminal-non-final → paused state, don't auto-flush.                                                                                      |
-| Rapid multi-enqueue                                | FIFO array; flush pops one per `final`. Cap at e.g. **20** with a toast if exceeded (ponytail: hard cap, raise if anyone hits it).                                                 |
-| Reload                                             | `queued` is in-memory `$state` — lost on reload (acceptable v1; persist to the chat draft store only if requested).                                                                |
+| Case | Behavior |
+|---|---|
+| Disconnected (`!conn.connected`) | Do **not** queue — keep today's return (nothing to flush into). Composer keeps the text. |
+| Capture mode (`#`) | `handleSubmit` capture branch is a no-op stub today (`+page.svelte:623`) — queue only `ask`. |
+| New-chat / switch agent mid-queue | Queue is per-agent (`agentChat[agentId]`), so it stays with its agent. Starting a *new* chat on the same agent: **clear** `queued` (the thread reset invalidates pending context). |
+| 2-min send-safety timeout fires (`chat-rpc.ts:84`) | It nulls `sending`/`runId`; treat like a terminal-non-final → paused state, don't auto-flush. |
+| Rapid multi-enqueue | FIFO array; flush pops one per `final`. Cap at e.g. **20** with a toast if exceeded (ponytail: hard cap, raise if anyone hits it). |
+| Reload | `queued` is in-memory `$state` — lost on reload (acceptable v1; persist to the chat draft store only if requested). |
 
 ---
 

--- a/src/routes/api/meta/sync/tick/+server.ts
+++ b/src/routes/api/meta/sync/tick/+server.ts
@@ -2,12 +2,21 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json, error } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { getCoreDb } from '$server/db/pg-client';
-import { enqueueJob, findDueJobs, getLatestSucceededJob } from '$server/services/meta/meta-sync-jobs.service';
-import { defaultSinceDate, listConnectedOrgIds, runJob } from '$server/services/meta/meta-sync.service';
+import {
+  enqueueJob,
+  findDueJobs,
+  getLatestSucceededJob,
+} from '$server/services/meta/meta-sync-jobs.service';
+import {
+  defaultSinceDate,
+  listConnectedOrgIds,
+  runJob,
+} from '$server/services/meta/meta-sync.service';
 
-const SYNC_KINDS = ['posts', 'ads', 'messages'] as const;
+const SYNC_KINDS = ['posts', 'ads', 'messages', 'messages_tail'] as const;
 const STALE_ENQUEUE_MS = 6 * 60 * 60_000; // spec §6: re-enqueue a kind once its last success is >6h old
-const CLAIM_LIMIT = 3;
+const MESSAGE_TAIL_STALE_MS = 5 * 60_000;
+const CLAIM_LIMIT = 6;
 
 /**
  * GET/POST /api/meta/sync/tick — cron entrypoint (Vercel Cron only ever sends
@@ -35,8 +44,11 @@ const handle: RequestHandler = async ({ request }) => {
     for (const kind of SYNC_KINDS) {
       try {
         const latest = await getLatestSucceededJob(ctx, kind);
-        const ageMs = latest?.finishedAt ? Date.now() - new Date(latest.finishedAt).getTime() : Number.POSITIVE_INFINITY;
-        if (ageMs > STALE_ENQUEUE_MS) {
+        const ageMs = latest?.finishedAt
+          ? Date.now() - new Date(latest.finishedAt).getTime()
+          : Number.POSITIVE_INFINITY;
+        const staleAfter = kind === 'messages_tail' ? MESSAGE_TAIL_STALE_MS : STALE_ENQUEUE_MS;
+        if (ageMs > staleAfter) {
           await enqueueJob(ctx, kind, { since });
           enqueued++;
         }
@@ -47,7 +59,13 @@ const handle: RequestHandler = async ({ request }) => {
   }
 
   const due = await findDueJobs(CLAIM_LIMIT);
-  const results: Array<{ jobId: string; orgId: string; kind: string; ok: boolean; error?: string }> = [];
+  const results: Array<{
+    jobId: string;
+    orgId: string;
+    kind: string;
+    ok: boolean;
+    error?: string;
+  }> = [];
   for (const j of due) {
     const ctx = { db: getCoreDb(), tenantId: j.orgId };
     try {

--- a/src/routes/api/meta/sync/tick/+server.ts
+++ b/src/routes/api/meta/sync/tick/+server.ts
@@ -23,11 +23,14 @@ const STALE_ENQUEUE_MS = 6 * 60 * 60_000; // spec §6: re-enqueue a kind once it
  * not a code change; no staleness constant here can beat the cron period.
  */
 const MESSAGE_TAIL_STALE_MS = 0;
-/** Two slots per connected org so one tick can cover every org's tail job
- * (findDueJobs reserves half the slots for that lane) without letting a large
- * tenant list turn one tick into an unbounded run. */
-const CLAIM_LIMIT_MIN = 6;
-const CLAIM_LIMIT_MAX = 24;
+/** One cheap tail slice per connected org, so a tick covers every org's
+ * freshness lane. Backlog slices are orders of magnitude more expensive (up to
+ * 150 posts / 100 conversations / 90 ad rows each, run sequentially in this one
+ * request), so that lane stays at a small fixed cap no matter how many orgs
+ * connect — it is catch-up work, not latency-sensitive. */
+const TAIL_CLAIM_MIN = 3;
+const TAIL_CLAIM_MAX = 24;
+const BACKLOG_CLAIM_LIMIT = 3;
 
 /**
  * GET/POST /api/meta/sync/tick — cron entrypoint (Vercel Cron only ever sends
@@ -70,7 +73,8 @@ const handle: RequestHandler = async ({ request }) => {
   }
 
   const due = await findDueJobs(
-    Math.min(CLAIM_LIMIT_MAX, Math.max(CLAIM_LIMIT_MIN, orgIds.length * 2)),
+    Math.min(TAIL_CLAIM_MAX, Math.max(TAIL_CLAIM_MIN, orgIds.length)),
+    BACKLOG_CLAIM_LIMIT,
   );
   const results: Array<{
     jobId: string;

--- a/src/routes/api/meta/sync/tick/+server.ts
+++ b/src/routes/api/meta/sync/tick/+server.ts
@@ -6,6 +6,7 @@ import {
   enqueueJob,
   findDueJobs,
   getLatestSucceededJob,
+  pruneTerminalTailJobs,
 } from '$server/services/meta/meta-sync-jobs.service';
 import {
   defaultSinceDate,
@@ -77,7 +78,13 @@ const handle: RequestHandler = async ({ request }) => {
       results.push({ jobId: j.jobId, orgId: j.orgId, kind: j.kind, ok: false, error: msg });
     }
   }
-  return json({ enqueued, claimed: results.length, results });
+  let pruned = 0;
+  try {
+    pruned = await pruneTerminalTailJobs();
+  } catch (e) {
+    console.error('[meta-sync] tail job retention failed', e);
+  }
+  return json({ enqueued, claimed: results.length, pruned, results });
 };
 
 export const GET = handle;

--- a/src/routes/api/meta/sync/tick/+server.ts
+++ b/src/routes/api/meta/sync/tick/+server.ts
@@ -16,8 +16,18 @@ import {
 
 const SYNC_KINDS = ['posts', 'ads', 'messages', 'messages_tail'] as const;
 const STALE_ENQUEUE_MS = 6 * 60 * 60_000; // spec §6: re-enqueue a kind once its last success is >6h old
-const MESSAGE_TAIL_STALE_MS = 5 * 60_000;
-const CLAIM_LIMIT = 6;
+/**
+ * The tail lane is topped up on EVERY tick, so message freshness equals the
+ * cron period of this route — hourly today (src/lib/automations/system-automations.ts,
+ * netcup crontab). Tightening freshness below an hour is a scheduling change,
+ * not a code change; no staleness constant here can beat the cron period.
+ */
+const MESSAGE_TAIL_STALE_MS = 0;
+/** Two slots per connected org so one tick can cover every org's tail job
+ * (findDueJobs reserves half the slots for that lane) without letting a large
+ * tenant list turn one tick into an unbounded run. */
+const CLAIM_LIMIT_MIN = 6;
+const CLAIM_LIMIT_MAX = 24;
 
 /**
  * GET/POST /api/meta/sync/tick — cron entrypoint (Vercel Cron only ever sends
@@ -30,7 +40,7 @@ const CLAIM_LIMIT = 6;
  * Two phases, each per-job/per-org isolated so one failure never 500s the tick:
  * 1. enqueue-if-stale — for every org with a live Meta connection, top up any
  *    sync kind whose last SUCCESS is stale (or has never run).
- * 2. claim + advance up to CLAIM_LIMIT due jobs (queued, or running past the
+ * 2. claim + advance a bounded number of due jobs (queued, or running past the
  *    staleness window) across all orgs, one bounded slice each.
  */
 const handle: RequestHandler = async ({ request }) => {
@@ -59,7 +69,9 @@ const handle: RequestHandler = async ({ request }) => {
     }
   }
 
-  const due = await findDueJobs(CLAIM_LIMIT);
+  const due = await findDueJobs(
+    Math.min(CLAIM_LIMIT_MAX, Math.max(CLAIM_LIMIT_MIN, orgIds.length * 2)),
+  );
   const results: Array<{
     jobId: string;
     orgId: string;

--- a/src/server/db/pg-meta-schema.ts
+++ b/src/server/db/pg-meta-schema.ts
@@ -1,4 +1,17 @@
-import { pgTable, uuid, text, jsonb, numeric, timestamp, boolean, integer, date, index, uniqueIndex, primaryKey } from 'drizzle-orm/pg-core';
+import {
+  pgTable,
+  uuid,
+  text,
+  jsonb,
+  numeric,
+  timestamp,
+  boolean,
+  integer,
+  date,
+  index,
+  uniqueIndex,
+  primaryKey,
+} from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 
 /**
@@ -14,7 +27,7 @@ export const metaConnections = pgTable(
   {
     id: uuid('id').primaryKey().defaultRandom(),
     orgId: text('org_id').notNull(),
-    kind: text('kind').notNull(),                   // 'flb'|'system_user'
+    kind: text('kind').notNull(), // 'flb'|'system_user'
     fbUserId: text('fb_user_id'),
     tokenCiphertext: text('token_ciphertext'),
     tokenIv: text('token_iv'),
@@ -35,14 +48,16 @@ export const metaAssets = pgTable(
   {
     id: uuid('id').primaryKey().defaultRandom(),
     orgId: text('org_id').notNull(),
-    connectionId: uuid('connection_id').notNull().references(() => metaConnections.id, { onDelete: 'cascade' }),
-    kind: text('kind').notNull(),                    // 'page'|'ig'|'ad_account'
+    connectionId: uuid('connection_id')
+      .notNull()
+      .references(() => metaConnections.id, { onDelete: 'cascade' }),
+    kind: text('kind').notNull(), // 'page'|'ig'|'ad_account'
     externalId: text('external_id').notNull(),
     name: text('name'),
     pageTokenCiphertext: text('page_token_ciphertext'),
     pageTokenIv: text('page_token_iv'),
-    parentPageId: text('parent_page_id'),            // for ig assets
-    currency: text('currency'),                       // for ad_account assets
+    parentPageId: text('parent_page_id'), // for ig assets
+    currency: text('currency'), // for ad_account assets
     enabled: boolean('enabled').notNull().default(true),
     meta: jsonb('meta').notNull().default({}),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
@@ -58,8 +73,10 @@ export const metaPostInsights = pgTable(
   {
     id: uuid('id').primaryKey().defaultRandom(),
     orgId: text('org_id').notNull(),
-    assetId: uuid('asset_id').notNull().references(() => metaAssets.id, { onDelete: 'cascade' }),
-    platform: text('platform').notNull(),            // 'fb'|'ig'
+    assetId: uuid('asset_id')
+      .notNull()
+      .references(() => metaAssets.id, { onDelete: 'cascade' }),
+    platform: text('platform').notNull(), // 'fb'|'ig'
     postId: text('post_id').notNull(),
     permalink: text('permalink'),
     caption: text('caption'),
@@ -74,7 +91,12 @@ export const metaPostInsights = pgTable(
     fetchedAt: timestamp('fetched_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => ({
-    uniq: uniqueIndex('meta_post_insights_org_post_metric_period_uniq').on(t.orgId, t.postId, t.metric, t.period),
+    uniq: uniqueIndex('meta_post_insights_org_post_metric_period_uniq').on(
+      t.orgId,
+      t.postId,
+      t.metric,
+      t.period,
+    ),
     assetIdx: index('meta_post_insights_asset_idx').on(t.assetId),
   }),
 );
@@ -114,7 +136,7 @@ export const metaSyncJobs = pgTable(
   {
     id: uuid('id').primaryKey().defaultRandom(),
     orgId: text('org_id').notNull(),
-    kind: text('kind').notNull(),                    // 'posts'|'ads'|'messages'
+    kind: text('kind').notNull(), // 'posts'|'ads'|'messages'|'messages_tail'
     status: text('status').notNull().default('queued'), // queued|running|succeeded|failed|cancelled
     pageCursor: text('page_cursor'),
     since: date('since'),
@@ -144,11 +166,11 @@ export const metaPostMedia = pgTable(
   'meta_post_media',
   {
     orgId: text('org_id').notNull(),
-    platform: text('platform').notNull(),            // 'fb'|'ig'
+    platform: text('platform').notNull(), // 'fb'|'ig'
     postId: text('post_id').notNull(),
-    fileId: text('file_id'),                          // → files.id (null until mirrored)
-    sourceUrl: text('source_url'),                     // last CDN url mirrored from (audit/debug — expires, never re-served)
-    mediaType: text('media_type'),                      // IMAGE|VIDEO|CAROUSEL_ALBUM|REELS (IG) / FB type
+    fileId: text('file_id'), // → files.id (null until mirrored)
+    sourceUrl: text('source_url'), // last CDN url mirrored from (audit/debug — expires, never re-served)
+    mediaType: text('media_type'), // IMAGE|VIDEO|CAROUSEL_ALBUM|REELS (IG) / FB type
     status: text('status').notNull().default('pending'), // pending|mirrored|failed|skipped
     error: text('error'),
     attempts: integer('attempts').notNull().default(0),
@@ -218,7 +240,11 @@ export const metaLeadAttribution = pgTable(
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => ({
-    leadUniq: uniqueIndex('meta_lead_attribution_org_id_channel_sender_id_key').on(t.orgId, t.channel, t.senderId),
+    leadUniq: uniqueIndex('meta_lead_attribution_org_id_channel_sender_id_key').on(
+      t.orgId,
+      t.channel,
+      t.senderId,
+    ),
     campaignIdx: index('meta_lead_attribution_org_campaign_idx').on(t.orgId, t.campaignId),
     originIdx: index('meta_lead_attribution_org_origin_idx').on(t.orgId, t.origin),
   }),

--- a/src/server/db/qdrant-owned-embeddings-migration.test.ts
+++ b/src/server/db/qdrant-owned-embeddings-migration.test.ts
@@ -16,7 +16,20 @@ describe('Qdrant-owned embedding storage migration', () => {
     expect(migration).not.toMatch(/update\s+public\.brain_vector_generations/iu);
   });
 
-  it('only calls a chunk indexed once a reconcile cycle completed after it was written', () => {
+  it('records an ack receipt per chunk so the pending signal both catches and drains', () => {
+    const ack = migration
+      .split('create or replace function')
+      .find((fn) => fn.includes('public.ack_brain_vector_job'));
+    expect(ack).toBeDefined();
+    expect(ack).toContain('returning o.* into acked');
+    expect(ack).toContain(
+      "when acked.desired_operation = 'upsert' then acked.desired_content_hash",
+    );
+    expect(ack).toContain('set vector_indexed_hash = indexed_hash');
+    expect(ack).toContain('chunk.org_id = acked.org_id');
+  });
+
+  it('calls a chunk pending until an ack confirms its current content', () => {
     const statusFns = migration
       .split('create or replace function')
       .filter((fn) => /brain_vector_app_source_(state|pending_count)/u.test(fn));
@@ -24,12 +37,8 @@ describe('Qdrant-owned embedding storage migration', () => {
     for (const fn of statusFns) {
       expect(fn).toContain('left join public.brain_vector_outbox job');
       expect(fn).toContain('job.collection_generation = (select generation from active)');
-      expect(fn).toContain(
-        "select coalesce((select last_completed_at from active), '-infinity'::timestamptz) as at",
-      );
-      expect(fn).toContain('chunk.updated_at');
-      expect(fn).toContain('(select at from swept)');
-      expect(fn).not.toContain('last_completed_at is not null');
+      expect(fn).toContain('chunk.vector_indexed_hash is distinct from chunk.content_hash');
+      expect(fn).not.toContain('last_completed_at');
     }
   });
 

--- a/src/server/db/qdrant-owned-embeddings-migration.test.ts
+++ b/src/server/db/qdrant-owned-embeddings-migration.test.ts
@@ -25,11 +25,16 @@ describe('Qdrant-owned embedding storage migration', () => {
     expect(ack).toContain(
       "when acked.desired_operation = 'upsert' then acked.desired_content_hash",
     );
+    expect(ack).toContain(
+      "when acked.desired_operation = 'upsert' then acked.collection_generation",
+    );
     expect(ack).toContain('set vector_indexed_hash = indexed_hash');
+    expect(ack).toContain('vector_indexed_generation = indexed_generation');
     expect(ack).toContain('chunk.org_id = acked.org_id');
+    expect(ack).toContain('chunk.vector_indexed_generation is distinct from indexed_generation');
   });
 
-  it('calls a chunk pending until an ack confirms its current content', () => {
+  it('calls a chunk pending until the ACTIVE generation confirms its current content', () => {
     const statusFns = migration
       .split('create or replace function')
       .filter((fn) => /brain_vector_app_source_(state|pending_count)/u.test(fn));
@@ -38,6 +43,9 @@ describe('Qdrant-owned embedding storage migration', () => {
       expect(fn).toContain('left join public.brain_vector_outbox job');
       expect(fn).toContain('job.collection_generation = (select generation from active)');
       expect(fn).toContain('chunk.vector_indexed_hash is distinct from chunk.content_hash');
+      expect(fn).toContain(
+        'chunk.vector_indexed_generation is distinct from (select generation from active)',
+      );
       expect(fn).not.toContain('last_completed_at');
     }
   });

--- a/src/server/db/qdrant-owned-embeddings-migration.test.ts
+++ b/src/server/db/qdrant-owned-embeddings-migration.test.ts
@@ -16,7 +16,7 @@ describe('Qdrant-owned embedding storage migration', () => {
     expect(migration).not.toMatch(/update\s+public\.brain_vector_generations/iu);
   });
 
-  it('never reports a source ready while its chunks are unproven in the serving index', () => {
+  it('only calls a chunk indexed once a reconcile cycle completed after it was written', () => {
     const statusFns = migration
       .split('create or replace function')
       .filter((fn) => /brain_vector_app_source_(state|pending_count)/u.test(fn));
@@ -25,10 +25,11 @@ describe('Qdrant-owned embedding storage migration', () => {
       expect(fn).toContain('left join public.brain_vector_outbox job');
       expect(fn).toContain('job.collection_generation = (select generation from active)');
       expect(fn).toContain(
-        'select exists (select 1 from active where active.last_completed_at is not null) as ok',
+        "select coalesce((select last_completed_at from active), '-infinity'::timestamptz) as at",
       );
-      expect(fn).toContain('job.chunk_id is null');
-      expect(fn).toContain('not (select ok from swept)');
+      expect(fn).toContain('chunk.updated_at');
+      expect(fn).toContain('(select at from swept)');
+      expect(fn).not.toContain('last_completed_at is not null');
     }
   });
 

--- a/src/server/db/qdrant-owned-embeddings-migration.test.ts
+++ b/src/server/db/qdrant-owned-embeddings-migration.test.ts
@@ -16,6 +16,22 @@ describe('Qdrant-owned embedding storage migration', () => {
     expect(migration).not.toMatch(/update\s+public\.brain_vector_generations/iu);
   });
 
+  it('never reports a source ready while its chunks are unproven in the serving index', () => {
+    const statusFns = migration
+      .split('create or replace function')
+      .filter((fn) => /brain_vector_app_source_(state|pending_count)/u.test(fn));
+    expect(statusFns).toHaveLength(2);
+    for (const fn of statusFns) {
+      expect(fn).toContain('left join public.brain_vector_outbox job');
+      expect(fn).toContain('job.collection_generation = (select generation from active)');
+      expect(fn).toContain(
+        'select exists (select 1 from active where active.last_completed_at is not null) as ok',
+      );
+      expect(fn).toContain('job.chunk_id is null');
+      expect(fn).toContain('not (select ok from swept)');
+    }
+  });
+
   it('exposes only org-scoped application status RPCs to app_ledger', () => {
     expect(migration).toContain('brain_vector_app_generation_mode()');
     expect(migration).toContain('brain_vector_app_source_state(p_source_id uuid)');

--- a/src/server/db/qdrant-owned-embeddings-migration.test.ts
+++ b/src/server/db/qdrant-owned-embeddings-migration.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const migration = readFileSync(
+  new URL(
+    '../../../supabase/migrations/20260725030000_qdrant_owned_embeddings.sql',
+    import.meta.url,
+  ),
+  'utf8',
+);
+
+describe('Qdrant-owned embedding storage migration', () => {
+  it('defaults existing generations to pgvector and requires an explicit Qdrant cutover', () => {
+    expect(migration).toContain("default 'pgvector'");
+    expect(migration).toContain("storage_mode in ('pgvector', 'qdrant')");
+    expect(migration).not.toMatch(/update\s+public\.brain_vector_generations/iu);
+  });
+});

--- a/src/server/db/qdrant-owned-embeddings-migration.test.ts
+++ b/src/server/db/qdrant-owned-embeddings-migration.test.ts
@@ -15,4 +15,14 @@ describe('Qdrant-owned embedding storage migration', () => {
     expect(migration).toContain("storage_mode in ('pgvector', 'qdrant')");
     expect(migration).not.toMatch(/update\s+public\.brain_vector_generations/iu);
   });
+
+  it('exposes only org-scoped application status RPCs to app_ledger', () => {
+    expect(migration).toContain('brain_vector_app_generation_mode()');
+    expect(migration).toContain('brain_vector_app_source_state(p_source_id uuid)');
+    expect(migration).toContain('brain_vector_app_source_pending_count(p_source_id uuid)');
+    expect(migration).toContain("chunk.org_id = current_setting('app.current_org_id', true)");
+    expect(migration).toContain(
+      'grant execute on function public.brain_vector_app_source_state(uuid) to app_ledger',
+    );
+  });
 });

--- a/src/server/services/brain-corpus-jobs.service.test.ts
+++ b/src/server/services/brain-corpus-jobs.service.test.ts
@@ -216,6 +216,28 @@ describe('all-channel conversation brain dirty jobs', () => {
     );
   });
 
+  it('drains queued legacy WhatsApp jobs after the all-channel handler deploys', async () => {
+    const legacy = {
+      ...job({
+        kind: 'dirty',
+        conversations: [{ accountId: 'a1', chatId: 'c1', months: ['2026-07'] }],
+        next: 0,
+        failures: [],
+      }),
+      type: 'brain_corpus_whatsapp',
+      refId: 'whatsapp:dirty',
+    };
+
+    await expect(advanceBrainCorpusJob(legacy as never)).resolves.toEqual({ done: true });
+    expect(syncConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: 'org-1' }),
+      'whatsapp',
+      'a1',
+      'c1',
+      { months: ['2026-07'] },
+    );
+  });
+
   it('isolates a poison conversation and marks only its account source', async () => {
     syncConversation.mockRejectedValueOnce(new Error('provider down'));
     await expect(

--- a/src/server/services/brain-corpus-jobs.service.test.ts
+++ b/src/server/services/brain-corpus-jobs.service.test.ts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const enqueueJob = vi.fn();
 const registerJobHandler = vi.fn();
-const syncWhatsAppConversation = vi.fn();
-const backfillWhatsAppConversations = vi.fn();
-const markWhatsAppSourceFailure = vi.fn();
+const syncConversation = vi.fn();
+const backfillConversations = vi.fn();
+const markConversationSourceFailure = vi.fn();
 const selectLimit = vi.fn();
 const updateReturning = vi.fn();
 const db = {
@@ -20,25 +20,25 @@ vi.mock('./bg-runtime', () => ({
   advanceJob: vi.fn(),
 }));
 vi.mock('./brain-corpus.service', () => ({
-  syncWhatsAppConversation,
-  backfillWhatsAppConversations,
-  markWhatsAppSourceFailure,
+  syncConversation,
+  backfillConversations,
+  markConversationSourceFailure,
 }));
 vi.mock('$server/db/pg-client', () => ({ getCoreDb: vi.fn(() => db) }));
 
 const {
   advanceBrainCorpusJob,
-  collectDirtyWhatsAppConversations,
-  enqueueWhatsAppBrainChanges,
-  mergeDirtyWhatsAppConversations,
+  collectDirtyConversations,
+  enqueueConversationBrainChanges,
+  mergeDirtyConversations,
 } = await import('./brain-corpus-jobs.service');
 
 const job = (cursor: unknown) => ({
   id: 'job-1',
   tenantId: 'org-1',
   userId: null,
-  type: 'brain_corpus_whatsapp',
-  refId: 'whatsapp:dirty',
+  type: 'brain_corpus_conversations',
+  refId: 'conversations:dirty',
   status: 'running',
   cursor: JSON.stringify(cursor),
   error: null,
@@ -55,12 +55,12 @@ beforeEach(() => {
   enqueueJob.mockResolvedValue('job-1');
   selectLimit.mockResolvedValue([]);
   updateReturning.mockResolvedValue([]);
-  syncWhatsAppConversation.mockResolvedValue({ processed: 1 });
-  markWhatsAppSourceFailure.mockResolvedValue(undefined);
+  syncConversation.mockResolvedValue({ processed: 1 });
+  markConversationSourceFailure.mockResolvedValue(undefined);
 });
 
-describe('WhatsApp brain dirty jobs', () => {
-  it('selects only safely identifiable 1:1 human WhatsApp rows and deduplicates conversations', () => {
+describe('all-channel conversation brain dirty jobs', () => {
+  it('selects safely identifiable 1:1 human rows across channels and deduplicates conversations', () => {
     const rows = [
       {
         channel: 'whatsapp',
@@ -94,16 +94,17 @@ describe('WhatsApp brain dirty jobs', () => {
         chatId: 'c2',
         isGroup: false,
         isBot: false,
-        content: 'skip',
+        content: 'include',
       },
     ];
-    expect(collectDirtyWhatsAppConversations(rows)).toEqual([
-      { accountId: 'a1', chatId: 'c1', months: ['2026-07', '2026-08'] },
+    expect(collectDirtyConversations(rows)).toEqual([
+      { channel: 'telegram', accountId: 'a1', chatId: 'c2', months: [] },
+      { channel: 'whatsapp', accountId: 'a1', chatId: 'c1', months: ['2026-07', '2026-08'] },
     ]);
   });
 
   it('enqueues one durable batch job for distinct conversations', async () => {
-    await enqueueWhatsAppBrainChanges('org-1', [
+    await enqueueConversationBrainChanges('org-1', [
       {
         channel: 'whatsapp',
         accountId: 'a1',
@@ -125,7 +126,7 @@ describe('WhatsApp brain dirty jobs', () => {
     expect(enqueueJob).toHaveBeenCalledWith(
       expect.objectContaining({
         tenantId: 'org-1',
-        type: 'brain_corpus_whatsapp',
+        type: 'brain_corpus_conversations',
         cursor: expect.objectContaining({ kind: 'dirty', next: 0, failures: [] }),
       }),
     );
@@ -137,14 +138,16 @@ describe('WhatsApp brain dirty jobs', () => {
         id: 'queued-1',
         cursor: JSON.stringify({
           kind: 'dirty',
-          conversations: [{ accountId: 'a1', chatId: 'c1', months: ['2026-07'] }],
+          conversations: [
+            { channel: 'whatsapp', accountId: 'a1', chatId: 'c1', months: ['2026-07'] },
+          ],
           next: 0,
         }),
       },
     ]);
     updateReturning.mockResolvedValueOnce([{ id: 'queued-1' }]);
     await expect(
-      enqueueWhatsAppBrainChanges('org-1', [
+      enqueueConversationBrainChanges('org-1', [
         {
           channel: 'whatsapp',
           accountId: 'a1',
@@ -166,7 +169,9 @@ describe('WhatsApp brain dirty jobs', () => {
         id: 'queued-1',
         cursor: JSON.stringify({
           kind: 'dirty',
-          conversations: [{ accountId: 'a1', chatId: 'c1', months: ['2026-07'] }],
+          conversations: [
+            { channel: 'whatsapp', accountId: 'a1', chatId: 'c1', months: ['2026-07'] },
+          ],
           next: 0,
           failures: [],
         }),
@@ -174,7 +179,7 @@ describe('WhatsApp brain dirty jobs', () => {
     ]);
     updateReturning.mockResolvedValueOnce([]);
     await expect(
-      enqueueWhatsAppBrainChanges('org-1', [
+      enqueueConversationBrainChanges('org-1', [
         {
           channel: 'whatsapp',
           accountId: 'a1',
@@ -193,14 +198,15 @@ describe('WhatsApp brain dirty jobs', () => {
       job({
         kind: 'dirty',
         conversations: [
-          { accountId: 'a1', chatId: 'c1', months: ['2026-07'] },
-          { accountId: 'a1', chatId: 'c2', months: ['2026-08'] },
+          { channel: 'whatsapp', accountId: 'a1', chatId: 'c1', months: ['2026-07'] },
+          { channel: 'instagram', accountId: 'a1', chatId: 'c2', months: ['2026-08'] },
         ],
         next: 0,
       }) as never,
     );
-    expect(syncWhatsAppConversation).toHaveBeenCalledWith(
+    expect(syncConversation).toHaveBeenCalledWith(
       expect.objectContaining({ tenantId: 'org-1' }),
+      'whatsapp',
       'a1',
       'c1',
       { months: ['2026-07'] },
@@ -211,21 +217,24 @@ describe('WhatsApp brain dirty jobs', () => {
   });
 
   it('isolates a poison conversation and marks only its account source', async () => {
-    syncWhatsAppConversation.mockRejectedValueOnce(new Error('provider down'));
+    syncConversation.mockRejectedValueOnce(new Error('provider down'));
     await expect(
       advanceBrainCorpusJob(
         job({
           kind: 'dirty',
-          conversations: [{ accountId: 'a1', chatId: 'c1', months: ['2026-07'] }],
+          conversations: [
+            { channel: 'whatsapp', accountId: 'a1', chatId: 'c1', months: ['2026-07'] },
+          ],
           next: 0,
         }) as never,
       ),
     ).resolves.toEqual({
       done: true,
-      error: 'a1/c1: provider down',
+      error: 'whatsapp/a1/c1: provider down',
     });
-    expect(markWhatsAppSourceFailure).toHaveBeenCalledWith(
+    expect(markConversationSourceFailure).toHaveBeenCalledWith(
       expect.objectContaining({ tenantId: 'org-1' }),
+      'whatsapp',
       'a1',
       expect.any(Error),
     );
@@ -233,22 +242,34 @@ describe('WhatsApp brain dirty jobs', () => {
 
   it('coalesces account/chat/month work and lets an unknown month dominate', () => {
     expect(
-      mergeDirtyWhatsAppConversations([
-        { accountId: 'a1', chatId: 'c1', months: ['2026-07'] },
-        { accountId: 'a1', chatId: 'c1', months: ['2026-08', '2026-07'] },
-        { accountId: 'a1', chatId: 'c2', months: [] },
-        { accountId: 'a1', chatId: 'c2', months: ['2026-09'] },
+      mergeDirtyConversations([
+        { channel: 'whatsapp', accountId: 'a1', chatId: 'c1', months: ['2026-07'] },
+        {
+          channel: 'whatsapp',
+          accountId: 'a1',
+          chatId: 'c1',
+          months: ['2026-08', '2026-07'],
+        },
+        { channel: 'whatsapp', accountId: 'a1', chatId: 'c2', months: [] },
+        { channel: 'whatsapp', accountId: 'a1', chatId: 'c2', months: ['2026-09'] },
+        { channel: 'instagram', accountId: 'a1', chatId: 'c2', months: ['2026-09'] },
       ]),
     ).toEqual([
-      { accountId: 'a1', chatId: 'c1', months: ['2026-07', '2026-08'] },
-      { accountId: 'a1', chatId: 'c2', months: [] },
+      { channel: 'instagram', accountId: 'a1', chatId: 'c2', months: ['2026-09'] },
+      {
+        channel: 'whatsapp',
+        accountId: 'a1',
+        chatId: 'c1',
+        months: ['2026-07', '2026-08'],
+      },
+      { channel: 'whatsapp', accountId: 'a1', chatId: 'c2', months: [] },
     ]);
   });
 });
 
-describe('WhatsApp brain reconcile jobs', () => {
+describe('all-channel conversation brain reconcile jobs', () => {
   it('persists the service cursor instead of restarting at the first page', async () => {
-    backfillWhatsAppConversations.mockResolvedValueOnce({
+    backfillConversations.mockResolvedValueOnce({
       processed: 25,
       changedChunks: 3,
       embeddedChunks: 3,
@@ -264,7 +285,7 @@ describe('WhatsApp brain reconcile jobs', () => {
         embeddedChunks: 2,
       }) as never,
     );
-    expect(backfillWhatsAppConversations).toHaveBeenCalledWith(
+    expect(backfillConversations).toHaveBeenCalledWith(
       expect.objectContaining({ tenantId: 'org-1' }),
       { cursor: 'current-page', limit: 25 },
     );

--- a/src/server/services/brain-corpus-jobs.service.ts
+++ b/src/server/services/brain-corpus-jobs.service.ts
@@ -17,6 +17,7 @@ import {
 } from './brain-corpus.service';
 
 export const BRAIN_CORPUS_JOB_TYPE = 'brain_corpus_conversations';
+export const LEGACY_BRAIN_CORPUS_JOB_TYPE = 'brain_corpus_whatsapp';
 const RECONCILE_REF = 'conversations:reconcile';
 const DIRTY_REF = 'conversations:dirty';
 const RECONCILE_BATCH = 25;
@@ -46,6 +47,15 @@ interface ReconcileCursor {
 }
 
 type BrainCorpusCursor = DirtyCursor | ReconcileCursor;
+type LegacyCompatibleDirtyConversation = Omit<DirtyConversation, 'channel'> & {
+  channel?: string;
+};
+interface ParsedDirtyConversation {
+  channel?: unknown;
+  accountId?: unknown;
+  chatId?: unknown;
+  months?: unknown;
+}
 
 type DirtyIngestRow = Pick<
   IngestRow,
@@ -203,19 +213,28 @@ export async function ensureConversationReconcileJob(
 
 function parseCursor(job: BgJob): BrainCorpusCursor {
   if (!job.cursor) throw new Error('brain corpus job is missing its durable cursor');
-  const value = JSON.parse(job.cursor) as Partial<BrainCorpusCursor>;
+  const value = JSON.parse(job.cursor) as {
+    kind?: unknown;
+    conversations?: ParsedDirtyConversation[];
+    next?: unknown;
+    failures?: unknown;
+    cursor?: unknown;
+    processed?: unknown;
+    changedChunks?: unknown;
+    embeddedChunks?: unknown;
+  };
   if (value.kind === 'dirty' && Array.isArray(value.conversations)) {
     return {
       kind: 'dirty',
       conversations: value.conversations
         .filter(
-          (item): item is DirtyConversation =>
-            typeof item?.channel === 'string' &&
+          (item): item is LegacyCompatibleDirtyConversation =>
+            (typeof item?.channel === 'string' || job.type === LEGACY_BRAIN_CORPUS_JOB_TYPE) &&
             typeof item?.accountId === 'string' &&
             typeof item?.chatId === 'string',
         )
         .map((item) => ({
-          channel: item.channel,
+          channel: item.channel ?? 'whatsapp',
           accountId: item.accountId,
           chatId: item.chatId,
           months: Array.isArray(item.months)
@@ -318,6 +337,7 @@ export async function advanceBrainCorpusJob(job: BgJob): Promise<AdvanceResult> 
 }
 
 registerJobHandler({ type: BRAIN_CORPUS_JOB_TYPE, advance: advanceBrainCorpusJob });
+registerJobHandler({ type: LEGACY_BRAIN_CORPUS_JOB_TYPE, advance: advanceBrainCorpusJob });
 
 /** Optional on-demand kick after enqueue; the cron remains authoritative. */
 export async function advanceBrainCorpusJobNow(jobId: string): Promise<void> {

--- a/src/server/services/brain-corpus-jobs.service.ts
+++ b/src/server/services/brain-corpus-jobs.service.ts
@@ -11,17 +11,18 @@ import {
   type BgJob,
 } from './bg-runtime';
 import {
-  backfillWhatsAppConversations,
-  markWhatsAppSourceFailure,
-  syncWhatsAppConversation,
+  backfillConversations,
+  markConversationSourceFailure,
+  syncConversation,
 } from './brain-corpus.service';
 
-export const BRAIN_CORPUS_JOB_TYPE = 'brain_corpus_whatsapp';
-const RECONCILE_REF = 'whatsapp:reconcile';
-const DIRTY_REF = 'whatsapp:dirty';
+export const BRAIN_CORPUS_JOB_TYPE = 'brain_corpus_conversations';
+const RECONCILE_REF = 'conversations:reconcile';
+const DIRTY_REF = 'conversations:dirty';
 const RECONCILE_BATCH = 25;
 
-export interface DirtyWhatsAppConversation {
+export interface DirtyConversation {
+  channel: string;
   accountId: string;
   chatId: string;
   /** Empty means the event lacked a trustworthy timestamp; rescan all months. */
@@ -30,7 +31,7 @@ export interface DirtyWhatsAppConversation {
 
 interface DirtyCursor {
   kind: 'dirty';
-  conversations: DirtyWhatsAppConversation[];
+  conversations: DirtyConversation[];
   next: number;
   /** Durable, bounded failure notes accumulated while later items continue. */
   failures: string[];
@@ -51,17 +52,16 @@ type DirtyIngestRow = Pick<
   'channel' | 'accountId' | 'chatId' | 'isGroup' | 'isBot' | 'content'
 > & { occurredAt?: number | null };
 
-export function collectDirtyWhatsAppConversations(
-  rows: DirtyIngestRow[],
-): DirtyWhatsAppConversation[] {
-  const unique = new Map<string, DirtyWhatsAppConversation>();
+export function collectDirtyConversations(rows: DirtyIngestRow[]): DirtyConversation[] {
+  const unique = new Map<string, DirtyConversation>();
   for (const row of rows) {
-    if (row.channel !== 'whatsapp') continue;
+    const channel = row.channel.trim().toLowerCase();
+    if (!channel) continue;
     if (row.isGroup === true || row.isBot === true) continue;
-    if (!row.accountId?.trim() || !row.chatId?.trim() || !row.content?.trim()) continue;
-    const accountId = row.accountId.trim();
+    if (!row.chatId?.trim() || !row.content?.trim()) continue;
+    const accountId = row.accountId?.trim() || 'default';
     const chatId = row.chatId.trim();
-    const key = `${accountId}\u0000${chatId}`;
+    const key = `${channel}\u0000${accountId}\u0000${chatId}`;
     const existing = unique.get(key);
     const occurredAt = typeof row.occurredAt === 'number' ? new Date(row.occurredAt) : null;
     const month =
@@ -74,18 +74,21 @@ export function collectDirtyWhatsAppConversations(
       !month || existing?.months.length === 0
         ? []
         : [...new Set([...(existing?.months ?? []), month])].sort();
-    unique.set(key, { accountId, chatId, months });
+    unique.set(key, { channel, accountId, chatId, months });
   }
   return [...unique.values()].sort(
-    (a, b) => a.accountId.localeCompare(b.accountId) || a.chatId.localeCompare(b.chatId),
+    (a, b) =>
+      a.channel.localeCompare(b.channel) ||
+      a.accountId.localeCompare(b.accountId) ||
+      a.chatId.localeCompare(b.chatId),
   );
 }
 
-export async function enqueueWhatsAppBrainChanges(
+export async function enqueueConversationBrainChanges(
   orgId: string,
   rows: DirtyIngestRow[],
 ): Promise<string | null> {
-  const conversations = collectDirtyWhatsAppConversations(rows);
+  const conversations = collectDirtyConversations(rows);
   if (conversations.length === 0) return null;
   const db = getCoreDb();
   const [queued] = await db
@@ -104,7 +107,7 @@ export async function enqueueWhatsAppBrainChanges(
     try {
       const current = parseCursor({ cursor: queued.cursor } as BgJob);
       if (current.kind === 'dirty') {
-        const merged = mergeDirtyWhatsAppConversations([
+        const merged = mergeDirtyConversations([
           ...current.conversations.slice(current.next),
           ...conversations,
         ]);
@@ -141,26 +144,32 @@ export async function enqueueWhatsAppBrainChanges(
   });
 }
 
-export function mergeDirtyWhatsAppConversations(
-  conversations: DirtyWhatsAppConversation[],
-): DirtyWhatsAppConversation[] {
-  const merged = new Map<string, DirtyWhatsAppConversation>();
+export function mergeDirtyConversations(conversations: DirtyConversation[]): DirtyConversation[] {
+  const merged = new Map<string, DirtyConversation>();
   for (const item of conversations) {
-    const key = `${item.accountId}\u0000${item.chatId}`;
+    const key = `${item.channel}\u0000${item.accountId}\u0000${item.chatId}`;
     const current = merged.get(key);
     const months = !current
       ? [...item.months]
       : current.months.length === 0 || item.months.length === 0
         ? []
         : [...new Set([...current.months, ...item.months])].sort();
-    merged.set(key, { accountId: item.accountId, chatId: item.chatId, months });
+    merged.set(key, {
+      channel: item.channel,
+      accountId: item.accountId,
+      chatId: item.chatId,
+      months,
+    });
   }
   return [...merged.values()].sort(
-    (a, b) => a.accountId.localeCompare(b.accountId) || a.chatId.localeCompare(b.chatId),
+    (a, b) =>
+      a.channel.localeCompare(b.channel) ||
+      a.accountId.localeCompare(b.accountId) ||
+      a.chatId.localeCompare(b.chatId),
   );
 }
 
-export async function ensureWhatsAppReconcileJob(
+export async function ensureConversationReconcileJob(
   orgId: string,
 ): Promise<{ jobId: string; created: boolean }> {
   const db = getCoreDb();
@@ -200,10 +209,13 @@ function parseCursor(job: BgJob): BrainCorpusCursor {
       kind: 'dirty',
       conversations: value.conversations
         .filter(
-          (item): item is DirtyWhatsAppConversation =>
-            typeof item?.accountId === 'string' && typeof item?.chatId === 'string',
+          (item): item is DirtyConversation =>
+            typeof item?.channel === 'string' &&
+            typeof item?.accountId === 'string' &&
+            typeof item?.chatId === 'string',
         )
         .map((item) => ({
+          channel: item.channel,
           accountId: item.accountId,
           chatId: item.chatId,
           months: Array.isArray(item.months)
@@ -246,22 +258,34 @@ export async function advanceBrainCorpusJob(job: BgJob): Promise<AdvanceResult> 
     }
     let failure: string | null = null;
     try {
-      await syncWhatsAppConversation(ctx, conversation.accountId, conversation.chatId, {
-        months: conversation.months,
-      });
+      await syncConversation(
+        ctx,
+        conversation.channel,
+        conversation.accountId,
+        conversation.chatId,
+        {
+          months: conversation.months,
+        },
+      );
     } catch (cause) {
       try {
-        await markWhatsAppSourceFailure(ctx, conversation.accountId, cause);
+        await markConversationSourceFailure(
+          ctx,
+          conversation.channel,
+          conversation.accountId,
+          cause,
+        );
       } catch (markCause) {
         console.error('[brain-corpus] failed to expose source failure', markCause);
       }
       console.error('[brain-corpus] isolated dirty conversation failure', {
+        channel: conversation.channel,
         accountId: conversation.accountId,
         chatId: conversation.chatId,
         cause,
       });
       const reason = cause instanceof Error ? cause.message : String(cause);
-      failure = `${conversation.accountId}/${conversation.chatId}: ${reason}`;
+      failure = `${conversation.channel}/${conversation.accountId}/${conversation.chatId}: ${reason}`;
     }
     const next = cursor.next + 1;
     const failures = failure ? [...cursor.failures, failure].slice(-20) : cursor.failures;
@@ -271,7 +295,7 @@ export async function advanceBrainCorpusJob(job: BgJob): Promise<AdvanceResult> 
   }
 
   try {
-    const page = await backfillWhatsAppConversations(ctx, {
+    const page = await backfillConversations(ctx, {
       cursor: cursor.cursor,
       limit: RECONCILE_BATCH,
     });
@@ -285,7 +309,7 @@ export async function advanceBrainCorpusJob(job: BgJob): Promise<AdvanceResult> 
     return page.hasMore ? { done: false, cursor: next } : { done: true };
   } catch (cause) {
     try {
-      await markWhatsAppSourceFailure(ctx, null, cause);
+      await markConversationSourceFailure(ctx, null, null, cause);
     } catch (markCause) {
       console.error('[brain-corpus] failed to expose reconcile failure', markCause);
     }
@@ -299,3 +323,9 @@ registerJobHandler({ type: BRAIN_CORPUS_JOB_TYPE, advance: advanceBrainCorpusJob
 export async function advanceBrainCorpusJobNow(jobId: string): Promise<void> {
   await advanceJob(jobId, 20_000);
 }
+
+/** Compatibility aliases for routes/tests written before the all-channel corpus. */
+export const collectDirtyWhatsAppConversations = collectDirtyConversations;
+export const enqueueWhatsAppBrainChanges = enqueueConversationBrainChanges;
+export const mergeDirtyWhatsAppConversations = mergeDirtyConversations;
+export const ensureWhatsAppReconcileJob = ensureConversationReconcileJob;

--- a/src/server/services/brain-corpus.service.test.ts
+++ b/src/server/services/brain-corpus.service.test.ts
@@ -192,17 +192,11 @@ describe('brain corpus all-channel normalization', () => {
         displayName: 'Ada',
         lifecycleOverride: null,
         source: 'instagram',
-        customFields: {},
       },
       party: null,
       identities: [],
       tags: Array.from({ length: 1000 }, (_, index) => `${index}:${'x'.repeat(20)}`),
       activities: [],
-      finance: { invoiceCount: 0, total: 0, lastIssuedAt: null, recentInvoices: [] },
-      bookings: [],
-      salesOrders: [],
-      posTickets: [],
-      memberships: [],
     } satisfies ConversationRelationshipContext;
 
     const rendered = renderConversationRelationshipContext(context);

--- a/src/server/services/brain-corpus.service.test.ts
+++ b/src/server/services/brain-corpus.service.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
   canPromoteVerifiedEmptyWhatsAppSource,
+  decodeConversationCursor,
   decodeWhatsAppCursor,
+  encodeConversationCursor,
   encodeWhatsAppCursor,
   knowledgeContentHash,
+  normalizeConversation,
   normalizeWhatsAppConversation,
   normalizeWhatsAppConversationSegments,
   preparedConversationNeedsWrite,
@@ -99,6 +102,83 @@ describe('brain corpus WhatsApp normalization', () => {
   });
 });
 
+describe('brain corpus all-channel normalization', () => {
+  it('includes joined CRM and business context in Instagram documents and revision hashes', () => {
+    const relationshipContext = {
+      contact: {
+        id: 'contact-1',
+        humanId: 'CRM-1',
+        displayName: 'Ada Lovelace',
+        lifecycleOverride: 'customer',
+        source: 'instagram',
+        customFields: { distrito: 'Miraflores' },
+      },
+      party: {
+        id: 'party-1',
+        type: 'person',
+        name: 'Ada Lovelace',
+        phone9: '911111111',
+        email: 'ada@example.com',
+        docType: 'DNI',
+        docNumber: '12345678',
+        dob: null,
+        dniVerified: true,
+      },
+      identities: [
+        {
+          channel: 'instagram',
+          externalId: 'ig-ada',
+          handle: 'ada',
+        },
+      ],
+      tags: ['VIP'],
+      activities: [],
+      finance: {
+        invoiceCount: 1,
+        total: 250,
+        lastIssuedAt: '2026-07-20T15:00:00Z',
+        recentInvoices: [],
+      },
+      bookings: [
+        {
+          status: 'confirmed',
+          startTime: '2026-07-24T15:00:00Z',
+          title: 'Follow-up',
+          notes: null,
+        },
+      ],
+      salesOrders: [],
+      posTickets: [],
+      memberships: [],
+    };
+    const first = normalizeConversation(
+      'instagram',
+      'faces',
+      'ig-chat-1',
+      [message('1', 'When is my appointment?')],
+      relationshipContext,
+    );
+    const changed = normalizeConversation(
+      'instagram',
+      'faces',
+      'ig-chat-1',
+      [message('1', 'When is my appointment?')],
+      {
+        ...relationshipContext,
+        finance: { ...relationshipContext.finance, total: 300 },
+      },
+    );
+
+    expect(first.title).toContain('Instagram');
+    expect(first.metadata.channel).toBe('instagram');
+    expect(first.metadata.contactId).toBe('contact-1');
+    expect(first.chunks[0].contextPrefix).toContain('Ada Lovelace');
+    expect(first.chunks[0].contextPrefix).toContain('confirmed');
+    expect(first.contentHash).not.toBe(changed.contentHash);
+    expect(first.sourceRevision).not.toBe(changed.sourceRevision);
+  });
+});
+
 describe('brain corpus WhatsApp cursor', () => {
   it('round-trips the deterministic account/chat tuple', () => {
     const value = { accountId: '+51922286663', chatId: '51911111111@s.whatsapp.net' };
@@ -108,6 +188,13 @@ describe('brain corpus WhatsApp cursor', () => {
   it('fails closed for malformed cursors', () => {
     expect(decodeWhatsAppCursor('not-base64-json')).toBeNull();
     expect(decodeWhatsAppCursor(Buffer.from('{}').toString('base64url'))).toBeNull();
+  });
+});
+
+describe('brain corpus all-channel cursor', () => {
+  it('round-trips the deterministic channel/account/chat tuple', () => {
+    const value = { channel: 'instagram', accountId: 'faces', chatId: 'ig-chat-1' };
+    expect(decodeConversationCursor(encodeConversationCursor(value))).toEqual(value);
   });
 });
 

--- a/src/server/services/brain-corpus.service.test.ts
+++ b/src/server/services/brain-corpus.service.test.ts
@@ -168,7 +168,7 @@ describe('brain corpus all-channel normalization', () => {
       [message('1', 'When is my appointment?')],
       {
         ...relationshipContext,
-        finance: { ...relationshipContext.finance, total: 300 },
+        tags: [...relationshipContext.tags, 'Returning'],
       },
     );
 
@@ -176,7 +176,10 @@ describe('brain corpus all-channel normalization', () => {
     expect(first.metadata.channel).toBe('instagram');
     expect(first.metadata.contactId).toBe('contact-1');
     expect(first.chunks[0].contextPrefix).toContain('Ada Lovelace');
-    expect(first.chunks[0].contextPrefix).toContain('confirmed');
+    expect(first.chunks[0].contextPrefix).toContain('VIP');
+    expect(first.chunks[0].contextPrefix).not.toContain('ada@example.com');
+    expect(first.chunks[0].contextPrefix).not.toContain('12345678');
+    expect(first.chunks[0].contextPrefix).not.toContain('Finance');
     expect(first.contentHash).not.toBe(changed.contentHash);
     expect(first.sourceRevision).not.toBe(changed.sourceRevision);
   });
@@ -193,12 +196,8 @@ describe('brain corpus all-channel normalization', () => {
       },
       party: null,
       identities: [],
-      tags: [],
-      activities: Array.from({ length: 10 }, (_, index) => ({
-        kind: 'note',
-        body: `${index}:${'x'.repeat(2000)}`,
-        occurredAt: '2026-07-25T00:00:00Z',
-      })),
+      tags: Array.from({ length: 1000 }, (_, index) => `${index}:${'x'.repeat(20)}`),
+      activities: [],
       finance: { invoiceCount: 0, total: 0, lastIssuedAt: null, recentInvoices: [] },
       bookings: [],
       salesOrders: [],

--- a/src/server/services/brain-corpus.service.test.ts
+++ b/src/server/services/brain-corpus.service.test.ts
@@ -11,6 +11,8 @@ import {
   normalizeWhatsAppConversationSegments,
   preparedConversationNeedsWrite,
   qdrantOwnsKnowledgeEmbeddings,
+  renderConversationRelationshipContext,
+  type ConversationRelationshipContext,
   type WhatsAppMessageInput,
 } from './brain-corpus.service';
 
@@ -177,6 +179,36 @@ describe('brain corpus all-channel normalization', () => {
     expect(first.chunks[0].contextPrefix).toContain('confirmed');
     expect(first.contentHash).not.toBe(changed.contentHash);
     expect(first.sourceRevision).not.toBe(changed.sourceRevision);
+  });
+
+  it('bounds relationship context before it is sent to either embedding owner', () => {
+    const context = {
+      contact: {
+        id: 'contact-1',
+        humanId: 'CRM-1',
+        displayName: 'Ada',
+        lifecycleOverride: null,
+        source: 'instagram',
+        customFields: {},
+      },
+      party: null,
+      identities: [],
+      tags: [],
+      activities: Array.from({ length: 10 }, (_, index) => ({
+        kind: 'note',
+        body: `${index}:${'x'.repeat(2000)}`,
+        occurredAt: '2026-07-25T00:00:00Z',
+      })),
+      finance: { invoiceCount: 0, total: 0, lastIssuedAt: null, recentInvoices: [] },
+      bookings: [],
+      salesOrders: [],
+      posTickets: [],
+      memberships: [],
+    } satisfies ConversationRelationshipContext;
+
+    const rendered = renderConversationRelationshipContext(context);
+    expect(rendered.length).toBe(6000);
+    expect(rendered.endsWith('…')).toBe(true);
   });
 });
 

--- a/src/server/services/brain-corpus.service.test.ts
+++ b/src/server/services/brain-corpus.service.test.ts
@@ -10,6 +10,7 @@ import {
   normalizeWhatsAppConversation,
   normalizeWhatsAppConversationSegments,
   preparedConversationNeedsWrite,
+  qdrantOwnsKnowledgeEmbeddings,
   type WhatsAppMessageInput,
 } from './brain-corpus.service';
 
@@ -199,6 +200,19 @@ describe('brain corpus all-channel cursor', () => {
 });
 
 describe('brain corpus idempotent persistence', () => {
+  it('requires an explicit Qdrant storage ownership flag', () => {
+    const before = process.env.BRAIN_VECTOR_STORAGE_MODE;
+    try {
+      delete process.env.BRAIN_VECTOR_STORAGE_MODE;
+      expect(qdrantOwnsKnowledgeEmbeddings()).toBe(false);
+      process.env.BRAIN_VECTOR_STORAGE_MODE = 'qdrant';
+      expect(qdrantOwnsKnowledgeEmbeddings()).toBe(true);
+    } finally {
+      if (before === undefined) delete process.env.BRAIN_VECTOR_STORAGE_MODE;
+      else process.env.BRAIN_VECTOR_STORAGE_MODE = before;
+    }
+  });
+
   it('skips document and chunk upserts when a prepared conversation is fully current', () => {
     expect(
       preparedConversationNeedsWrite({

--- a/src/server/services/brain-corpus.service.ts
+++ b/src/server/services/brain-corpus.service.ts
@@ -27,6 +27,12 @@ const EMBEDDING_BATCH_CONCURRENCY = Math.min(
   Math.max(1, Number(process.env.BRAIN_EMBEDDING_BATCH_CONCURRENCY) || 4),
 );
 
+/** Qdrant-owned mode keeps canonical text/metadata in Postgres and delegates
+ * vector generation to the durable serving-index worker. */
+export function qdrantOwnsKnowledgeEmbeddings(): boolean {
+  return process.env.BRAIN_VECTOR_STORAGE_MODE === 'qdrant';
+}
+
 export type BrainKind = 'master' | 'focused';
 
 export interface WhatsAppConversationCursor {
@@ -1437,8 +1443,8 @@ async function prepareConversations(
           return (
             !old ||
             old.content_hash !== chunk.contentHash ||
-            !old.has_embedding ||
-            old.embedding_model !== KNOWLEDGE_EMBEDDING_MODEL
+            (!qdrantOwnsKnowledgeEmbeddings() &&
+              (!old.has_embedding || old.embedding_model !== KNOWLEDGE_EMBEDDING_MODEL))
           );
         })
         .map((chunk) => chunk.chunkKey),
@@ -1467,7 +1473,7 @@ async function embedChangedChunks(
       })),
   );
   const out = new Map<string, number[]>();
-  if (changed.length === 0 || !embeddingsEnabled()) return out;
+  if (changed.length === 0 || qdrantOwnsKnowledgeEmbeddings() || !embeddingsEnabled()) return out;
   const batches: Array<typeof changed> = [];
   for (let i = 0; i < changed.length; i += EMBEDDING_BATCH_SIZE) {
     batches.push(changed.slice(i, i + EMBEDDING_BATCH_SIZE));
@@ -1490,6 +1496,7 @@ async function persistConversations(
   vectors: Map<string, number[]>,
 ): Promise<{ deletedChunks: number }> {
   if (prepared.length === 0) return { deletedChunks: 0 };
+  const qdrantStorage = qdrantOwnsKnowledgeEmbeddings();
   return withOrgCore(ctx, async (tx) => {
     let deletedChunks = 0;
     for (const conversation of prepared) {
@@ -1503,7 +1510,9 @@ async function persistConversations(
         vectors.has(`${documentId}\u0000${chunkKey}`),
       );
       const documentStatus =
-        conversation.changedChunkKeys.size > 0 && !allChangedEmbedded ? 'pending' : 'ready';
+        !qdrantStorage && conversation.changedChunkKeys.size > 0 && !allChangedEmbedded
+          ? 'pending'
+          : 'ready';
       await tx.execute(sql`
         insert into knowledge_documents
           (id, org_id, source_id, external_id, title, raw_text, normalized_text,
@@ -1587,10 +1596,28 @@ async function persistConversations(
               where document.org_id = knowledge_sources.org_id
                 and document.source_id = knowledge_sources.id and document.status <> 'deleted'
             ) then 'queued'
+            when ${qdrantStorage} and exists (
+              select 1
+              from knowledge_chunks chunk
+              join brain_vector_outbox vector_job
+                on vector_job.chunk_id = chunk.id
+              where chunk.org_id = knowledge_sources.org_id
+                and chunk.source_id = knowledge_sources.id
+                and vector_job.status = 'dead'
+            ) then 'failed'
             when exists (
               select 1 from knowledge_chunks chunk
               where chunk.org_id = knowledge_sources.org_id
-                and chunk.source_id = knowledge_sources.id and chunk.embedding is null
+                and chunk.source_id = knowledge_sources.id
+                and ${
+                  qdrantStorage
+                    ? sql`exists (
+                        select 1 from brain_vector_outbox vector_job
+                        where vector_job.chunk_id = chunk.id
+                          and vector_job.status in ('queued', 'running')
+                      )`
+                    : sql`chunk.embedding is null`
+                }
             ) then 'queued'
             else 'ready'
           end,
@@ -1888,7 +1915,17 @@ async function loadSourceAggregates(
       select count(distinct document.id)::int as document_count,
         count(chunk.id)::int as chunk_count,
         (
-          count(chunk.id) filter (where chunk.embedding is null)
+          count(chunk.id) filter (
+            where ${
+              qdrantOwnsKnowledgeEmbeddings()
+                ? sql`exists (
+                    select 1 from brain_vector_outbox vector_job
+                    where vector_job.chunk_id = chunk.id
+                      and vector_job.status in ('queued', 'running', 'dead')
+                  )`
+                : sql`chunk.embedding is null`
+            }
+          )
           + count(distinct document.id) filter (
               where document.status in ('pending', 'processing', 'failed') and chunk.id is null
             )

--- a/src/server/services/brain-corpus.service.ts
+++ b/src/server/services/brain-corpus.service.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { error } from '@sveltejs/kit';
-import { and, asc, eq, sql, type SQL } from 'drizzle-orm';
+import { and, asc, eq, or, sql, type SQL } from 'drizzle-orm';
 import type { CoreCtx } from '$server/auth/core-ctx';
 import {
   brainSources,
@@ -80,6 +80,8 @@ export interface NormalizedWhatsAppDocument {
   chunks: NormalizedKnowledgeChunk[];
 }
 
+/** Exactly what renderConversationRelationshipContext and the document
+ * metadata consume — no PII (phone/email/document) is joined or carried. */
 export interface ConversationRelationshipContext {
   contact: {
     id: string;
@@ -87,62 +89,15 @@ export interface ConversationRelationshipContext {
     displayName: string | null;
     lifecycleOverride: string | null;
     source: string;
-    customFields: Record<string, unknown>;
   } | null;
   party: {
     id: string;
     type: string;
     name: string | null;
-    phone9: string | null;
-    email: string | null;
-    docType: string | null;
-    docNumber: string | null;
-    dob: string | null;
-    dniVerified: boolean;
   } | null;
-  identities: Array<{ channel: string; externalId: string; handle: string | null }>;
+  identities: Array<{ channel: string }>;
   tags: string[];
-  activities: Array<{ kind: string; body: string | null; occurredAt: string }>;
-  finance: {
-    invoiceCount: number;
-    total: number;
-    lastIssuedAt: string | null;
-    recentInvoices: Array<{
-      documentId: string | null;
-      issuedAt: string | null;
-      total: number;
-      currency: string | null;
-      status: string | null;
-      items: string[];
-    }>;
-  };
-  bookings: Array<{
-    startTime: string;
-    status: string;
-    title: string | null;
-    notes: string | null;
-  }>;
-  salesOrders: Array<{
-    humanId: string | null;
-    createdAt: string;
-    status: string;
-    description: string | null;
-    total: number | null;
-    currency: string | null;
-  }>;
-  posTickets: Array<{
-    humanId: string | null;
-    submittedAt: string;
-    status: string;
-    total: number;
-    currency: string;
-  }>;
-  memberships: Array<{
-    planName: string | null;
-    status: string;
-    startedAt: string;
-    nextCycleDate: string;
-  }>;
+  activities: Array<{ kind: string; occurredAt: string }>;
 }
 
 export function whatsappCalendarMonth(value: Date): string {
@@ -685,15 +640,16 @@ export async function discoverConversationSources(ctx: CoreCtx): Promise<Knowled
     return tx
       .select()
       .from(knowledgeSources)
-      .where(eq(knowledgeSources.orgId, ctx.tenantId))
-      .orderBy(asc(knowledgeSources.connector), asc(knowledgeSources.externalKey))
-      .then((sources) =>
-        sources.filter(
-          (source) =>
-            (source.config as { domain?: unknown } | null)?.domain === 'conversations' ||
-            source.connector === WHATSAPP_CONNECTOR,
+      .where(
+        and(
+          eq(knowledgeSources.orgId, ctx.tenantId),
+          or(
+            sql`${knowledgeSources.config}->>'domain' = 'conversations'`,
+            eq(knowledgeSources.connector, WHATSAPP_CONNECTOR),
+          ),
         ),
-      );
+      )
+      .orderBy(asc(knowledgeSources.connector), asc(knowledgeSources.externalKey));
   });
 }
 
@@ -1080,33 +1036,16 @@ async function loadConversationRelationshipContexts(
           'humanId', contact.human_id,
           'displayName', contact.display_name,
           'lifecycleOverride', contact.lifecycle_override,
-          'source', contact.source,
-          'customFields', '{}'::jsonb
+          'source', contact.source
         ),
         'party', case when party.id is null then null else jsonb_build_object(
           'id', party.id::text,
           'type', party.type,
-          'name', party.name,
-          'phone9', null,
-          'email', null,
-          'docType', null,
-          'docNumber', null,
-          'dob', null,
-          'dniVerified', false
+          'name', party.name
         ) end,
         'identities', coalesce(identities.rows, '[]'::jsonb),
         'tags', coalesce(tags.rows, '[]'::jsonb),
-        'activities', coalesce(activities.rows, '[]'::jsonb),
-        'finance', jsonb_build_object(
-          'invoiceCount', 0,
-          'total', 0,
-          'lastIssuedAt', null,
-          'recentInvoices', '[]'::jsonb
-        ),
-        'bookings', '[]'::jsonb,
-        'salesOrders', '[]'::jsonb,
-        'posTickets', '[]'::jsonb,
-        'memberships', '[]'::jsonb
+        'activities', coalesce(activities.rows, '[]'::jsonb)
       ) end as relationship_context
     from requested
     left join crm_contact_identities identity
@@ -1121,11 +1060,7 @@ async function loadConversationRelationshipContexts(
       on party.org_id = current_setting('app.current_org_id', true)
       and party.id = contact.party_id
     left join lateral (
-      select jsonb_agg(jsonb_build_object(
-        'channel', ci.channel,
-        'externalId', '',
-        'handle', null
-      ) order by ci.channel) as rows
+      select jsonb_agg(jsonb_build_object('channel', ci.channel) order by ci.channel) as rows
       from crm_contact_identities ci
       where ci.org_id = current_setting('app.current_org_id', true)
         and ci.contact_id = contact.id
@@ -1142,7 +1077,6 @@ async function loadConversationRelationshipContexts(
     left join lateral (
       select jsonb_agg(jsonb_build_object(
         'kind', activity.kind,
-        'body', null,
         'occurredAt', activity.occurred_at
       ) order by activity.occurred_at desc) as rows
       from (

--- a/src/server/services/brain-corpus.service.ts
+++ b/src/server/services/brain-corpus.service.ts
@@ -340,9 +340,9 @@ export function renderConversationRelationshipContext(
 }
 
 /**
- * Deterministic turn-aware WhatsApp normalizer. SQL removes duplicate stable
- * message IDs before this runs; the defensive map also makes the pure helper
- * safe for callers/tests that pass duplicate rows directly.
+ * Deterministic turn-aware normalizer for any 1:1 chat channel. SQL removes
+ * duplicate stable message IDs before this runs; the defensive map also makes
+ * the pure helper safe for callers/tests that pass duplicate rows directly.
  */
 export function normalizeConversation(
   channel: string,

--- a/src/server/services/brain-corpus.service.ts
+++ b/src/server/services/brain-corpus.service.ts
@@ -15,7 +15,10 @@ import type { AccessPrincipal } from './brains.service';
 
 export const KNOWLEDGE_EMBEDDING_MODEL = 'text-embedding-3-small';
 export const WHATSAPP_CONNECTOR = 'whatsapp';
-export const WHATSAPP_FOCUSED_BRAIN_NAME = 'WhatsApp Conversations';
+export const LEGACY_WHATSAPP_FOCUSED_BRAIN_NAME = 'WhatsApp Conversations';
+export const CONVERSATIONS_FOCUSED_BRAIN_NAME = 'All Conversations';
+/** Backward-compatible export for callers that still import the old symbol. */
+export const WHATSAPP_FOCUSED_BRAIN_NAME = CONVERSATIONS_FOCUSED_BRAIN_NAME;
 const DEFAULT_CONVERSATION_BATCH = 50;
 const DEFAULT_CHUNK_MAX_CHARS = 6000;
 const EMBEDDING_BATCH_SIZE = 64;
@@ -29,6 +32,10 @@ export type BrainKind = 'master' | 'focused';
 export interface WhatsAppConversationCursor {
   accountId: string;
   chatId: string;
+}
+
+export interface ConversationCursor extends WhatsAppConversationCursor {
+  channel: string;
 }
 
 export interface WhatsAppMessageInput {
@@ -66,11 +73,77 @@ export interface NormalizedWhatsAppDocument {
   chunks: NormalizedKnowledgeChunk[];
 }
 
+export interface ConversationRelationshipContext {
+  contact: {
+    id: string;
+    humanId: string | null;
+    displayName: string | null;
+    lifecycleOverride: string | null;
+    source: string;
+    customFields: Record<string, unknown>;
+  } | null;
+  party: {
+    id: string;
+    type: string;
+    name: string | null;
+    phone9: string | null;
+    email: string | null;
+    docType: string | null;
+    docNumber: string | null;
+    dob: string | null;
+    dniVerified: boolean;
+  } | null;
+  identities: Array<{ channel: string; externalId: string; handle: string | null }>;
+  tags: string[];
+  activities: Array<{ kind: string; body: string | null; occurredAt: string }>;
+  finance: {
+    invoiceCount: number;
+    total: number;
+    lastIssuedAt: string | null;
+    recentInvoices: Array<{
+      documentId: string | null;
+      issuedAt: string | null;
+      total: number;
+      currency: string | null;
+      status: string | null;
+      items: string[];
+    }>;
+  };
+  bookings: Array<{
+    startTime: string;
+    status: string;
+    title: string | null;
+    notes: string | null;
+  }>;
+  salesOrders: Array<{
+    humanId: string | null;
+    createdAt: string;
+    status: string;
+    description: string | null;
+    total: number | null;
+    currency: string | null;
+  }>;
+  posTickets: Array<{
+    humanId: string | null;
+    submittedAt: string;
+    status: string;
+    total: number;
+    currency: string;
+  }>;
+  memberships: Array<{
+    planName: string | null;
+    status: string;
+    startedAt: string;
+    nextCycleDate: string;
+  }>;
+}
+
 export function whatsappCalendarMonth(value: Date): string {
   return value.toISOString().slice(0, 7);
 }
 
 export interface WhatsAppConversationKey extends WhatsAppConversationCursor {
+  channel: string;
   sourceId: string;
 }
 
@@ -266,15 +339,117 @@ function splitLongTurn(turn: string, maxChars: number): string[] {
   return out;
 }
 
+function channelLabel(channel: string): string {
+  return channel
+    .split(/[-_]/g)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function compactJson(value: unknown, maxChars = 2000): string {
+  const serialized = JSON.stringify(value);
+  return serialized.length <= maxChars ? serialized : `${serialized.slice(0, maxChars)}…`;
+}
+
+export function renderConversationRelationshipContext(
+  context: ConversationRelationshipContext | null,
+): string {
+  if (!context?.contact) return 'CRM contact: not matched';
+  const lines = [
+    `CRM contact: ${context.contact.displayName ?? context.contact.humanId ?? context.contact.id}`,
+    `CRM profile: lifecycle=${context.contact.lifecycleOverride ?? 'derived'}; source=${context.contact.source}; custom=${compactJson(context.contact.customFields)}`,
+  ];
+  if (context.party) {
+    lines.push(
+      `Party: ${context.party.name ?? context.party.id}; type=${context.party.type}; document=${context.party.docType ?? ''} ${context.party.docNumber ?? ''}; verified=${context.party.dniVerified}; phone=${context.party.phone9 ?? ''}; email=${context.party.email ?? ''}`,
+    );
+  }
+  if (context.identities.length > 0) {
+    lines.push(
+      `Channel identities: ${context.identities
+        .map((identity) => `${identity.channel}:${identity.handle ?? identity.externalId}`)
+        .join(', ')}`,
+    );
+  }
+  if (context.tags.length > 0) lines.push(`CRM tags: ${context.tags.join(', ')}`);
+  if (context.activities.length > 0) {
+    lines.push(
+      `Recent CRM activity: ${context.activities
+        .map(
+          (activity) =>
+            `${activity.occurredAt} ${activity.kind}${activity.body ? ` — ${activity.body}` : ''}`,
+        )
+        .join(' | ')}`,
+    );
+  }
+  if (context.finance.invoiceCount > 0) {
+    lines.push(
+      `Finance summary: invoices=${context.finance.invoiceCount}; total=${context.finance.total}; last=${context.finance.lastIssuedAt ?? 'unknown'}`,
+    );
+    lines.push(
+      `Recent invoices: ${context.finance.recentInvoices
+        .map(
+          (invoice) =>
+            `${invoice.issuedAt ?? 'unknown'} ${invoice.documentId ?? ''} ${invoice.status ?? ''} ${invoice.currency ?? ''} ${invoice.total}${invoice.items.length ? ` [${invoice.items.join(', ')}]` : ''}`,
+        )
+        .join(' | ')}`,
+    );
+  }
+  if (context.bookings.length > 0) {
+    lines.push(
+      `Bookings: ${context.bookings
+        .map(
+          (booking) =>
+            `${booking.startTime} ${booking.status} ${booking.title ?? ''}${booking.notes ? ` — ${booking.notes}` : ''}`,
+        )
+        .join(' | ')}`,
+    );
+  }
+  if (context.salesOrders.length > 0) {
+    lines.push(
+      `Sales orders: ${context.salesOrders
+        .map(
+          (order) =>
+            `${order.createdAt} ${order.humanId ?? ''} ${order.status} ${order.description ?? ''} ${order.currency ?? ''} ${order.total ?? ''}`,
+        )
+        .join(' | ')}`,
+    );
+  }
+  if (context.posTickets.length > 0) {
+    lines.push(
+      `POS tickets: ${context.posTickets
+        .map(
+          (ticket) =>
+            `${ticket.submittedAt} ${ticket.humanId ?? ''} ${ticket.status} ${ticket.currency} ${ticket.total}`,
+        )
+        .join(' | ')}`,
+    );
+  }
+  if (context.memberships.length > 0) {
+    lines.push(
+      `Memberships: ${context.memberships
+        .map(
+          (membership) =>
+            `${membership.planName ?? 'plan'} ${membership.status} started=${membership.startedAt} next=${membership.nextCycleDate}`,
+        )
+        .join(' | ')}`,
+    );
+  }
+  return lines.join('\n');
+}
+
 /**
  * Deterministic turn-aware WhatsApp normalizer. SQL removes duplicate stable
  * message IDs before this runs; the defensive map also makes the pure helper
  * safe for callers/tests that pass duplicate rows directly.
  */
-export function normalizeWhatsAppConversation(
+export function normalizeConversation(
+  channel: string,
   accountId: string,
   chatId: string,
   inputRows: WhatsAppMessageInput[],
+  relationshipContext: ConversationRelationshipContext | null = null,
   maxChars = DEFAULT_CHUNK_MAX_CHARS,
 ): NormalizedWhatsAppDocument {
   const rows = [...inputRows]
@@ -283,7 +458,7 @@ export function normalizeWhatsAppConversation(
       if (!row.messageId) return true;
       return all.findIndex((candidate) => candidate.messageId === row.messageId) === index;
     });
-  if (rows.length === 0) throw new Error('cannot normalize an empty WhatsApp conversation');
+  if (rows.length === 0) throw new Error('cannot normalize an empty conversation');
 
   const rawTurns = rows.map((row) => `${roleFor(row.direction)}: ${row.content.trim()}`);
   const normalizedTurns = rows.map(
@@ -295,7 +470,9 @@ export function normalizeWhatsAppConversation(
   if (rows.some((row) => whatsappCalendarMonth(row.occurredAt) !== segmentMonth)) {
     throw new Error('normalizeWhatsAppConversation requires rows from one UTC calendar month');
   }
-  const contextPrefix = `WhatsApp account ${accountId}; conversation ${chatId}; month ${segmentMonth}`;
+  const label = channelLabel(channel);
+  const joinedContext = renderConversationRelationshipContext(relationshipContext);
+  const contextPrefix = `${label} account ${accountId}; conversation ${chatId}; month ${segmentMonth}\n${joinedContext}`;
   const occurredAt = rows.at(-1)!.occurredAt;
   const sourceUpdatedAt = rows.reduce(
     (latest, row) => (row.createdAt > latest ? row.createdAt : latest),
@@ -331,25 +508,27 @@ export function normalizeWhatsAppConversation(
     contentHash: knowledgeContentHash(`${contextPrefix}\n\n${chunkText}`),
     occurredAt,
     metadata: {
-      channel: 'whatsapp',
+      channel,
       accountId,
       chatId,
       segmentMonth,
       messageCount: rows.length,
+      contactId: relationshipContext?.contact?.id ?? null,
+      partyId: relationshipContext?.party?.id ?? null,
     },
   }));
 
   return {
     externalId: `conversation:${accountId}:${chatId}:${segmentMonth}`,
-    title: `WhatsApp · ${chatId} · ${segmentMonth}`,
+    title: `${label} · ${relationshipContext?.contact?.displayName ?? chatId} · ${segmentMonth}`,
     rawText,
-    normalizedText,
-    contentHash: knowledgeContentHash(normalizedText),
-    sourceRevision,
+    normalizedText: `${joinedContext}\n\n${normalizedText}`,
+    contentHash: knowledgeContentHash(`${joinedContext}\n\n${normalizedText}`),
+    sourceRevision: sha256(`${sourceRevision}\u0000${joinedContext}`),
     occurredAt,
     sourceUpdatedAt,
     metadata: {
-      channel: 'whatsapp',
+      channel,
       accountId,
       chatId,
       segmentMonth,
@@ -363,17 +542,31 @@ export function normalizeWhatsAppConversation(
             .filter((v): v is string => Boolean(v)),
         ),
       ),
+      contactId: relationshipContext?.contact?.id ?? null,
+      partyId: relationshipContext?.party?.id ?? null,
+      relationshipContext,
     },
     chunks,
   };
 }
 
-/** Stable UTC-month segments: later or mid-history messages only change their
- * own month and can never renumber/rekey subsequent documents. */
-export function normalizeWhatsAppConversationSegments(
+export function normalizeWhatsAppConversation(
   accountId: string,
   chatId: string,
   inputRows: WhatsAppMessageInput[],
+  maxChars = DEFAULT_CHUNK_MAX_CHARS,
+): NormalizedWhatsAppDocument {
+  return normalizeConversation('whatsapp', accountId, chatId, inputRows, null, maxChars);
+}
+
+/** Stable UTC-month segments: later or mid-history messages only change their
+ * own month and can never renumber/rekey subsequent documents. */
+export function normalizeConversationSegments(
+  channel: string,
+  accountId: string,
+  chatId: string,
+  inputRows: WhatsAppMessageInput[],
+  relationshipContext: ConversationRelationshipContext | null = null,
   maxChars = DEFAULT_CHUNK_MAX_CHARS,
 ): NormalizedWhatsAppDocument[] {
   const byMonth = new Map<string, WhatsAppMessageInput[]>();
@@ -385,7 +578,18 @@ export function normalizeWhatsAppConversationSegments(
   }
   return [...byMonth.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([, rows]) => normalizeWhatsAppConversation(accountId, chatId, rows, maxChars));
+    .map(([, rows]) =>
+      normalizeConversation(channel, accountId, chatId, rows, relationshipContext, maxChars),
+    );
+}
+
+export function normalizeWhatsAppConversationSegments(
+  accountId: string,
+  chatId: string,
+  inputRows: WhatsAppMessageInput[],
+  maxChars = DEFAULT_CHUNK_MAX_CHARS,
+): NormalizedWhatsAppDocument[] {
+  return normalizeConversationSegments('whatsapp', accountId, chatId, inputRows, null, maxChars);
 }
 
 export function encodeWhatsAppCursor(cursor: WhatsAppConversationCursor): string {
@@ -406,10 +610,34 @@ export function decodeWhatsAppCursor(cursor?: string | null): WhatsAppConversati
   }
 }
 
+export function encodeConversationCursor(cursor: ConversationCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+export function decodeConversationCursor(cursor?: string | null): ConversationCursor | null {
+  if (!cursor) return null;
+  try {
+    const value = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as Record<
+      string,
+      unknown
+    >;
+    if (
+      typeof value.channel !== 'string' ||
+      typeof value.accountId !== 'string' ||
+      typeof value.chatId !== 'string'
+    ) {
+      return null;
+    }
+    return { channel: value.channel, accountId: value.accountId, chatId: value.chatId };
+  } catch {
+    return null;
+  }
+}
+
 /** One canonical eligibility predicate for discovery, reconciliation, reads,
  * and verified-empty source promotion. Keeping this shared prevents source
  * health from drifting away from the corpus population rules. */
-export function eligibleWhatsAppMessagePredicate(alias: string): SQL {
+export function eligibleConversationMessagePredicate(alias: string): SQL {
   const message = sql.identifier(alias);
   return sql`
     nullif(trim(${message}.chat_id), '') is not null
@@ -418,6 +646,8 @@ export function eligibleWhatsAppMessagePredicate(alias: string): SQL {
     and nullif(trim(${message}.content), '') is not null
   `;
 }
+
+export const eligibleWhatsAppMessagePredicate = eligibleConversationMessagePredicate;
 
 export async function ensureMasterBrain(ctx: CoreCtx, createdBy?: string | null): Promise<Brain> {
   return withOrgCore(ctx, async (tx) => {
@@ -444,32 +674,42 @@ export async function ensureMasterBrain(ctx: CoreCtx, createdBy?: string | null)
   });
 }
 
-/** Discover one deterministic source for each WhatsApp account in the ledger. */
-export async function discoverWhatsAppSources(ctx: CoreCtx): Promise<KnowledgeSource[]> {
+/** Discover one deterministic source for every content-bearing 1:1 chat
+ * channel/account pair in the org-scoped ledger. */
+export async function discoverConversationSources(ctx: CoreCtx): Promise<KnowledgeSource[]> {
   return withOrgCore(ctx, async (tx) => {
     const accounts = (await tx.execute(sql`
-      select trim(message.account_id) as account_id,
+      select lower(trim(message.channel)) as channel,
+        coalesce(nullif(trim(message.account_id), ''), 'default') as account_id,
         count(distinct (
           message.chat_id,
           to_char(coalesce(message.occurred_at, message.created_at) at time zone 'UTC', 'YYYY-MM')
         )) filter (
-          where ${eligibleWhatsAppMessagePredicate('message')}
+          where ${eligibleConversationMessagePredicate('message')}
         )::int as conversation_count
       from messages message
       where message.org_id = current_setting('app.current_org_id', true)
-        and message.channel = 'whatsapp'
-        and nullif(trim(message.account_id), '') is not null
-      group by trim(message.account_id)
-      order by trim(message.account_id)
-    `)) as unknown as Array<{ account_id: string; conversation_count: number }>;
+        and nullif(trim(message.channel), '') is not null
+      group by lower(trim(message.channel)),
+        coalesce(nullif(trim(message.account_id), ''), 'default')
+      having count(*) filter (
+        where ${eligibleConversationMessagePredicate('message')}
+      ) > 0
+      order by lower(trim(message.channel)),
+        coalesce(nullif(trim(message.account_id), ''), 'default')
+    `)) as unknown as Array<{
+      channel: string;
+      account_id: string;
+      conversation_count: number;
+    }>;
     if (accounts.length === 0) return [];
 
     const values = sql.join(
       accounts.map(
-        ({ account_id, conversation_count }) => sql`(
-        current_setting('app.current_org_id', true), ${WHATSAPP_CONNECTOR}, ${account_id},
-        ${`WhatsApp ${account_id}`},
-        ${JSON.stringify({ channel: 'whatsapp', accountId: account_id, domain: 'whatsapp', requiredModule: 'crm', requiredFieldLevel: 1 })}::jsonb,
+        ({ channel, account_id, conversation_count }) => sql`(
+        current_setting('app.current_org_id', true), ${channel}, ${account_id},
+        ${`${channelLabel(channel)} ${account_id}`},
+        ${JSON.stringify({ channel, accountId: account_id, domain: 'conversations', requiredModule: 'crm', requiredFieldLevel: 1 })}::jsonb,
         'discovered', 'incremental', 'event+reconcile',
         ${JSON.stringify({ expectedDocuments: Number(conversation_count) })}::jsonb
       )`,
@@ -501,35 +741,46 @@ export async function discoverWhatsAppSources(ctx: CoreCtx): Promise<KnowledgeSo
     return tx
       .select()
       .from(knowledgeSources)
-      .where(
-        and(
-          eq(knowledgeSources.orgId, ctx.tenantId),
-          eq(knowledgeSources.connector, WHATSAPP_CONNECTOR),
+      .where(eq(knowledgeSources.orgId, ctx.tenantId))
+      .orderBy(asc(knowledgeSources.connector), asc(knowledgeSources.externalKey))
+      .then((sources) =>
+        sources.filter(
+          (source) =>
+            (source.config as { domain?: unknown } | null)?.domain === 'conversations' ||
+            source.connector === WHATSAPP_CONNECTOR,
         ),
-      )
-      .orderBy(asc(knowledgeSources.externalKey));
+      );
   });
 }
 
+export async function discoverWhatsAppSources(ctx: CoreCtx): Promise<KnowledgeSource[]> {
+  return (await discoverConversationSources(ctx)).filter(
+    (source) => source.connector === WHATSAPP_CONNECTOR,
+  );
+}
+
 /** Lightweight event-path ensure: no corpus-wide ledger aggregate. */
-export async function ensureWhatsAppSource(
+export async function ensureConversationSource(
   ctx: CoreCtx,
+  channel: string,
   accountId: string,
 ): Promise<KnowledgeSource> {
+  const normalizedChannel = channel.trim().toLowerCase();
   const normalizedAccountId = accountId.trim();
-  if (!normalizedAccountId) throw new Error('WhatsApp source requires a non-empty accountId');
+  if (!normalizedChannel) throw new Error('conversation source requires a non-empty channel');
+  if (!normalizedAccountId) throw new Error('conversation source requires a non-empty accountId');
   const source = await withOrgCore(ctx, async (tx) => {
     await tx
       .insert(knowledgeSources)
       .values({
         orgId: ctx.tenantId,
-        connector: WHATSAPP_CONNECTOR,
+        connector: normalizedChannel,
         externalKey: normalizedAccountId,
-        name: `WhatsApp ${normalizedAccountId}`,
+        name: `${channelLabel(normalizedChannel)} ${normalizedAccountId}`,
         config: {
-          channel: 'whatsapp',
+          channel: normalizedChannel,
           accountId: normalizedAccountId,
-          domain: 'whatsapp',
+          domain: 'conversations',
           requiredModule: 'crm',
           requiredFieldLevel: 1,
         },
@@ -552,37 +803,57 @@ export async function ensureWhatsAppSource(
       .where(
         and(
           eq(knowledgeSources.orgId, ctx.tenantId),
-          eq(knowledgeSources.connector, WHATSAPP_CONNECTOR),
+          eq(knowledgeSources.connector, normalizedChannel),
           eq(knowledgeSources.externalKey, normalizedAccountId),
         ),
       )
       .limit(1);
-    if (!source) throw new Error(`failed to ensure WhatsApp source ${normalizedAccountId}`);
+    if (!source) {
+      throw new Error(`failed to ensure ${normalizedChannel} source ${normalizedAccountId}`);
+    }
     return source;
   });
-  // Master membership is implicit; the standard WhatsApp focused scope needs
+  // Master membership is implicit; the standard conversations focused scope needs
   // an explicit reference when an account first appears after bootstrap.
   await ensureMasterBrain(ctx);
-  await ensureWhatsAppFocusedBrain(ctx, [source.id]);
+  await ensureConversationsFocusedBrain(ctx, [source.id]);
   return source;
 }
 
-export async function markWhatsAppSourceFailure(
+export function ensureWhatsAppSource(ctx: CoreCtx, accountId: string): Promise<KnowledgeSource> {
+  return ensureConversationSource(ctx, WHATSAPP_CONNECTOR, accountId);
+}
+
+export async function markConversationSourceFailure(
   ctx: CoreCtx,
+  channel: string | null,
   accountId: string | null,
   cause: unknown,
 ): Promise<void> {
   const message = cause instanceof Error ? cause.message : String(cause);
   await withOrgCore(ctx, (tx) => {
+    const channelFilter = channel ? sql`and connector = ${channel}` : sql``;
     const accountFilter = accountId ? sql`and external_key = ${accountId}` : sql``;
     return tx.execute(sql`
       update knowledge_sources
       set status = 'failed', last_error = ${message.slice(0, 1000)}, updated_at = now()
       where org_id = current_setting('app.current_org_id', true)
-        and connector = ${WHATSAPP_CONNECTOR}
+        and (
+          config->>'domain' = 'conversations'
+          or connector = ${WHATSAPP_CONNECTOR}
+        )
+        ${channelFilter}
         ${accountFilter}
     `);
   });
+}
+
+export function markWhatsAppSourceFailure(
+  ctx: CoreCtx,
+  accountId: string | null,
+  cause: unknown,
+): Promise<void> {
+  return markConversationSourceFailure(ctx, WHATSAPP_CONNECTOR, accountId, cause);
 }
 
 const VERIFIED_EMPTY_WHATSAPP_SOURCE_STATUSES = ['discovered', 'queued'] as const;
@@ -596,13 +867,16 @@ export function canPromoteVerifiedEmptyWhatsAppSource(status: string): boolean {
   return (VERIFIED_EMPTY_WHATSAPP_SOURCE_STATUSES as readonly string[]).includes(status);
 }
 
-export async function markVerifiedEmptyWhatsAppSourcesReady(ctx: CoreCtx): Promise<number> {
+export async function markVerifiedEmptyConversationSourcesReady(ctx: CoreCtx): Promise<number> {
   return withOrgCore(ctx, async (tx) => {
     const promoted = (await tx.execute(sql`
       update knowledge_sources source
       set status = 'ready', last_synced_at = now(), last_error = null, updated_at = now()
       where source.org_id = current_setting('app.current_org_id', true)
-        and source.connector = ${WHATSAPP_CONNECTOR}
+        and (
+          source.config->>'domain' = 'conversations'
+          or source.connector = ${WHATSAPP_CONNECTOR}
+        )
         and source.status = any(${textArray([...VERIFIED_EMPTY_WHATSAPP_SOURCE_STATUSES])})
         and coalesce((source.watermark->>'expectedDocuments')::int, 0) = 0
         and not exists (
@@ -614,9 +888,9 @@ export async function markVerifiedEmptyWhatsAppSourcesReady(ctx: CoreCtx): Promi
         and not exists (
           select 1 from messages message
           where message.org_id = source.org_id
-            and message.channel = 'whatsapp'
-            and trim(message.account_id) = source.external_key
-            and ${eligibleWhatsAppMessagePredicate('message')}
+            and lower(trim(message.channel)) = source.connector
+            and coalesce(nullif(trim(message.account_id), ''), 'default') = source.external_key
+            and ${eligibleConversationMessagePredicate('message')}
         )
       returning source.id
     `)) as unknown as Array<{ id: string }>;
@@ -624,7 +898,11 @@ export async function markVerifiedEmptyWhatsAppSourcesReady(ctx: CoreCtx): Promi
   });
 }
 
-export async function ensureWhatsAppFocusedBrain(
+export function markVerifiedEmptyWhatsAppSourcesReady(ctx: CoreCtx): Promise<number> {
+  return markVerifiedEmptyConversationSourcesReady(ctx);
+}
+
+export async function ensureConversationsFocusedBrain(
   ctx: CoreCtx,
   sourceIds: string[],
   createdBy?: string | null,
@@ -638,18 +916,22 @@ export async function ensureWhatsAppFocusedBrain(
         and(
           eq(brains.orgId, ctx.tenantId),
           eq(brains.kind, 'focused'),
-          eq(brains.name, WHATSAPP_FOCUSED_BRAIN_NAME),
+          sql`${brains.name} in (${CONVERSATIONS_FOCUSED_BRAIN_NAME}, ${LEGACY_WHATSAPP_FOCUSED_BRAIN_NAME})`,
         ),
       )
-      .orderBy(asc(brains.createdAt))
+      .orderBy(
+        sql`case when ${brains.name} = ${CONVERSATIONS_FOCUSED_BRAIN_NAME} then 0 else 1 end`,
+        asc(brains.createdAt),
+      )
       .limit(1);
     if (!brain) {
       [brain] = await tx
         .insert(brains)
         .values({
           orgId: ctx.tenantId,
-          name: WHATSAPP_FOCUSED_BRAIN_NAME,
-          description: 'Customer conversations from connected WhatsApp accounts.',
+          name: CONVERSATIONS_FOCUSED_BRAIN_NAME,
+          description:
+            'Org-scoped customer conversations from every connected chat channel, enriched with joined CRM and related business context.',
           icon: 'message-circle',
           visibility: 'org',
           kind: 'focused',
@@ -657,6 +939,18 @@ export async function ensureWhatsAppFocusedBrain(
           createdBy: createdBy ?? null,
         })
         .returning();
+    } else if (brain.name === LEGACY_WHATSAPP_FOCUSED_BRAIN_NAME) {
+      const [renamed] = await tx
+        .update(brains)
+        .set({
+          name: CONVERSATIONS_FOCUSED_BRAIN_NAME,
+          description:
+            'Org-scoped customer conversations from every connected chat channel, enriched with joined CRM and related business context.',
+          updatedAt: new Date(),
+        })
+        .where(and(eq(brains.id, brain.id), eq(brains.orgId, ctx.tenantId)))
+        .returning();
+      if (renamed) brain = renamed;
     }
     await tx
       .insert(brainSources)
@@ -666,35 +960,63 @@ export async function ensureWhatsAppFocusedBrain(
   });
 }
 
-async function scanWhatsAppKeys(
+export function ensureWhatsAppFocusedBrain(
+  ctx: CoreCtx,
+  sourceIds: string[],
+  createdBy?: string | null,
+): Promise<Brain | null> {
+  return ensureConversationsFocusedBrain(ctx, sourceIds, createdBy);
+}
+
+async function scanConversationKeys(
   tx: CoreTx,
-  sourceByAccount: Map<string, string>,
-  cursor: WhatsAppConversationCursor | null,
+  sourceByChannelAccount: Map<string, string>,
+  cursor: ConversationCursor | null,
   limit: number,
 ): Promise<{ keys: WhatsAppConversationKey[]; hasMore: boolean }> {
-  if (sourceByAccount.size === 0) return { keys: [], hasMore: false };
-  const accounts = [...sourceByAccount.keys()];
+  if (sourceByChannelAccount.size === 0) return { keys: [], hasMore: false };
+  const sources = [...sourceByChannelAccount.keys()].map((key) => {
+    const [channel, accountId] = key.split('\u0000');
+    return { channel, accountId };
+  });
+  const sourceValues = sql.join(
+    sources.map(({ channel, accountId }) => sql`(${channel}::text, ${accountId}::text)`),
+    sql`, `,
+  );
   const cursorFilter = cursor
-    ? sql`and (m.account_id, m.chat_id) > (${cursor.accountId}, ${cursor.chatId})`
+    ? sql`and (
+        lower(trim(m.channel)),
+        coalesce(nullif(trim(m.account_id), ''), 'default'),
+        m.chat_id
+      ) > (${cursor.channel}, ${cursor.accountId}, ${cursor.chatId})`
     : sql``;
   const rows = (await tx.execute(sql`
-    select m.account_id, m.chat_id
+    select lower(trim(m.channel)) as channel,
+      coalesce(nullif(trim(m.account_id), ''), 'default') as account_id,
+      m.chat_id
     from messages m
     where m.org_id = current_setting('app.current_org_id', true)
-      and m.channel = 'whatsapp'
-      and m.account_id = any(${textArray(accounts)})
-      and ${eligibleWhatsAppMessagePredicate('m')}
+      and (
+        lower(trim(m.channel)),
+        coalesce(nullif(trim(m.account_id), ''), 'default')
+      ) in (${sourceValues})
+      and ${eligibleConversationMessagePredicate('m')}
       ${cursorFilter}
-    group by m.account_id, m.chat_id
-    order by m.account_id, m.chat_id
+    group by lower(trim(m.channel)),
+      coalesce(nullif(trim(m.account_id), ''), 'default'),
+      m.chat_id
+    order by lower(trim(m.channel)),
+      coalesce(nullif(trim(m.account_id), ''), 'default'),
+      m.chat_id
     limit ${limit + 1}
-  `)) as unknown as Array<{ account_id: string; chat_id: string }>;
+  `)) as unknown as Array<{ channel: string; account_id: string; chat_id: string }>;
   const hasMore = rows.length > limit;
   return {
     keys: rows.slice(0, limit).map((row) => ({
+      channel: row.channel,
       accountId: row.account_id,
       chatId: row.chat_id,
-      sourceId: sourceByAccount.get(row.account_id)!,
+      sourceId: sourceByChannelAccount.get(`${row.channel}\u0000${row.account_id}`)!,
     })),
     hasMore,
   };
@@ -702,7 +1024,7 @@ async function scanWhatsAppKeys(
 
 function keyValues(keys: WhatsAppConversationKey[]) {
   return sql.join(
-    keys.map((key) => sql`(${key.accountId}::text, ${key.chatId}::text)`),
+    keys.map((key) => sql`(${key.channel}::text, ${key.accountId}::text, ${key.chatId}::text)`),
     sql`, `,
   );
 }
@@ -721,7 +1043,7 @@ function uuidArray(values: string[]) {
   )}]::uuid[]`;
 }
 
-async function loadWhatsAppRows(
+async function loadConversationRows(
   tx: CoreTx,
   keys: WhatsAppConversationKey[],
   onlyMonths?: string[],
@@ -732,24 +1054,37 @@ async function loadWhatsAppRows(
     ? sql`where to_char(coalesce(occurred_at, created_at) at time zone 'UTC', 'YYYY-MM') = any(${textArray(onlyMonths)})`
     : sql``;
   const rows = (await tx.execute(sql`
-    select account_id, chat_id, id::text as id, message_id, direction, content,
+    select normalized_channel as channel, normalized_account_id as account_id,
+      chat_id, id::text as id, message_id, direction, content,
       sender_id, sender_name, occurred_at, created_at
     from (
       select distinct on (
-        m.account_id, m.chat_id, coalesce(nullif(m.message_id, ''), 'row:' || m.id::text)
-      ) m.*
+        lower(trim(m.channel)),
+        coalesce(nullif(trim(m.account_id), ''), 'default'),
+        m.chat_id,
+        coalesce(nullif(m.message_id, ''), 'row:' || m.id::text)
+      ) m.*,
+        lower(trim(m.channel)) as normalized_channel,
+        coalesce(nullif(trim(m.account_id), ''), 'default') as normalized_account_id
       from messages m
       where m.org_id = current_setting('app.current_org_id', true)
-        and m.channel = 'whatsapp'
-        and ${eligibleWhatsAppMessagePredicate('m')}
-        and (m.account_id, m.chat_id) in (${keyValues(keys)})
-      order by m.account_id, m.chat_id,
+        and ${eligibleConversationMessagePredicate('m')}
+        and (
+          lower(trim(m.channel)),
+          coalesce(nullif(trim(m.account_id), ''), 'default'),
+          m.chat_id
+        ) in (${keyValues(keys)})
+      order by lower(trim(m.channel)),
+        coalesce(nullif(trim(m.account_id), ''), 'default'),
+        m.chat_id,
         coalesce(nullif(m.message_id, ''), 'row:' || m.id::text),
         coalesce(m.occurred_at, m.created_at), m.id
     ) deduped
     ${monthFilter}
-    order by account_id, chat_id, coalesce(occurred_at, created_at), id
+    order by normalized_channel, normalized_account_id, chat_id,
+      coalesce(occurred_at, created_at), id
   `)) as unknown as Array<{
+    channel: string;
     account_id: string;
     chat_id: string;
     id: string;
@@ -762,7 +1097,7 @@ async function loadWhatsAppRows(
     created_at: Date | string;
   }>;
   for (const row of rows) {
-    const key = `${row.account_id}\u0000${row.chat_id}`;
+    const key = `${row.channel}\u0000${row.account_id}\u0000${row.chat_id}`;
     const values = out.get(key) ?? [];
     const createdAt = asDate(row.created_at);
     values.push({
@@ -780,19 +1115,274 @@ async function loadWhatsAppRows(
   return out;
 }
 
+async function loadConversationRelationshipContexts(
+  tx: CoreTx,
+  keys: WhatsAppConversationKey[],
+): Promise<Map<string, ConversationRelationshipContext | null>> {
+  const out = new Map<string, ConversationRelationshipContext | null>();
+  if (keys.length === 0) return out;
+  const requested = sql.join(
+    [...new Map(keys.map((key) => [`${key.channel}\u0000${key.chatId}`, key])).values()].map(
+      (key) => sql`(${key.channel}::text, ${key.chatId}::text)`,
+    ),
+    sql`, `,
+  );
+  const rows = (await tx.execute(sql`
+    with requested(channel, chat_id) as (values ${requested})
+    select requested.channel, requested.chat_id,
+      case when contact.id is null then null else jsonb_build_object(
+        'contact', jsonb_build_object(
+          'id', contact.id::text,
+          'humanId', contact.human_id,
+          'displayName', contact.display_name,
+          'lifecycleOverride', contact.lifecycle_override,
+          'source', contact.source,
+          'customFields', contact.custom_fields
+        ),
+        'party', case when party.id is null then null else jsonb_build_object(
+          'id', party.id::text,
+          'type', party.type,
+          'name', party.name,
+          'phone9', party.phone9,
+          'email', party.email,
+          'docType', party.doc_type,
+          'docNumber', party.doc_number,
+          'dob', party.dob,
+          'dniVerified', party.dni_verified
+        ) end,
+        'identities', coalesce(identities.rows, '[]'::jsonb),
+        'tags', coalesce(tags.rows, '[]'::jsonb),
+        'activities', coalesce(activities.rows, '[]'::jsonb),
+        'finance', jsonb_build_object(
+          'invoiceCount', coalesce(finance.invoice_count, 0),
+          'total', coalesce(finance.total, 0),
+          'lastIssuedAt', finance.last_issued_at,
+          'recentInvoices', coalesce(recent_invoices.rows, '[]'::jsonb)
+        ),
+        'bookings', coalesce(bookings.rows, '[]'::jsonb),
+        'salesOrders', coalesce(sales_orders.rows, '[]'::jsonb),
+        'posTickets', coalesce(pos_tickets.rows, '[]'::jsonb),
+        'memberships', coalesce(memberships.rows, '[]'::jsonb)
+      ) end as relationship_context
+    from requested
+    left join crm_contact_identities identity
+      on identity.org_id = current_setting('app.current_org_id', true)
+      and identity.channel = requested.channel
+      and identity.external_id = requested.chat_id
+    left join crm_contacts contact
+      on contact.org_id = current_setting('app.current_org_id', true)
+      and contact.id = identity.contact_id
+      and contact.deleted_at is null
+    left join parties party
+      on party.org_id = current_setting('app.current_org_id', true)
+      and party.id = contact.party_id
+    left join lateral (
+      select jsonb_agg(jsonb_build_object(
+        'channel', ci.channel,
+        'externalId', ci.external_id,
+        'handle', ci.handle
+      ) order by ci.channel, ci.external_id) as rows
+      from crm_contact_identities ci
+      where ci.org_id = current_setting('app.current_org_id', true)
+        and ci.contact_id = contact.id
+    ) identities on true
+    left join lateral (
+      select jsonb_agg(tag.name order by tag.position, tag.name) as rows
+      from crm_contact_tags membership
+      join crm_tags tag
+        on tag.org_id = current_setting('app.current_org_id', true)
+        and tag.id = membership.tag_id
+      where membership.org_id = current_setting('app.current_org_id', true)
+        and membership.contact_id = contact.id
+    ) tags on true
+    left join lateral (
+      select jsonb_agg(jsonb_build_object(
+        'kind', activity.kind,
+        'body', activity.body,
+        'occurredAt', activity.occurred_at
+      ) order by activity.occurred_at desc) as rows
+      from (
+        select kind, body, occurred_at
+        from crm_activities
+        where org_id = current_setting('app.current_org_id', true)
+          and contact_id = contact.id
+        order by occurred_at desc
+        limit 10
+      ) activity
+    ) activities on true
+    left join lateral (
+      select count(*)::int as invoice_count,
+        coalesce(sum(coalesce(invoice.total, 0)), 0)::float8 as total,
+        max(invoice.issued_at) as last_issued_at
+      from fin_invoices invoice
+      left join fin_clients client
+        on client.org_id = current_setting('app.current_org_id', true)
+        and client.id = invoice.client_id
+      where invoice.org_id = current_setting('app.current_org_id', true)
+        and contact.id is not null
+        and (
+          (contact.party_id is not null and client.party_id = contact.party_id)
+          or (
+            nullif(trim(contact.custom_fields->>'dni'), '') is not null
+            and regexp_replace(coalesce(invoice.client_doc_number, ''), '[^0-9]', '', 'g')
+              = regexp_replace(contact.custom_fields->>'dni', '[^0-9]', '', 'g')
+          )
+        )
+    ) finance on true
+    left join lateral (
+      select jsonb_agg(jsonb_build_object(
+        'documentId', invoice.document_id,
+        'issuedAt', invoice.issued_at,
+        'total', coalesce(invoice.total, 0)::float8,
+        'currency', invoice.currency,
+        'status', invoice.status,
+        'items', invoice.items
+      ) order by invoice.issued_at desc nulls last) as rows
+      from (
+        select fi.document_id, fi.issued_at, fi.total, fi.currency, fi.status,
+          coalesce((
+            select jsonb_agg(item.description order by item.total desc nulls last)
+            from (
+              select description, total
+              from fin_invoice_items
+              where org_id = current_setting('app.current_org_id', true)
+                and invoice_id = fi.id
+                and description is not null
+              order by total desc nulls last
+              limit 5
+            ) item
+          ), '[]'::jsonb) as items
+        from fin_invoices fi
+        left join fin_clients fc
+          on fc.org_id = current_setting('app.current_org_id', true)
+          and fc.id = fi.client_id
+        where fi.org_id = current_setting('app.current_org_id', true)
+          and contact.id is not null
+          and (
+            (contact.party_id is not null and fc.party_id = contact.party_id)
+            or (
+              nullif(trim(contact.custom_fields->>'dni'), '') is not null
+              and regexp_replace(coalesce(fi.client_doc_number, ''), '[^0-9]', '', 'g')
+                = regexp_replace(contact.custom_fields->>'dni', '[^0-9]', '', 'g')
+            )
+          )
+        order by fi.issued_at desc nulls last
+        limit 10
+      ) invoice
+    ) recent_invoices on true
+    left join lateral (
+      select jsonb_agg(jsonb_build_object(
+        'startTime', booking.start_time,
+        'status', booking.status,
+        'title', booking.title,
+        'notes', booking.notes
+      ) order by booking.start_time desc) as rows
+      from (
+        select start_time, status, title, notes
+        from sched_bookings
+        where org_id = current_setting('app.current_org_id', true)
+          and (
+            crm_contact_id = contact.id
+            or (contact.party_id is not null and party_id = contact.party_id)
+          )
+        order by start_time desc
+        limit 10
+      ) booking
+    ) bookings on true
+    left join lateral (
+      select jsonb_agg(jsonb_build_object(
+        'humanId', sales_order.human_id,
+        'createdAt', sales_order.created_at,
+        'status', sales_order.status,
+        'description', sales_order.description,
+        'total', sales_order.total::float8,
+        'currency', sales_order.currency
+      ) order by sales_order.created_at desc) as rows
+      from (
+        select human_id, created_at, status, description, total, currency
+        from sales_orders
+        where org_id = current_setting('app.current_org_id', true)
+          and (
+            crm_contact_id = contact.id
+            or (contact.party_id is not null and party_id = contact.party_id)
+          )
+        order by created_at desc
+        limit 10
+      ) sales_order
+    ) sales_orders on true
+    left join lateral (
+      select jsonb_agg(jsonb_build_object(
+        'humanId', ticket.human_id,
+        'submittedAt', ticket.submitted_at,
+        'status', ticket.status,
+        'total', ticket.total::float8,
+        'currency', ticket.currency
+      ) order by ticket.submitted_at desc) as rows
+      from (
+        select human_id, submitted_at, status, total, currency
+        from pos_tickets
+        where org_id = current_setting('app.current_org_id', true)
+          and (
+            crm_contact_id = contact.id
+            or (contact.party_id is not null and party_id = contact.party_id)
+          )
+        order by submitted_at desc
+        limit 10
+      ) ticket
+    ) pos_tickets on true
+    left join lateral (
+      select jsonb_agg(jsonb_build_object(
+        'planName', membership.plan_name,
+        'status', membership.status,
+        'startedAt', membership.started_at,
+        'nextCycleDate', membership.next_cycle_date
+      ) order by membership.started_at desc) as rows
+      from (
+        select plan.name as plan_name, member.status, member.started_at, member.next_cycle_date
+        from memberships member
+        left join membership_plans plan
+          on plan.org_id = current_setting('app.current_org_id', true)
+          and plan.id = member.plan_id
+        where member.org_id = current_setting('app.current_org_id', true)
+          and (
+            member.crm_contact_id = contact.id
+            or (contact.party_id is not null and member.party_id = contact.party_id)
+          )
+        order by member.started_at desc
+        limit 10
+      ) membership
+    ) memberships on true
+  `)) as unknown as Array<{
+    channel: string;
+    chat_id: string;
+    relationship_context: ConversationRelationshipContext | null;
+  }>;
+  for (const row of rows) {
+    out.set(`${row.channel}\u0000${row.chat_id}`, row.relationship_context);
+  }
+  return out;
+}
+
 async function prepareConversations(
   tx: CoreTx,
   keys: WhatsAppConversationKey[],
   onlyMonths?: string[],
 ): Promise<PreparedConversation[]> {
-  const rowsByKey = await loadWhatsAppRows(tx, keys, onlyMonths);
+  const [rowsByKey, contextByKey] = await Promise.all([
+    loadConversationRows(tx, keys, onlyMonths),
+    loadConversationRelationshipContexts(tx, keys),
+  ]);
   const normalized = keys
     .flatMap((key) => {
-      const rows = rowsByKey.get(`${key.accountId}\u0000${key.chatId}`) ?? [];
+      const rows = rowsByKey.get(`${key.channel}\u0000${key.accountId}\u0000${key.chatId}`) ?? [];
       return rows.length > 0
-        ? normalizeWhatsAppConversationSegments(key.accountId, key.chatId, rows).map(
-            (document) => ({ key, document }),
-          )
+        ? normalizeConversationSegments(
+            key.channel,
+            key.accountId,
+            key.chatId,
+            rows,
+            contextByKey.get(`${key.channel}\u0000${key.chatId}`) ?? null,
+          ).map((document) => ({ key, document }))
         : [];
     })
     .filter(
@@ -1054,9 +1644,9 @@ async function runPreparedBatch(
  * retrieval. A later reappearance revives the document through the normal
  * upsert path.
  */
-export async function reconcileDeletedWhatsAppDocuments(
+export async function reconcileDeletedConversationDocuments(
   ctx: CoreCtx,
-  only?: { accountId: string; chatId: string; months?: string[] },
+  only?: { channel: string; accountId: string; chatId: string; months?: string[] },
 ): Promise<WhatsAppReconcileResult> {
   return withOrgCore(ctx, async (tx) => {
     const monthScope = only?.months?.length
@@ -1066,7 +1656,8 @@ export async function reconcileDeletedWhatsAppDocuments(
         )`
       : sql``;
     const specific = only
-      ? sql`and source.external_key = ${only.accountId}
+      ? sql`and source.connector = ${only.channel}
+            and source.external_key = ${only.accountId}
             and document.metadata->>'chatId' = ${only.chatId}
             ${monthScope}`
       : sql``;
@@ -1076,7 +1667,10 @@ export async function reconcileDeletedWhatsAppDocuments(
       from knowledge_sources source
       where document.org_id = current_setting('app.current_org_id', true)
         and source.org_id = document.org_id and source.id = document.source_id
-        and source.connector = ${WHATSAPP_CONNECTOR}
+        and (
+          source.config->>'domain' = 'conversations'
+          or source.connector = ${WHATSAPP_CONNECTOR}
+        )
         and document.status <> 'deleted'
         ${specific}
         and (
@@ -1084,14 +1678,14 @@ export async function reconcileDeletedWhatsAppDocuments(
           or not exists (
           select 1 from messages message
           where message.org_id = document.org_id
-            and message.channel = 'whatsapp'
-            and message.account_id = source.external_key
+            and lower(trim(message.channel)) = source.connector
+            and coalesce(nullif(trim(message.account_id), ''), 'default') = source.external_key
             and message.chat_id = document.metadata->>'chatId'
             and to_char(
               coalesce(message.occurred_at, message.created_at) at time zone 'UTC',
               'YYYY-MM'
             ) = document.metadata->>'segmentMonth'
-            and ${eligibleWhatsAppMessagePredicate('message')}
+            and ${eligibleConversationMessagePredicate('message')}
           )
         )
       returning document.id::text
@@ -1108,55 +1702,80 @@ export async function reconcileDeletedWhatsAppDocuments(
   });
 }
 
+export function reconcileDeletedWhatsAppDocuments(
+  ctx: CoreCtx,
+  only?: { accountId: string; chatId: string; months?: string[] },
+): Promise<WhatsAppReconcileResult> {
+  return reconcileDeletedConversationDocuments(
+    ctx,
+    only ? { channel: WHATSAPP_CONNECTOR, ...only } : undefined,
+  );
+}
+
 /** Cursor-driven full/catch-up page. Re-running from the start is idempotent. */
-export async function backfillWhatsAppConversations(
+export async function backfillConversations(
   ctx: CoreCtx,
   opts?: { cursor?: string | null; limit?: number },
 ): Promise<WhatsAppBackfillResult> {
   const limit = Math.max(1, Math.min(500, Math.floor(opts?.limit ?? DEFAULT_CONVERSATION_BATCH)));
   await ensureMasterBrain(ctx);
-  const sources = await discoverWhatsAppSources(ctx);
-  await ensureWhatsAppFocusedBrain(
+  const sources = await discoverConversationSources(ctx);
+  await ensureConversationsFocusedBrain(
     ctx,
     sources.map((source) => source.id),
   );
-  const sourceByAccount = new Map(sources.map((source) => [source.externalKey, source.id]));
-  const cursor = decodeWhatsAppCursor(opts?.cursor);
+  const sourceByChannelAccount = new Map(
+    sources.map((source) => [`${source.connector}\u0000${source.externalKey}`, source.id]),
+  );
+  const cursor = decodeConversationCursor(opts?.cursor);
   const preparedPage = await withOrgCore(ctx, async (tx) => {
-    const page = await scanWhatsAppKeys(tx, sourceByAccount, cursor, limit);
+    const page = await scanConversationKeys(tx, sourceByChannelAccount, cursor, limit);
     return { ...page, prepared: await prepareConversations(tx, page.keys) };
   });
   const counts = await runPreparedBatch(ctx, preparedPage.prepared);
   const last = preparedPage.keys.at(-1) ?? null;
   let reconciled = { deletedDocuments: 0, deletedChunks: 0 };
   if (!preparedPage.hasMore) {
-    reconciled = await reconcileDeletedWhatsAppDocuments(ctx);
-    await markVerifiedEmptyWhatsAppSourcesReady(ctx);
+    reconciled = await reconcileDeletedConversationDocuments(ctx);
+    await markVerifiedEmptyConversationSourcesReady(ctx);
   }
   return {
     ...counts,
     deletedChunks: counts.deletedChunks + reconciled.deletedChunks,
     nextCursor:
       preparedPage.hasMore && last
-        ? encodeWhatsAppCursor({ accountId: last.accountId, chatId: last.chatId })
+        ? encodeConversationCursor({
+            channel: last.channel,
+            accountId: last.accountId,
+            chatId: last.chatId,
+          })
         : null,
     hasMore: preparedPage.hasMore,
   };
 }
 
-/** Event-hook target: rebuild exactly one account-scoped conversation. */
-export async function syncWhatsAppConversation(
+export function backfillWhatsAppConversations(
   ctx: CoreCtx,
+  opts?: { cursor?: string | null; limit?: number },
+): Promise<WhatsAppBackfillResult> {
+  return backfillConversations(ctx, opts);
+}
+
+/** Event-hook target: rebuild exactly one channel/account-scoped conversation. */
+export async function syncConversation(
+  ctx: CoreCtx,
+  channel: string,
   accountId: string,
   chatId: string,
   opts?: { months?: string[] },
 ): Promise<WhatsAppBackfillResult> {
-  const source = await ensureWhatsAppSource(ctx, accountId);
-  const key = { accountId, chatId, sourceId: source.id };
+  const source = await ensureConversationSource(ctx, channel, accountId);
+  const key = { channel, accountId, chatId, sourceId: source.id };
   const months = opts?.months?.filter((month) => /^\d{4}-\d{2}$/.test(month));
   const prepared = await withOrgCore(ctx, (tx) => prepareConversations(tx, [key], months));
   if (prepared.length === 0) {
-    const reconciled = await reconcileDeletedWhatsAppDocuments(ctx, {
+    const reconciled = await reconcileDeletedConversationDocuments(ctx, {
+      channel,
       accountId,
       chatId,
       months,
@@ -1173,13 +1792,27 @@ export async function syncWhatsAppConversation(
     };
   }
   const counts = await runPreparedBatch(ctx, prepared);
-  const reconciled = await reconcileDeletedWhatsAppDocuments(ctx, { accountId, chatId, months });
+  const reconciled = await reconcileDeletedConversationDocuments(ctx, {
+    channel,
+    accountId,
+    chatId,
+    months,
+  });
   return {
     ...counts,
     deletedChunks: counts.deletedChunks + reconciled.deletedChunks,
     nextCursor: null,
     hasMore: false,
   };
+}
+
+export function syncWhatsAppConversation(
+  ctx: CoreCtx,
+  accountId: string,
+  chatId: string,
+  opts?: { months?: string[] },
+): Promise<WhatsAppBackfillResult> {
+  return syncConversation(ctx, WHATSAPP_CONNECTOR, accountId, chatId, opts);
 }
 
 export async function bootstrapBrainCorpus(
@@ -1192,13 +1825,13 @@ export async function bootstrapBrainCorpus(
   backfill: WhatsAppBackfillResult;
 }> {
   const masterBrain = await ensureMasterBrain(ctx, opts?.createdBy);
-  const sources = await discoverWhatsAppSources(ctx);
-  const focusedBrain = await ensureWhatsAppFocusedBrain(
+  const sources = await discoverConversationSources(ctx);
+  const focusedBrain = await ensureConversationsFocusedBrain(
     ctx,
     sources.map((source) => source.id),
     opts?.createdBy,
   );
-  const backfill = await backfillWhatsAppConversations(ctx, {
+  const backfill = await backfillConversations(ctx, {
     cursor: opts?.cursor,
     limit: opts?.limit,
   });

--- a/src/server/services/brain-corpus.service.ts
+++ b/src/server/services/brain-corpus.service.ts
@@ -21,6 +21,7 @@ export const CONVERSATIONS_FOCUSED_BRAIN_NAME = 'All Conversations';
 export const WHATSAPP_FOCUSED_BRAIN_NAME = CONVERSATIONS_FOCUSED_BRAIN_NAME;
 const DEFAULT_CONVERSATION_BATCH = 50;
 const DEFAULT_CHUNK_MAX_CHARS = 6000;
+const DEFAULT_CONTEXT_MAX_CHARS = 6000;
 const EMBEDDING_BATCH_SIZE = 64;
 const EMBEDDING_BATCH_CONCURRENCY = Math.min(
   8,
@@ -442,7 +443,10 @@ export function renderConversationRelationshipContext(
         .join(' | ')}`,
     );
   }
-  return lines.join('\n');
+  const rendered = lines.join('\n');
+  return rendered.length <= DEFAULT_CONTEXT_MAX_CHARS
+    ? rendered
+    : `${rendered.slice(0, DEFAULT_CONTEXT_MAX_CHARS - 1)}…`;
 }
 
 /**
@@ -1498,6 +1502,20 @@ async function persistConversations(
   if (prepared.length === 0) return { deletedChunks: 0 };
   const qdrantStorage = qdrantOwnsKnowledgeEmbeddings();
   return withOrgCore(ctx, async (tx) => {
+    if (qdrantStorage) {
+      const generations = (await tx.execute(sql`
+        select storage_mode
+        from brain_vector_generations
+        where is_active and enqueue_enabled
+        order by activated_at desc nulls last
+        limit 2
+      `)) as unknown as Array<{ storage_mode: string }>;
+      if (generations.length !== 1 || generations[0].storage_mode !== 'qdrant') {
+        throw new Error(
+          'BRAIN_VECTOR_STORAGE_MODE=qdrant requires one active Qdrant-owned vector generation',
+        );
+      }
+    }
     let deletedChunks = 0;
     for (const conversation of prepared) {
       // A reconcile page can contain hundreds of documents whose hashes and

--- a/src/server/services/brain-corpus.service.ts
+++ b/src/server/services/brain-corpus.service.ts
@@ -354,92 +354,27 @@ function channelLabel(channel: string): string {
     .join(' ');
 }
 
-function compactJson(value: unknown, maxChars = 2000): string {
-  const serialized = JSON.stringify(value);
-  return serialized.length <= maxChars ? serialized : `${serialized.slice(0, maxChars)}…`;
-}
-
 export function renderConversationRelationshipContext(
   context: ConversationRelationshipContext | null,
 ): string {
   if (!context?.contact) return 'CRM contact: not matched';
   const lines = [
     `CRM contact: ${context.contact.displayName ?? context.contact.humanId ?? context.contact.id}`,
-    `CRM profile: lifecycle=${context.contact.lifecycleOverride ?? 'derived'}; source=${context.contact.source}; custom=${compactJson(context.contact.customFields)}`,
+    `CRM profile: lifecycle=${context.contact.lifecycleOverride ?? 'derived'}; source=${context.contact.source}`,
   ];
   if (context.party) {
-    lines.push(
-      `Party: ${context.party.name ?? context.party.id}; type=${context.party.type}; document=${context.party.docType ?? ''} ${context.party.docNumber ?? ''}; verified=${context.party.dniVerified}; phone=${context.party.phone9 ?? ''}; email=${context.party.email ?? ''}`,
-    );
+    lines.push(`Party: ${context.party.name ?? context.party.id}; type=${context.party.type}`);
   }
   if (context.identities.length > 0) {
     lines.push(
-      `Channel identities: ${context.identities
-        .map((identity) => `${identity.channel}:${identity.handle ?? identity.externalId}`)
-        .join(', ')}`,
+      `Known channels: ${[...new Set(context.identities.map((identity) => identity.channel))].join(', ')}`,
     );
   }
   if (context.tags.length > 0) lines.push(`CRM tags: ${context.tags.join(', ')}`);
   if (context.activities.length > 0) {
     lines.push(
       `Recent CRM activity: ${context.activities
-        .map(
-          (activity) =>
-            `${activity.occurredAt} ${activity.kind}${activity.body ? ` — ${activity.body}` : ''}`,
-        )
-        .join(' | ')}`,
-    );
-  }
-  if (context.finance.invoiceCount > 0) {
-    lines.push(
-      `Finance summary: invoices=${context.finance.invoiceCount}; total=${context.finance.total}; last=${context.finance.lastIssuedAt ?? 'unknown'}`,
-    );
-    lines.push(
-      `Recent invoices: ${context.finance.recentInvoices
-        .map(
-          (invoice) =>
-            `${invoice.issuedAt ?? 'unknown'} ${invoice.documentId ?? ''} ${invoice.status ?? ''} ${invoice.currency ?? ''} ${invoice.total}${invoice.items.length ? ` [${invoice.items.join(', ')}]` : ''}`,
-        )
-        .join(' | ')}`,
-    );
-  }
-  if (context.bookings.length > 0) {
-    lines.push(
-      `Bookings: ${context.bookings
-        .map(
-          (booking) =>
-            `${booking.startTime} ${booking.status} ${booking.title ?? ''}${booking.notes ? ` — ${booking.notes}` : ''}`,
-        )
-        .join(' | ')}`,
-    );
-  }
-  if (context.salesOrders.length > 0) {
-    lines.push(
-      `Sales orders: ${context.salesOrders
-        .map(
-          (order) =>
-            `${order.createdAt} ${order.humanId ?? ''} ${order.status} ${order.description ?? ''} ${order.currency ?? ''} ${order.total ?? ''}`,
-        )
-        .join(' | ')}`,
-    );
-  }
-  if (context.posTickets.length > 0) {
-    lines.push(
-      `POS tickets: ${context.posTickets
-        .map(
-          (ticket) =>
-            `${ticket.submittedAt} ${ticket.humanId ?? ''} ${ticket.status} ${ticket.currency} ${ticket.total}`,
-        )
-        .join(' | ')}`,
-    );
-  }
-  if (context.memberships.length > 0) {
-    lines.push(
-      `Memberships: ${context.memberships
-        .map(
-          (membership) =>
-            `${membership.planName ?? 'plan'} ${membership.status} started=${membership.startedAt} next=${membership.nextCycleDate}`,
-        )
+        .map((activity) => `${activity.occurredAt} ${activity.kind}`)
         .join(' | ')}`,
     );
   }
@@ -554,7 +489,6 @@ export function normalizeConversation(
       ),
       contactId: relationshipContext?.contact?.id ?? null,
       partyId: relationshipContext?.party?.id ?? null,
-      relationshipContext,
     },
     chunks,
   };
@@ -1147,32 +1081,32 @@ async function loadConversationRelationshipContexts(
           'displayName', contact.display_name,
           'lifecycleOverride', contact.lifecycle_override,
           'source', contact.source,
-          'customFields', contact.custom_fields
+          'customFields', '{}'::jsonb
         ),
         'party', case when party.id is null then null else jsonb_build_object(
           'id', party.id::text,
           'type', party.type,
           'name', party.name,
-          'phone9', party.phone9,
-          'email', party.email,
-          'docType', party.doc_type,
-          'docNumber', party.doc_number,
-          'dob', party.dob,
-          'dniVerified', party.dni_verified
+          'phone9', null,
+          'email', null,
+          'docType', null,
+          'docNumber', null,
+          'dob', null,
+          'dniVerified', false
         ) end,
         'identities', coalesce(identities.rows, '[]'::jsonb),
         'tags', coalesce(tags.rows, '[]'::jsonb),
         'activities', coalesce(activities.rows, '[]'::jsonb),
         'finance', jsonb_build_object(
-          'invoiceCount', coalesce(finance.invoice_count, 0),
-          'total', coalesce(finance.total, 0),
-          'lastIssuedAt', finance.last_issued_at,
-          'recentInvoices', coalesce(recent_invoices.rows, '[]'::jsonb)
+          'invoiceCount', 0,
+          'total', 0,
+          'lastIssuedAt', null,
+          'recentInvoices', '[]'::jsonb
         ),
-        'bookings', coalesce(bookings.rows, '[]'::jsonb),
-        'salesOrders', coalesce(sales_orders.rows, '[]'::jsonb),
-        'posTickets', coalesce(pos_tickets.rows, '[]'::jsonb),
-        'memberships', coalesce(memberships.rows, '[]'::jsonb)
+        'bookings', '[]'::jsonb,
+        'salesOrders', '[]'::jsonb,
+        'posTickets', '[]'::jsonb,
+        'memberships', '[]'::jsonb
       ) end as relationship_context
     from requested
     left join crm_contact_identities identity
@@ -1189,9 +1123,9 @@ async function loadConversationRelationshipContexts(
     left join lateral (
       select jsonb_agg(jsonb_build_object(
         'channel', ci.channel,
-        'externalId', ci.external_id,
-        'handle', ci.handle
-      ) order by ci.channel, ci.external_id) as rows
+        'externalId', '',
+        'handle', null
+      ) order by ci.channel) as rows
       from crm_contact_identities ci
       where ci.org_id = current_setting('app.current_org_id', true)
         and ci.contact_id = contact.id
@@ -1208,11 +1142,11 @@ async function loadConversationRelationshipContexts(
     left join lateral (
       select jsonb_agg(jsonb_build_object(
         'kind', activity.kind,
-        'body', activity.body,
+        'body', null,
         'occurredAt', activity.occurred_at
       ) order by activity.occurred_at desc) as rows
       from (
-        select kind, body, occurred_at
+        select kind, occurred_at
         from crm_activities
         where org_id = current_setting('app.current_org_id', true)
           and contact_id = contact.id
@@ -1220,148 +1154,6 @@ async function loadConversationRelationshipContexts(
         limit 10
       ) activity
     ) activities on true
-    left join lateral (
-      select count(*)::int as invoice_count,
-        coalesce(sum(coalesce(invoice.total, 0)), 0)::float8 as total,
-        max(invoice.issued_at) as last_issued_at
-      from fin_invoices invoice
-      left join fin_clients client
-        on client.org_id = current_setting('app.current_org_id', true)
-        and client.id = invoice.client_id
-      where invoice.org_id = current_setting('app.current_org_id', true)
-        and contact.id is not null
-        and (
-          (contact.party_id is not null and client.party_id = contact.party_id)
-          or (
-            nullif(trim(contact.custom_fields->>'dni'), '') is not null
-            and regexp_replace(coalesce(invoice.client_doc_number, ''), '[^0-9]', '', 'g')
-              = regexp_replace(contact.custom_fields->>'dni', '[^0-9]', '', 'g')
-          )
-        )
-    ) finance on true
-    left join lateral (
-      select jsonb_agg(jsonb_build_object(
-        'documentId', invoice.document_id,
-        'issuedAt', invoice.issued_at,
-        'total', coalesce(invoice.total, 0)::float8,
-        'currency', invoice.currency,
-        'status', invoice.status,
-        'items', invoice.items
-      ) order by invoice.issued_at desc nulls last) as rows
-      from (
-        select fi.document_id, fi.issued_at, fi.total, fi.currency, fi.status,
-          coalesce((
-            select jsonb_agg(item.description order by item.total desc nulls last)
-            from (
-              select description, total
-              from fin_invoice_items
-              where org_id = current_setting('app.current_org_id', true)
-                and invoice_id = fi.id
-                and description is not null
-              order by total desc nulls last
-              limit 5
-            ) item
-          ), '[]'::jsonb) as items
-        from fin_invoices fi
-        left join fin_clients fc
-          on fc.org_id = current_setting('app.current_org_id', true)
-          and fc.id = fi.client_id
-        where fi.org_id = current_setting('app.current_org_id', true)
-          and contact.id is not null
-          and (
-            (contact.party_id is not null and fc.party_id = contact.party_id)
-            or (
-              nullif(trim(contact.custom_fields->>'dni'), '') is not null
-              and regexp_replace(coalesce(fi.client_doc_number, ''), '[^0-9]', '', 'g')
-                = regexp_replace(contact.custom_fields->>'dni', '[^0-9]', '', 'g')
-            )
-          )
-        order by fi.issued_at desc nulls last
-        limit 10
-      ) invoice
-    ) recent_invoices on true
-    left join lateral (
-      select jsonb_agg(jsonb_build_object(
-        'startTime', booking.start_time,
-        'status', booking.status,
-        'title', booking.title,
-        'notes', booking.notes
-      ) order by booking.start_time desc) as rows
-      from (
-        select start_time, status, title, notes
-        from sched_bookings
-        where org_id = current_setting('app.current_org_id', true)
-          and (
-            crm_contact_id = contact.id
-            or (contact.party_id is not null and party_id = contact.party_id)
-          )
-        order by start_time desc
-        limit 10
-      ) booking
-    ) bookings on true
-    left join lateral (
-      select jsonb_agg(jsonb_build_object(
-        'humanId', sales_order.human_id,
-        'createdAt', sales_order.created_at,
-        'status', sales_order.status,
-        'description', sales_order.description,
-        'total', sales_order.total::float8,
-        'currency', sales_order.currency
-      ) order by sales_order.created_at desc) as rows
-      from (
-        select human_id, created_at, status, description, total, currency
-        from sales_orders
-        where org_id = current_setting('app.current_org_id', true)
-          and (
-            crm_contact_id = contact.id
-            or (contact.party_id is not null and party_id = contact.party_id)
-          )
-        order by created_at desc
-        limit 10
-      ) sales_order
-    ) sales_orders on true
-    left join lateral (
-      select jsonb_agg(jsonb_build_object(
-        'humanId', ticket.human_id,
-        'submittedAt', ticket.submitted_at,
-        'status', ticket.status,
-        'total', ticket.total::float8,
-        'currency', ticket.currency
-      ) order by ticket.submitted_at desc) as rows
-      from (
-        select human_id, submitted_at, status, total, currency
-        from pos_tickets
-        where org_id = current_setting('app.current_org_id', true)
-          and (
-            crm_contact_id = contact.id
-            or (contact.party_id is not null and party_id = contact.party_id)
-          )
-        order by submitted_at desc
-        limit 10
-      ) ticket
-    ) pos_tickets on true
-    left join lateral (
-      select jsonb_agg(jsonb_build_object(
-        'planName', membership.plan_name,
-        'status', membership.status,
-        'startedAt', membership.started_at,
-        'nextCycleDate', membership.next_cycle_date
-      ) order by membership.started_at desc) as rows
-      from (
-        select plan.name as plan_name, member.status, member.started_at, member.next_cycle_date
-        from memberships member
-        left join membership_plans plan
-          on plan.org_id = current_setting('app.current_org_id', true)
-          and plan.id = member.plan_id
-        where member.org_id = current_setting('app.current_org_id', true)
-          and (
-            member.crm_contact_id = contact.id
-            or (contact.party_id is not null and member.party_id = contact.party_id)
-          )
-        order by member.started_at desc
-        limit 10
-      ) membership
-    ) memberships on true
   `)) as unknown as Array<{
     channel: string;
     chat_id: string;
@@ -1504,13 +1296,9 @@ async function persistConversations(
   return withOrgCore(ctx, async (tx) => {
     if (qdrantStorage) {
       const generations = (await tx.execute(sql`
-        select storage_mode
-        from brain_vector_generations
-        where is_active and enqueue_enabled
-        order by activated_at desc nulls last
-        limit 2
-      `)) as unknown as Array<{ storage_mode: string }>;
-      if (generations.length !== 1 || generations[0].storage_mode !== 'qdrant') {
+        select public.brain_vector_app_generation_mode() as storage_mode
+      `)) as unknown as Array<{ storage_mode: string | null }>;
+      if (generations[0]?.storage_mode !== 'qdrant') {
         throw new Error(
           'BRAIN_VECTOR_STORAGE_MODE=qdrant requires one active Qdrant-owned vector generation',
         );
@@ -1614,28 +1402,13 @@ async function persistConversations(
               where document.org_id = knowledge_sources.org_id
                 and document.source_id = knowledge_sources.id and document.status <> 'deleted'
             ) then 'queued'
-            when ${qdrantStorage} and exists (
-              select 1
-              from knowledge_chunks chunk
-              join brain_vector_outbox vector_job
-                on vector_job.chunk_id = chunk.id
-              where chunk.org_id = knowledge_sources.org_id
-                and chunk.source_id = knowledge_sources.id
-                and vector_job.status = 'dead'
-            ) then 'failed'
+            when ${qdrantStorage}
+              then public.brain_vector_app_source_state(knowledge_sources.id)
             when exists (
               select 1 from knowledge_chunks chunk
               where chunk.org_id = knowledge_sources.org_id
                 and chunk.source_id = knowledge_sources.id
-                and ${
-                  qdrantStorage
-                    ? sql`exists (
-                        select 1 from brain_vector_outbox vector_job
-                        where vector_job.chunk_id = chunk.id
-                          and vector_job.status in ('queued', 'running')
-                      )`
-                    : sql`chunk.embedding is null`
-                }
+                and chunk.embedding is null
             ) then 'queued'
             else 'ready'
           end,
@@ -1933,17 +1706,11 @@ async function loadSourceAggregates(
       select count(distinct document.id)::int as document_count,
         count(chunk.id)::int as chunk_count,
         (
-          count(chunk.id) filter (
-            where ${
-              qdrantOwnsKnowledgeEmbeddings()
-                ? sql`exists (
-                    select 1 from brain_vector_outbox vector_job
-                    where vector_job.chunk_id = chunk.id
-                      and vector_job.status in ('queued', 'running', 'dead')
-                  )`
-                : sql`chunk.embedding is null`
-            }
-          )
+          ${
+            qdrantOwnsKnowledgeEmbeddings()
+              ? sql`public.brain_vector_app_source_pending_count(source.id)`
+              : sql`count(chunk.id) filter (where chunk.embedding is null)`
+          }
           + count(distinct document.id) filter (
               where document.status in ('pending', 'processing', 'failed') and chunk.id is null
             )

--- a/src/server/services/messages.service.ts
+++ b/src/server/services/messages.service.ts
@@ -2,7 +2,7 @@ import { and, eq, gte, lte, desc, sql, type SQL } from 'drizzle-orm';
 import { messages } from '@minion-stack/db/pg';
 import { cached, invalidateTags, keys, tags } from '@minion-stack/cache';
 import { withOrg } from '$server/db/pg-ledger-client';
-import { enqueueWhatsAppBrainChanges } from './brain-corpus-jobs.service';
+import { enqueueConversationBrainChanges } from './brain-corpus-jobs.service';
 
 /** Cache tags for message-ledger reads (omnichat conversations/threads). */
 const messageTags = (orgId: string) => tags.tenantDomain(orgId, 'messages');
@@ -127,7 +127,10 @@ async function enqueueBrainChangesAfterCommit(
   acceptedClientIds: string[],
 ): Promise<string | null> {
   try {
-    return await enqueueWhatsAppBrainChanges(orgId, acceptedIngestRows(rows, acceptedClientIds));
+    return await enqueueConversationBrainChanges(
+      orgId,
+      acceptedIngestRows(rows, acceptedClientIds),
+    );
   } catch (cause) {
     // The ledger commit already succeeded. Never return a false ingest failure
     // to the gateway (which would replay the batch); durable reconciliation is

--- a/src/server/services/meta/graph-read.test.ts
+++ b/src/server/services/meta/graph-read.test.ts
@@ -23,7 +23,10 @@ import {
   fbPostComments,
 } from './graph-read';
 
-function jsonResponse(body: unknown, init: { ok?: boolean; status?: number; headers?: Record<string, string> } = {}) {
+function jsonResponse(
+  body: unknown,
+  init: { ok?: boolean; status?: number; headers?: Record<string, string> } = {},
+) {
   return {
     ok: init.ok ?? true,
     status: init.status ?? 200,
@@ -41,7 +44,9 @@ function mockFetch(response: Response | ((url: string) => Response)) {
 
 describe('exchangeCodeForToken', () => {
   it('returns the token on success', async () => {
-    const fetchImpl = mockFetch(jsonResponse({ access_token: 'short-lived', token_type: 'bearer', expires_in: 3600 }));
+    const fetchImpl = mockFetch(
+      jsonResponse({ access_token: 'short-lived', token_type: 'bearer', expires_in: 3600 }),
+    );
     const res = await exchangeCodeForToken(
       { appId: 'app1', appSecret: 'secret1', code: 'code1', redirectUri: 'https://hub/cb' },
       { fetchImpl },
@@ -57,8 +62,13 @@ describe('exchangeCodeForToken', () => {
 
 describe('extendUserToken', () => {
   it('exchanges a short token for a long-lived one', async () => {
-    const fetchImpl = mockFetch(jsonResponse({ access_token: 'long-lived', expires_in: 5_184_000 }));
-    const res = await extendUserToken({ appId: 'app1', appSecret: 'secret1', shortToken: 'short' }, { fetchImpl });
+    const fetchImpl = mockFetch(
+      jsonResponse({ access_token: 'long-lived', expires_in: 5_184_000 }),
+    );
+    const res = await extendUserToken(
+      { appId: 'app1', appSecret: 'secret1', shortToken: 'short' },
+      { fetchImpl },
+    );
     expect(res.ok).toBe(true);
     expect(res.data?.access_token).toBe('long-lived');
     const calledUrl = (fetchImpl.mock.calls[0]?.[0] as string) ?? '';
@@ -90,8 +100,17 @@ describe('listPagesWithTokens', () => {
   it('returns pages and surfaces the next cursor', async () => {
     const fetchImpl = mockFetch(
       jsonResponse({
-        data: [{ id: 'page1', name: 'FACES', access_token: 'ptok', instagram_business_account: { id: 'ig1' } }],
-        paging: { next: 'https://graph.facebook.com/v23.0/me/accounts?after=xyz&access_token=utok' },
+        data: [
+          {
+            id: 'page1',
+            name: 'FACES',
+            access_token: 'ptok',
+            instagram_business_account: { id: 'ig1' },
+          },
+        ],
+        paging: {
+          next: 'https://graph.facebook.com/v23.0/me/accounts?after=xyz&access_token=utok',
+        },
       }),
     );
     const res = await listPagesWithTokens('utok', { fetchImpl });
@@ -134,9 +153,13 @@ describe('listPagesWithTokens', () => {
 
   it('never surfaces the access token in an error message', async () => {
     const fetchImpl = vi.fn(async () => {
-      throw new Error('network down while fetching https://graph.facebook.com/v23.0/me/accounts?access_token=SECRET');
+      throw new Error(
+        'network down while fetching https://graph.facebook.com/v23.0/me/accounts?access_token=SECRET',
+      );
     });
-    const res = await listPagesWithTokens('SECRET', { fetchImpl: fetchImpl as unknown as typeof fetch });
+    const res = await listPagesWithTokens('SECRET', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
     expect(res.ok).toBe(false);
     expect(res.error).not.toContain('SECRET');
   });
@@ -144,7 +167,9 @@ describe('listPagesWithTokens', () => {
 
 describe('listAdAccounts', () => {
   it('returns the ad account list', async () => {
-    const fetchImpl = mockFetch(jsonResponse({ data: [{ id: 'act_1', name: 'FACES Ads', currency: 'USD' }] }));
+    const fetchImpl = mockFetch(
+      jsonResponse({ data: [{ id: 'act_1', name: 'FACES Ads', currency: 'USD' }] }),
+    );
     const res = await listAdAccounts('utok', { fetchImpl });
     expect(res.ok).toBe(true);
     expect(res.data?.[0]?.currency).toBe('USD');
@@ -181,14 +206,23 @@ describe('postInsights', () => {
     const fetchImpl = mockFetch((url: string) => {
       const metric = new URL(url).searchParams.get('metric') ?? '';
       if (metric.includes(',')) {
-        return jsonResponse({ error: { message: 'Unsupported get request', code: 100 } }, { ok: false, status: 400 });
+        return jsonResponse(
+          { error: { message: 'Unsupported get request', code: 100 } },
+          { ok: false, status: 400 },
+        );
       }
       if (metric === 'bad_metric') {
-        return jsonResponse({ error: { message: 'Unsupported get request', code: 100 } }, { ok: false, status: 400 });
+        return jsonResponse(
+          { error: { message: 'Unsupported get request', code: 100 } },
+          { ok: false, status: 400 },
+        );
       }
       return jsonResponse({ data: [{ name: metric, values: [{ value: 1 }] }] });
     });
-    const res = await postInsights('post1', 'ptok', { metrics: ['post_impressions', 'bad_metric'], fetchImpl });
+    const res = await postInsights('post1', 'ptok', {
+      metrics: ['post_impressions', 'bad_metric'],
+      fetchImpl,
+    });
     expect(res.ok).toBe(true);
     expect(res.data?.map((m) => m.name)).toEqual(['post_impressions']);
     expect(res.failedMetrics).toEqual(['bad_metric']);
@@ -196,7 +230,10 @@ describe('postInsights', () => {
 
   it('fails when every metric fails individually too', async () => {
     const fetchImpl = mockFetch(
-      jsonResponse({ error: { message: 'Unsupported get request', code: 100 } }, { ok: false, status: 400 }),
+      jsonResponse(
+        { error: { message: 'Unsupported get request', code: 100 } },
+        { ok: false, status: 400 },
+      ),
     );
     const res = await postInsights('post1', 'ptok', { metrics: ['a', 'b'], fetchImpl });
     expect(res.ok).toBe(false);
@@ -225,7 +262,9 @@ describe('listIgMedia', () => {
 
 describe('igMediaInsights', () => {
   it('uses the VIDEO metric set (includes views)', async () => {
-    const fetchImpl = mockFetch(jsonResponse({ data: [{ name: 'views', values: [{ value: 10 }] }] }));
+    const fetchImpl = mockFetch(
+      jsonResponse({ data: [{ name: 'views', values: [{ value: 10 }] }] }),
+    );
     await igMediaInsights('media1', 'ptok', 'VIDEO', { fetchImpl });
     const calledUrl = (fetchImpl.mock.calls[0]?.[0] as string) ?? '';
     expect(decodeURIComponent(calledUrl)).toContain('views');
@@ -244,7 +283,12 @@ describe('adInsights', () => {
     const fetchImpl = mockFetch(
       jsonResponse({ data: [{ ad_id: 'ad1', spend: '12.34', campaign_name: 'Summer' }] }),
     );
-    const res = await adInsights('123', 'utok', { since: '2026-06-01', until: '2026-06-30' }, { fetchImpl });
+    const res = await adInsights(
+      '123',
+      'utok',
+      { since: '2026-06-01', until: '2026-06-30' },
+      { fetchImpl },
+    );
     expect(res.ok).toBe(true);
     expect(res.data?.[0]?.ad_id).toBe('ad1');
     const calledUrl = decodeURIComponent((fetchImpl.mock.calls[0]?.[0] as string) ?? '');
@@ -254,7 +298,12 @@ describe('adInsights', () => {
 
   it('does not double-prefix an already act_-prefixed id', async () => {
     const fetchImpl = mockFetch(jsonResponse({ data: [] }));
-    await adInsights('act_123', 'utok', { since: '2026-06-01', until: '2026-06-30' }, { fetchImpl });
+    await adInsights(
+      'act_123',
+      'utok',
+      { since: '2026-06-01', until: '2026-06-30' },
+      { fetchImpl },
+    );
     const calledUrl = (fetchImpl.mock.calls[0]?.[0] as string) ?? '';
     expect(calledUrl).toContain('/act_123/insights');
     expect(calledUrl).not.toContain('act_act_123');
@@ -266,7 +315,14 @@ describe('listAdsWithStoryIds', () => {
     const fetchImpl = mockFetch(
       jsonResponse({
         data: [
-          { id: 'ad-1', creative: { effective_object_story_id: 'page-1_100', effective_instagram_media_id: 'ig-777', thumbnail_url: 'https://cdn/1.jpg' } },
+          {
+            id: 'ad-1',
+            creative: {
+              effective_object_story_id: 'page-1_100',
+              effective_instagram_media_id: 'ig-777',
+              thumbnail_url: 'https://cdn/1.jpg',
+            },
+          },
           { id: 'ad-2', creative: {} }, // creative present, no story/ig-media/thumbnail — dark post, no preview
           { id: 'ad-3' }, // no creative at all
         ],
@@ -275,13 +331,20 @@ describe('listAdsWithStoryIds', () => {
     const res = await listAdsWithStoryIds('123', 'utok', { fetchImpl });
     expect(res.ok).toBe(true);
     expect(res.data).toEqual([
-      { adId: 'ad-1', storyId: 'page-1_100', igMediaId: 'ig-777', thumbnailUrl: 'https://cdn/1.jpg' },
+      {
+        adId: 'ad-1',
+        storyId: 'page-1_100',
+        igMediaId: 'ig-777',
+        thumbnailUrl: 'https://cdn/1.jpg',
+      },
       { adId: 'ad-2', storyId: null, igMediaId: null, thumbnailUrl: null },
       { adId: 'ad-3', storyId: null, igMediaId: null, thumbnailUrl: null },
     ]);
     const calledUrl = decodeURIComponent((fetchImpl.mock.calls[0]?.[0] as string) ?? '');
     expect(calledUrl).toContain('/act_123/ads');
-    expect(calledUrl).toContain('id,creative{effective_object_story_id,effective_instagram_media_id,thumbnail_url}');
+    expect(calledUrl).toContain(
+      'id,creative{effective_object_story_id,effective_instagram_media_id,thumbnail_url}',
+    );
   });
 
   it('does not double-prefix an already act_-prefixed id', async () => {
@@ -300,14 +363,21 @@ describe('listAdsWithStoryIds', () => {
         // paging.next links do live) — listAdsWithStoryIds must re-derive it.
         const u = new URL(url);
         expect(u.searchParams.get('appsecret_proof')).toBeTruthy();
-        return jsonResponse({ data: [{ id: 'ad-2', creative: { effective_object_story_id: 'page-1_200' } }] });
+        return jsonResponse({
+          data: [{ id: 'ad-2', creative: { effective_object_story_id: 'page-1_200' } }],
+        });
       }
       return jsonResponse({
         data: [{ id: 'ad-1', creative: { effective_object_story_id: 'page-1_100' } }],
-        paging: { next: 'https://graph.facebook.com/v23.0/act_123/ads?after=xyz&access_token=utok' },
+        paging: {
+          next: 'https://graph.facebook.com/v23.0/act_123/ads?after=xyz&access_token=utok',
+        },
       });
     });
-    const res = await listAdsWithStoryIds('123', 'utok', { fetchImpl: fetchImpl as unknown as typeof fetch, appSecret: 'shh' });
+    const res = await listAdsWithStoryIds('123', 'utok', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      appSecret: 'shh',
+    });
     expect(res.ok).toBe(true);
     expect(res.data).toEqual([
       { adId: 'ad-1', storyId: 'page-1_100', igMediaId: null, thumbnailUrl: null },
@@ -319,19 +389,26 @@ describe('listAdsWithStoryIds', () => {
   it('tolerates a mid-pagination failure — returns what was collected so far, not an error', async () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
-      if (url.includes('after=xyz')) return jsonResponse({ error: { message: 'boom' } }, { ok: false, status: 500 });
+      if (url.includes('after=xyz'))
+        return jsonResponse({ error: { message: 'boom' } }, { ok: false, status: 500 });
       return jsonResponse({
         data: [{ id: 'ad-1', creative: { effective_object_story_id: 'page-1_100' } }],
         paging: { next: 'https://graph.facebook.com/v23.0/act_123/ads?after=xyz' },
       });
     });
-    const res = await listAdsWithStoryIds('123', 'utok', { fetchImpl: fetchImpl as unknown as typeof fetch });
+    const res = await listAdsWithStoryIds('123', 'utok', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
     expect(res.ok).toBe(true);
-    expect(res.data).toEqual([{ adId: 'ad-1', storyId: 'page-1_100', igMediaId: null, thumbnailUrl: null }]);
+    expect(res.data).toEqual([
+      { adId: 'ad-1', storyId: 'page-1_100', igMediaId: null, thumbnailUrl: null },
+    ]);
   });
 
   it('surfaces the first-page failure as an error', async () => {
-    const fetchImpl = mockFetch(jsonResponse({ error: { message: 'nope', code: 1 } }, { ok: false, status: 400 }));
+    const fetchImpl = mockFetch(
+      jsonResponse({ error: { message: 'nope', code: 1 } }, { ok: false, status: 400 }),
+    );
     const res = await listAdsWithStoryIds('123', 'utok', { fetchImpl });
     expect(res.ok).toBe(false);
   });
@@ -353,7 +430,9 @@ describe('listConversations', () => {
 describe('fetchNextPage', () => {
   it('resumes pagination from a raw paging.next URL', async () => {
     const fetchImpl = mockFetch(jsonResponse({ data: [{ id: 'page2' }] }));
-    const res = await fetchNextPage('https://graph.facebook.com/v23.0/me/accounts?after=xyz', { fetchImpl });
+    const res = await fetchNextPage('https://graph.facebook.com/v23.0/me/accounts?after=xyz', {
+      fetchImpl,
+    });
     expect(res.ok).toBe(true);
     expect(res.data).toEqual([{ id: 'page2' }]);
     expect(fetchImpl).toHaveBeenCalledWith(
@@ -361,15 +440,37 @@ describe('fetchNextPage', () => {
       expect.anything(),
     );
   });
+
+  it('restores a token removed from a durable paging cursor', async () => {
+    const fetchImpl = mockFetch(jsonResponse({ data: [{ id: 'page2' }] }));
+    await fetchNextPage('https://graph.facebook.com/v23.0/me/accounts?after=xyz', {
+      fetchImpl,
+      accessToken: 'restored-token',
+      appSecret: 'app-secret',
+    });
+
+    const calledUrl = new URL((fetchImpl.mock.calls[0]?.[0] as string) ?? '');
+    expect(calledUrl.searchParams.get('access_token')).toBe('restored-token');
+    expect(calledUrl.searchParams.get('appsecret_proof')).toMatch(/^[a-f0-9]{64}$/);
+  });
 });
 
 describe('exchangeIgCodeForToken', () => {
   it('POSTs a form-encoded body to api.instagram.com/oauth/access_token (not a GET-with-query-params)', async () => {
     const fetchImpl = vi.fn(async () =>
-      jsonResponse({ access_token: 'ig-short-lived', user_id: '17800000000000000', permissions: ['instagram_business_basic'] }),
+      jsonResponse({
+        access_token: 'ig-short-lived',
+        user_id: '17800000000000000',
+        permissions: ['instagram_business_basic'],
+      }),
     );
     const res = await exchangeIgCodeForToken(
-      { appId: 'ig-app', appSecret: 'ig-secret', code: 'ig-code', redirectUri: 'https://hub/api/meta/ig/callback' },
+      {
+        appId: 'ig-app',
+        appSecret: 'ig-secret',
+        code: 'ig-code',
+        redirectUri: 'https://hub/api/meta/ig/callback',
+      },
       { fetchImpl: fetchImpl as unknown as typeof fetch },
     );
     expect(res.ok).toBe(true);
@@ -388,9 +489,16 @@ describe('exchangeIgCodeForToken', () => {
   });
 
   it('surfaces a failed exchange without throwing', async () => {
-    const fetchImpl = vi.fn(async () => jsonResponse({ error_message: 'Invalid platform app' }, { ok: false, status: 400 }));
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ error_message: 'Invalid platform app' }, { ok: false, status: 400 }),
+    );
     const res = await exchangeIgCodeForToken(
-      { appId: 'ig-app', appSecret: 'ig-secret', code: 'bad', redirectUri: 'https://hub/api/meta/ig/callback' },
+      {
+        appId: 'ig-app',
+        appSecret: 'ig-secret',
+        code: 'bad',
+        redirectUri: 'https://hub/api/meta/ig/callback',
+      },
       { fetchImpl: fetchImpl as unknown as typeof fetch },
     );
     expect(res.ok).toBe(false);
@@ -400,8 +508,13 @@ describe('exchangeIgCodeForToken', () => {
 
 describe('exchangeIgLongLivedToken', () => {
   it('GETs graph.instagram.com/access_token, unversioned (no /v23.0/ segment)', async () => {
-    const fetchImpl = mockFetch(jsonResponse({ access_token: 'ig-long-lived', token_type: 'bearer', expires_in: 5_184_000 }));
-    const res = await exchangeIgLongLivedToken({ appSecret: 'ig-secret', shortToken: 'ig-short' }, { fetchImpl });
+    const fetchImpl = mockFetch(
+      jsonResponse({ access_token: 'ig-long-lived', token_type: 'bearer', expires_in: 5_184_000 }),
+    );
+    const res = await exchangeIgLongLivedToken(
+      { appSecret: 'ig-secret', shortToken: 'ig-short' },
+      { fetchImpl },
+    );
     expect(res.ok).toBe(true);
     expect(res.data?.access_token).toBe('ig-long-lived');
     expect(res.data?.expires_in).toBe(5_184_000);
@@ -416,7 +529,9 @@ describe('exchangeIgLongLivedToken', () => {
 
 describe('refreshIgToken', () => {
   it('GETs the DISTINCT /refresh_access_token path, unversioned', async () => {
-    const fetchImpl = mockFetch(jsonResponse({ access_token: 'ig-refreshed', expires_in: 5_184_000 }));
+    const fetchImpl = mockFetch(
+      jsonResponse({ access_token: 'ig-refreshed', expires_in: 5_184_000 }),
+    );
     const res = await refreshIgToken({ token: 'ig-current' }, { fetchImpl });
     expect(res.ok).toBe(true);
     expect(res.data?.access_token).toBe('ig-refreshed');
@@ -439,9 +554,16 @@ describe('refreshIgToken', () => {
 describe('versioned opt — graph.instagram.com is unversioned, graph.facebook.com stays versioned', () => {
   it('listIgMedia against graph.instagram.com with versioned:false has no /v23.0/ segment', async () => {
     const fetchImpl = mockFetch(jsonResponse({ data: [] }));
-    await listIgMedia('ig-user-1', 'ig-token', {}, { fetchImpl, baseUrl: 'https://graph.instagram.com', versioned: false });
+    await listIgMedia(
+      'ig-user-1',
+      'ig-token',
+      {},
+      { fetchImpl, baseUrl: 'https://graph.instagram.com', versioned: false },
+    );
     const calledUrl = (fetchImpl.mock.calls[0]?.[0] as string) ?? '';
-    expect(calledUrl).toBe(`https://graph.instagram.com/ig-user-1/media?fields=${encodeURIComponent('id,caption,media_type,permalink,timestamp,like_count,comments_count,media_url,thumbnail_url')}&access_token=ig-token`);
+    expect(calledUrl).toBe(
+      `https://graph.instagram.com/ig-user-1/media?fields=${encodeURIComponent('id,caption,media_type,permalink,timestamp,like_count,comments_count,media_url,thumbnail_url')}&access_token=ig-token`,
+    );
     expect(calledUrl).not.toContain('/v23.0/');
   });
 
@@ -455,15 +577,15 @@ describe('versioned opt — graph.instagram.com is unversioned, graph.facebook.c
 
 describe('pickPreviewUrl', () => {
   it('prefers thumbnail_url for VIDEO', () => {
-    expect(pickPreviewUrl({ media_type: 'VIDEO', media_url: 'video.mp4', thumbnail_url: 'thumb.jpg' })).toBe(
-      'thumb.jpg',
-    );
+    expect(
+      pickPreviewUrl({ media_type: 'VIDEO', media_url: 'video.mp4', thumbnail_url: 'thumb.jpg' }),
+    ).toBe('thumb.jpg');
   });
 
   it('prefers thumbnail_url for REELS', () => {
-    expect(pickPreviewUrl({ media_type: 'REELS', media_url: 'video.mp4', thumbnail_url: 'thumb.jpg' })).toBe(
-      'thumb.jpg',
-    );
+    expect(
+      pickPreviewUrl({ media_type: 'REELS', media_url: 'video.mp4', thumbnail_url: 'thumb.jpg' }),
+    ).toBe('thumb.jpg');
   });
 
   it('falls back to media_url for VIDEO/REELS when no thumbnail_url', () => {
@@ -471,9 +593,9 @@ describe('pickPreviewUrl', () => {
   });
 
   it('uses media_url for IMAGE', () => {
-    expect(pickPreviewUrl({ media_type: 'IMAGE', media_url: 'img.jpg', thumbnail_url: 'ignored.jpg' })).toBe(
-      'img.jpg',
-    );
+    expect(
+      pickPreviewUrl({ media_type: 'IMAGE', media_url: 'img.jpg', thumbnail_url: 'ignored.jpg' }),
+    ).toBe('img.jpg');
   });
 
   it('uses media_url for CAROUSEL_ALBUM', () => {
@@ -491,7 +613,9 @@ describe('pickPreviewUrl', () => {
 
 describe('igMediaDetail', () => {
   it('hits the unversioned IG host with the media/children fields, no appsecret_proof', async () => {
-    const fetchImpl = mockFetch(jsonResponse({ media_type: 'CAROUSEL_ALBUM', children: { data: [] } }));
+    const fetchImpl = mockFetch(
+      jsonResponse({ media_type: 'CAROUSEL_ALBUM', children: { data: [] } }),
+    );
     const res = await igMediaDetail('media-1', 'ig-token', { fetchImpl });
     expect(res.ok).toBe(true);
     const calledUrl = (fetchImpl.mock.calls[0]?.[0] as string) ?? '';
@@ -502,7 +626,9 @@ describe('igMediaDetail', () => {
   });
 
   it('surfaces a graph error (e.g. permission denied) as ok:false', async () => {
-    const fetchImpl = mockFetch(jsonResponse({ error: { message: 'denied', code: 10 } }, { ok: false, status: 400 }));
+    const fetchImpl = mockFetch(
+      jsonResponse({ error: { message: 'denied', code: 10 } }, { ok: false, status: 400 }),
+    );
     const res = await igMediaDetail('media-1', 'ig-token', { fetchImpl });
     expect(res.ok).toBe(false);
   });
@@ -528,7 +654,9 @@ describe('fbPostAttachments / fbPostFullPicture', () => {
 
 describe('igMediaComments', () => {
   it('hits the unversioned IG host /comments edge with the reply fields, no appsecret_proof', async () => {
-    const fetchImpl = mockFetch(jsonResponse({ data: [{ id: 'c1', text: 'hi', username: 'a', like_count: 1 }] }));
+    const fetchImpl = mockFetch(
+      jsonResponse({ data: [{ id: 'c1', text: 'hi', username: 'a', like_count: 1 }] }),
+    );
     const res = await igMediaComments('media-1', 'ig-token', { fetchImpl });
     expect(res.ok).toBe(true);
     expect(res.data).toEqual([{ id: 'c1', text: 'hi', username: 'a', like_count: 1 }]);
@@ -540,7 +668,9 @@ describe('igMediaComments', () => {
   });
 
   it('surfaces a graph error (e.g. permission denied) as ok:false', async () => {
-    const fetchImpl = mockFetch(jsonResponse({ error: { message: 'denied', code: 10 } }, { ok: false, status: 400 }));
+    const fetchImpl = mockFetch(
+      jsonResponse({ error: { message: 'denied', code: 10 } }, { ok: false, status: 400 }),
+    );
     const res = await igMediaComments('media-1', 'ig-token', { fetchImpl });
     expect(res.ok).toBe(false);
   });
@@ -548,17 +678,23 @@ describe('igMediaComments', () => {
 
 describe('fbPostComments', () => {
   it('hits the versioned FB host /comments edge with from{name} field', async () => {
-    const fetchImpl = mockFetch(jsonResponse({ data: [{ id: 'c1', message: 'hey', from: { name: 'Dan' } }] }));
+    const fetchImpl = mockFetch(
+      jsonResponse({ data: [{ id: 'c1', message: 'hey', from: { name: 'Dan' } }] }),
+    );
     const res = await fbPostComments('123_456', 'page-token', { fetchImpl });
     expect(res.ok).toBe(true);
     expect(res.data).toEqual([{ id: 'c1', message: 'hey', from: { name: 'Dan' } }]);
     const calledUrl = (fetchImpl.mock.calls[0]?.[0] as string) ?? '';
     expect(calledUrl).toContain('/v23.0/123_456/comments');
-    expect(calledUrl).toContain(encodeURIComponent('id,message,from{name},created_time,like_count'));
+    expect(calledUrl).toContain(
+      encodeURIComponent('id,message,from{name},created_time,like_count'),
+    );
   });
 
   it('surfaces a permission denial as ok:false (expected — pages_read_user_content)', async () => {
-    const fetchImpl = mockFetch(jsonResponse({ error: { message: 'denied', code: 10 } }, { ok: false, status: 400 }));
+    const fetchImpl = mockFetch(
+      jsonResponse({ error: { message: 'denied', code: 10 } }, { ok: false, status: 400 }),
+    );
     const res = await fbPostComments('123_456', 'page-token', { fetchImpl });
     expect(res.ok).toBe(false);
   });
@@ -568,10 +704,15 @@ describe('timeout handling', () => {
   it('surfaces an abort as a network error, not a throw', async () => {
     const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
       return new Promise<Response>((_resolve, reject) => {
-        init?.signal?.addEventListener('abort', () => reject(new DOMException('timeout', 'TimeoutError')));
+        init?.signal?.addEventListener('abort', () =>
+          reject(new DOMException('timeout', 'TimeoutError')),
+        );
       });
     });
-    const res = await listAdAccounts('utok', { fetchImpl: fetchImpl as unknown as typeof fetch, timeoutMs: 1 });
+    const res = await listAdAccounts('utok', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      timeoutMs: 1,
+    });
     expect(res.ok).toBe(false);
     expect(res.status).toBe(0);
   });

--- a/src/server/services/meta/graph-read.ts
+++ b/src/server/services/meta/graph-read.ts
@@ -86,7 +86,11 @@ function resolveOpts(opts: GraphOpts): ResolvedOpts {
   };
 }
 
-function buildUrl(path: string, params: Record<string, string | number | undefined>, o: ResolvedOpts): string {
+function buildUrl(
+  path: string,
+  params: Record<string, string | number | undefined>,
+  o: ResolvedOpts,
+): string {
   const qs = new URLSearchParams();
   for (const [k, v] of Object.entries(params)) {
     if (v !== undefined) qs.set(k, String(v));
@@ -142,7 +146,9 @@ function classifyGraphError(body: unknown): string {
   if (!err) return 'graph request failed';
   if (err.code === 190) return 'token_expired';
   const suffix =
-    err.code != null ? ` (code ${err.code}${err.error_subcode != null ? ` subcode ${err.error_subcode}` : ''})` : '';
+    err.code != null
+      ? ` (code ${err.code}${err.error_subcode != null ? ` subcode ${err.error_subcode}` : ''})`
+      : '';
   return `${err.message ?? 'graph error'}${suffix}`;
 }
 
@@ -162,7 +168,10 @@ function extractUsage(res: Response): unknown {
 
 type RawResult = { ok: boolean; status: number; body?: unknown; error?: string; usage?: unknown };
 
-async function graphRequest(url: string, base: Pick<ResolvedOpts, 'fetchImpl' | 'timeoutMs'>): Promise<RawResult> {
+async function graphRequest(
+  url: string,
+  base: Pick<ResolvedOpts, 'fetchImpl' | 'timeoutMs'>,
+): Promise<RawResult> {
   let res: Response;
   try {
     res = await base.fetchImpl(url, { signal: AbortSignal.timeout(base.timeoutMs) });
@@ -191,18 +200,24 @@ function unwrapList<T>(body: unknown): { data: T[]; nextCursor?: string } {
  */
 export async function fetchNextPage<T = unknown>(
   nextUrl: string,
-  opts: Pick<GraphOpts, 'fetchImpl' | 'timeoutMs' | 'appSecret'> = {},
+  opts: Pick<GraphOpts, 'fetchImpl' | 'timeoutMs' | 'appSecret'> & {
+    accessToken?: string;
+  } = {},
 ): Promise<GraphResult<T[]>> {
   const base = { fetchImpl: opts.fetchImpl ?? fetch, timeoutMs: opts.timeoutMs ?? 15_000 };
   let url = nextUrl;
-  if (opts.appSecret) {
+  if (opts.accessToken || opts.appSecret) {
     try {
       const u = new URL(nextUrl);
-      const token = u.searchParams.get('access_token');
-      if (token && !u.searchParams.get('appsecret_proof')) {
-        u.searchParams.set('appsecret_proof', createHmac('sha256', opts.appSecret).update(token).digest('hex'));
-        url = u.toString();
+      if (opts.accessToken) u.searchParams.set('access_token', opts.accessToken);
+      const token = opts.accessToken ?? u.searchParams.get('access_token');
+      if (token && opts.appSecret) {
+        u.searchParams.set(
+          'appsecret_proof',
+          createHmac('sha256', opts.appSecret).update(token).digest('hex'),
+        );
       }
+      url = u.toString();
     } catch {
       // unparseable link — send as-is and let Graph report the real problem
     }
@@ -226,7 +241,12 @@ export async function exchangeCodeForToken(
   const o = resolveOpts(opts);
   const url = buildUrl(
     'oauth/access_token',
-    { client_id: params.appId, client_secret: params.appSecret, redirect_uri: params.redirectUri, code: params.code },
+    {
+      client_id: params.appId,
+      client_secret: params.appSecret,
+      redirect_uri: params.redirectUri,
+      code: params.code,
+    },
     o,
   );
   const res = await graphRequest(url, o);
@@ -315,7 +335,11 @@ export async function exchangeIgLongLivedToken(
   const o = resolveOpts({ baseUrl: 'https://graph.instagram.com', versioned: false, ...opts });
   const url = buildUrl(
     'access_token',
-    { grant_type: 'ig_exchange_token', client_secret: params.appSecret, access_token: params.shortToken },
+    {
+      grant_type: 'ig_exchange_token',
+      client_secret: params.appSecret,
+      access_token: params.shortToken,
+    },
     o,
   );
   const res = await graphRequest(url, o);
@@ -334,7 +358,11 @@ export async function refreshIgToken(
   opts: GraphOpts = {},
 ): Promise<GraphResult<IgLongLivedToken>> {
   const o = resolveOpts({ baseUrl: 'https://graph.instagram.com', versioned: false, ...opts });
-  const url = buildUrl('refresh_access_token', { grant_type: 'ig_refresh_token', access_token: params.token }, o);
+  const url = buildUrl(
+    'refresh_access_token',
+    { grant_type: 'ig_refresh_token', access_token: params.token },
+    o,
+  );
   const res = await graphRequest(url, o);
   if (!res.ok) return { ok: false, status: res.status, error: res.error, usage: res.usage };
   return { ok: true, status: res.status, data: res.body as IgLongLivedToken, usage: res.usage };
@@ -358,7 +386,10 @@ export async function listPagesWithTokens(
   const o = resolveOpts(opts);
   const url = buildUrl(
     'me/accounts',
-    { fields: 'id,name,access_token,instagram_business_account{id,username}', access_token: userToken },
+    {
+      fields: 'id,name,access_token,instagram_business_account{id,username}',
+      access_token: userToken,
+    },
     o,
   );
   const res = await graphRequest(url, o);
@@ -369,9 +400,16 @@ export async function listPagesWithTokens(
 
 export type AdAccount = { id: string; name?: string; currency?: string; account_status?: number };
 
-export async function listAdAccounts(userToken: string, opts: GraphOpts = {}): Promise<GraphResult<AdAccount[]>> {
+export async function listAdAccounts(
+  userToken: string,
+  opts: GraphOpts = {},
+): Promise<GraphResult<AdAccount[]>> {
   const o = resolveOpts(opts);
-  const url = buildUrl('me/adaccounts', { fields: 'id,name,currency,account_status', access_token: userToken }, o);
+  const url = buildUrl(
+    'me/adaccounts',
+    { fields: 'id,name,currency,account_status', access_token: userToken },
+    o,
+  );
   const res = await graphRequest(url, o);
   if (!res.ok) return { ok: false, status: res.status, error: res.error, usage: res.usage };
   const { data, nextCursor } = unwrapList<AdAccount>(res.body);
@@ -477,14 +515,24 @@ export async function listPagePosts(
   return { ok: true, status: res.status, data, nextCursor, usage: res.usage };
 }
 
-const DEFAULT_POST_METRICS = ['post_impressions', 'post_impressions_unique', 'post_clicks', 'post_reactions_by_type_total'];
+const DEFAULT_POST_METRICS = [
+  'post_impressions',
+  'post_impressions_unique',
+  'post_clicks',
+  'post_reactions_by_type_total',
+];
 
 export async function postInsights(
   postId: string,
   pageToken: string,
   opts: GraphOpts & { metrics?: string[] } = {},
 ): Promise<GraphResult<MetricInsight[]> & { failedMetrics?: string[] }> {
-  return fetchMetricsWithFallback(`${postId}/insights`, pageToken, opts.metrics ?? DEFAULT_POST_METRICS, opts);
+  return fetchMetricsWithFallback(
+    `${postId}/insights`,
+    pageToken,
+    opts.metrics ?? DEFAULT_POST_METRICS,
+    opts,
+  );
 }
 
 export type IgMedia = {
@@ -502,7 +550,8 @@ export type IgMedia = {
 };
 
 // media_url/thumbnail_url verified live 2026-07-05 under instagram_business_basic, no appsecret_proof (spec §5).
-const IG_MEDIA_FIELDS = 'id,caption,media_type,permalink,timestamp,like_count,comments_count,media_url,thumbnail_url';
+const IG_MEDIA_FIELDS =
+  'id,caption,media_type,permalink,timestamp,like_count,comments_count,media_url,thumbnail_url';
 
 /**
  * Which URL to render as a post's preview thumbnail (spec §5/§7). VIDEO/REELS
@@ -528,7 +577,11 @@ export async function listIgMedia(
   opts: GraphOpts = {},
 ): Promise<GraphResult<IgMedia[]>> {
   const o = resolveOpts(opts);
-  const url = buildUrl(`${igId}/media`, { fields: IG_MEDIA_FIELDS, since: params.since, access_token: pageToken }, o);
+  const url = buildUrl(
+    `${igId}/media`,
+    { fields: IG_MEDIA_FIELDS, since: params.since, access_token: pageToken },
+    o,
+  );
   const res = await graphRequest(url, o);
   if (!res.ok) return { ok: false, status: res.status, error: res.error, usage: res.usage };
   const { data, nextCursor } = unwrapList<IgMedia>(res.body);
@@ -552,7 +605,10 @@ export async function igMediaInsights(
   mediaType: string,
   opts: GraphOpts & { metrics?: string[] } = {},
 ): Promise<GraphResult<MetricInsight[]> & { failedMetrics?: string[] }> {
-  const metrics = opts.metrics ?? IG_MEDIA_METRICS_BY_TYPE[mediaType.toUpperCase()] ?? IG_MEDIA_METRICS_BY_TYPE.IMAGE;
+  const metrics =
+    opts.metrics ??
+    IG_MEDIA_METRICS_BY_TYPE[mediaType.toUpperCase()] ??
+    IG_MEDIA_METRICS_BY_TYPE.IMAGE;
   return fetchMetricsWithFallback(`${mediaId}/insights`, pageToken, metrics, opts);
 }
 
@@ -610,7 +666,11 @@ export async function adInsights(
 
 export type AdWithStory = {
   id?: string;
-  creative?: { effective_object_story_id?: string; effective_instagram_media_id?: string; thumbnail_url?: string };
+  creative?: {
+    effective_object_story_id?: string;
+    effective_instagram_media_id?: string;
+    thumbnail_url?: string;
+  };
 };
 
 export type AdStoryLink = {
@@ -633,7 +693,8 @@ export type AdStoryLink = {
 // expansion like this one vs. only working as a top-level query param on a
 // direct creative-node GET. Plain field, so the default (often small/cropped)
 // thumbnail size — acceptable for 40px table cells, revisit if larger is needed.
-const AD_FIELDS = 'id,creative{effective_object_story_id,effective_instagram_media_id,thumbnail_url}';
+const AD_FIELDS =
+  'id,creative{effective_object_story_id,effective_instagram_media_id,thumbnail_url}';
 
 /**
  * Paginates `act_X/ads` and returns every ad's id alongside its creative's
@@ -652,7 +713,11 @@ export async function listAdsWithStoryIds(
 ): Promise<GraphResult<AdStoryLink[]>> {
   const o = resolveOpts(opts);
   const accountPath = adAccountId.startsWith('act_') ? adAccountId : `act_${adAccountId}`;
-  const url = buildUrl(`${accountPath}/ads`, { fields: AD_FIELDS, limit: 100, access_token: userToken }, o);
+  const url = buildUrl(
+    `${accountPath}/ads`,
+    { fields: AD_FIELDS, limit: 100, access_token: userToken },
+    o,
+  );
   const res = await graphRequest(url, o);
   if (!res.ok) return { ok: false, status: res.status, error: res.error, usage: res.usage };
 
@@ -676,7 +741,11 @@ export async function listAdsWithStoryIds(
     // Some paging.next links don't echo the original appsecret_proof (live-verified
     // on /insights) — re-derive it from the link's own access_token, same as every
     // other fetchNextPage call site in this file.
-    const page = await fetchNextPage<AdWithStory>(nextCursor, { fetchImpl: o.fetchImpl, timeoutMs: o.timeoutMs, appSecret: o.appSecret });
+    const page = await fetchNextPage<AdWithStory>(nextCursor, {
+      fetchImpl: o.fetchImpl,
+      timeoutMs: o.timeoutMs,
+      appSecret: o.appSecret,
+    });
     if (!page.ok) break; // tolerate a mid-pagination failure — return what's collected so far
     for (const ad of page.data ?? []) {
       const link = toLink(ad);
@@ -699,7 +768,8 @@ export type IgMediaDetail = {
   children?: { data?: Array<{ media_type?: string; media_url?: string; thumbnail_url?: string }> };
 };
 
-const IG_MEDIA_DETAIL_FIELDS = 'media_type,media_url,thumbnail_url,children{media_type,media_url,thumbnail_url}';
+const IG_MEDIA_DETAIL_FIELDS =
+  'media_type,media_url,thumbnail_url,children{media_type,media_url,thumbnail_url}';
 
 /** IG media node + carousel children, for the post-detail "rich media" enrichment. Unversioned host, no appsecret_proof (spec §5.3). */
 export async function igMediaDetail(
@@ -715,7 +785,11 @@ export async function igMediaDetail(
 }
 
 export type FbAttachmentMedia = { image?: { src?: string }; source?: string };
-export type FbAttachment = { media_type?: string; media?: FbAttachmentMedia; subattachments?: { data?: FbAttachment[] } };
+export type FbAttachment = {
+  media_type?: string;
+  media?: FbAttachmentMedia;
+  subattachments?: { data?: FbAttachment[] };
+};
 export type FbAttachmentsResponse = { attachments?: { data?: FbAttachment[] } };
 
 /**
@@ -730,10 +804,19 @@ export async function fbPostAttachments(
   opts: GraphOpts = {},
 ): Promise<GraphResult<FbAttachmentsResponse>> {
   const o = resolveOpts(opts);
-  const url = buildUrl(postId, { fields: 'attachments{media,subattachments}', access_token: pageToken }, o);
+  const url = buildUrl(
+    postId,
+    { fields: 'attachments{media,subattachments}', access_token: pageToken },
+    o,
+  );
   const res = await graphRequest(url, o);
   if (!res.ok) return { ok: false, status: res.status, error: res.error, usage: res.usage };
-  return { ok: true, status: res.status, data: res.body as FbAttachmentsResponse, usage: res.usage };
+  return {
+    ok: true,
+    status: res.status,
+    data: res.body as FbAttachmentsResponse,
+    usage: res.usage,
+  };
 }
 
 export type FbFullPicture = { full_picture?: string };
@@ -777,7 +860,11 @@ export async function igMediaComments(
   opts: Pick<GraphOpts, 'fetchImpl' | 'timeoutMs'> = {},
 ): Promise<GraphResult<IgComment[]>> {
   const o = resolveOpts({ baseUrl: 'https://graph.instagram.com', versioned: false, ...opts });
-  const url = buildUrl(`${mediaId}/comments`, { fields: IG_COMMENT_FIELDS, access_token: token }, o);
+  const url = buildUrl(
+    `${mediaId}/comments`,
+    { fields: IG_COMMENT_FIELDS, access_token: token },
+    o,
+  );
   const res = await graphRequest(url, o);
   if (!res.ok) return { ok: false, status: res.status, error: res.error, usage: res.usage };
   const { data } = unwrapList<IgComment>(res.body);
@@ -806,7 +893,11 @@ export async function fbPostComments(
   opts: GraphOpts = {},
 ): Promise<GraphResult<FbComment[]>> {
   const o = resolveOpts(opts);
-  const url = buildUrl(`${postId}/comments`, { fields: FB_COMMENT_FIELDS, access_token: pageToken }, o);
+  const url = buildUrl(
+    `${postId}/comments`,
+    { fields: FB_COMMENT_FIELDS, access_token: pageToken },
+    o,
+  );
   const res = await graphRequest(url, o);
   if (!res.ok) return { ok: false, status: res.status, error: res.error, usage: res.usage };
   const { data } = unwrapList<FbComment>(res.body);
@@ -822,7 +913,13 @@ export type Conversation = {
   participants?: unknown;
   updated_time?: string;
   messages?: {
-    data?: Array<{ id: string; from?: unknown; to?: unknown; message?: string; created_time?: string }>;
+    data?: Array<{
+      id: string;
+      from?: unknown;
+      to?: unknown;
+      message?: string;
+      created_time?: string;
+    }>;
   };
 };
 
@@ -868,7 +965,12 @@ export async function getIgLoginUser(
   const b = (res.body ?? {}) as { user_id?: unknown; username?: unknown };
   const userId = b.user_id != null ? String(b.user_id) : '';
   if (!userId) return { ok: false, status: res.status, error: 'no user_id', usage: res.usage };
-  return { ok: true, status: res.status, data: { userId, username: b.username != null ? String(b.username) : null }, usage: res.usage };
+  return {
+    ok: true,
+    status: res.status,
+    data: { userId, username: b.username != null ? String(b.username) : null },
+    usage: res.usage,
+  };
 }
 
 type RawIgConvo = {
@@ -876,7 +978,14 @@ type RawIgConvo = {
   updated_time?: string;
   // `name` accepted too so normalizeIgConvo is idempotent (see below).
   participants?: { data?: Array<{ id?: string; username?: string; name?: string }> };
-  messages?: { data?: Array<{ id: string; from?: { id?: string; username?: string; name?: string }; message?: string; created_time?: string }> };
+  messages?: {
+    data?: Array<{
+      id: string;
+      from?: { id?: string; username?: string; name?: string };
+      message?: string;
+      created_time?: string;
+    }>;
+  };
 };
 
 /**
@@ -895,7 +1004,8 @@ export async function listIgLoginConversations(
     'me/conversations',
     {
       platform: 'instagram',
-      fields: 'updated_time,participants{id,username},messages{id,from{id,username},message,created_time}',
+      fields:
+        'updated_time,participants{id,username},messages{id,from{id,username},message,created_time}',
       access_token: token,
     },
     o,
@@ -919,7 +1029,9 @@ export function normalizeIgConvo(c: RawIgConvo): Conversation {
   return {
     id: c.id,
     updated_time: c.updated_time,
-    participants: { data: (c.participants?.data ?? []).map((p) => ({ id: p.id, name: p.name ?? p.username })) },
+    participants: {
+      data: (c.participants?.data ?? []).map((p) => ({ id: p.id, name: p.name ?? p.username })),
+    },
     messages: {
       data: (c.messages?.data ?? []).map((m) => ({
         id: m.id,

--- a/src/server/services/meta/meta-sync-jobs.service.ts
+++ b/src/server/services/meta/meta-sync-jobs.service.ts
@@ -127,22 +127,25 @@ export async function enqueueJob(
  * (mirrors finance's findResumableJobs) — the caller builds a per-org CoreCtx
  * and does all real work through withOrgCore.
  *
- * The tail lane re-enqueues one job per connected org on every tick, so a
- * single priority ordering would let it own every claim slot once there are
- * more orgs than slots and freeze posts/ads/messages forever. Each side is
- * therefore drawn separately: the tail lane leads with half the slots
- * reserved, backlog lanes take the rest, and whichever side is short gives
- * its unused capacity to the other.
+ * The two lanes are drawn under SEPARATE budgets rather than one shared limit,
+ * because they cost wildly different amounts and starve each other in opposite
+ * directions. A tail slice is one Graph page per target; a backlog slice
+ * paginates up to 150 posts / 100 conversations / 90 ad rows with a 55s
+ * per-request timeout. One shared limit either lets the tail lane (re-enqueued
+ * for every org on every tick) freeze posts/ads/messages forever, or lets the
+ * backlog lane blow up the tick's wall clock when it is scaled for tail
+ * coverage. Sizing them independently is what keeps both bounded.
  */
 export async function findDueJobs(
-  limit = 3,
+  tailLimit = 3,
+  backlogLimit = 3,
 ): Promise<Array<{ jobId: string; orgId: string; kind: string }>> {
   const db = getCoreDb();
   const due = or(
     eq(metaSyncJobs.status, 'queued'),
     and(eq(metaSyncJobs.status, 'running'), lt(metaSyncJobs.startedAt, staleClause)),
   );
-  const lane = (tail: boolean) =>
+  const lane = (tail: boolean, limit: number) =>
     db
       .select({ jobId: metaSyncJobs.id, orgId: metaSyncJobs.orgId, kind: metaSyncJobs.kind })
       .from(metaSyncJobs)
@@ -156,10 +159,9 @@ export async function findDueJobs(
         sql`case when ${metaSyncJobs.kind} = 'messages' then 0 else 1 end`,
         metaSyncJobs.createdAt,
       )
-      .limit(limit);
-  const [tail, backlog] = await Promise.all([lane(true), lane(false)]);
-  const reserved = Math.max(1, Math.floor(limit / 2));
-  return [...tail.slice(0, reserved), ...backlog, ...tail.slice(reserved)].slice(0, limit);
+      .limit(Math.max(0, Math.trunc(limit)));
+  const [tail, backlog] = await Promise.all([lane(true, tailLimit), lane(false, backlogLimit)]);
+  return [...tail, ...backlog];
 }
 
 /** Keep the high-frequency freshness lane bounded without touching active

--- a/src/server/services/meta/meta-sync-jobs.service.ts
+++ b/src/server/services/meta/meta-sync-jobs.service.ts
@@ -142,6 +142,7 @@ export async function findDueJobs(
     )
     .orderBy(
       sql`case
+        when ${metaSyncJobs.createdAt} < now() - interval '15 minutes' then 0
         when ${metaSyncJobs.kind} = 'messages_tail' then 0
         when ${metaSyncJobs.kind} = 'messages' then 1
         else 2

--- a/src/server/services/meta/meta-sync-jobs.service.ts
+++ b/src/server/services/meta/meta-sync-jobs.service.ts
@@ -47,7 +47,13 @@ export function getLatestSucceededJob(ctx: CoreCtx, kind: string): Promise<MetaS
     const [row] = await tx
       .select()
       .from(metaSyncJobs)
-      .where(and(eq(metaSyncJobs.orgId, ctx.tenantId), eq(metaSyncJobs.kind, kind), eq(metaSyncJobs.status, 'succeeded')))
+      .where(
+        and(
+          eq(metaSyncJobs.orgId, ctx.tenantId),
+          eq(metaSyncJobs.kind, kind),
+          eq(metaSyncJobs.status, 'succeeded'),
+        ),
+      )
       .orderBy(desc(metaSyncJobs.createdAt))
       .limit(1);
     return row ?? null;
@@ -96,7 +102,13 @@ export async function enqueueJob(
     return await withOrgCore(ctx, async (tx) => {
       const [row] = await tx
         .insert(metaSyncJobs)
-        .values({ orgId: ctx.tenantId, kind, status: 'queued', since: opts.since ?? null, until: opts.until ?? null })
+        .values({
+          orgId: ctx.tenantId,
+          kind,
+          status: 'queued',
+          since: opts.since ?? null,
+          until: opts.until ?? null,
+        })
         .returning();
       return row;
     });
@@ -115,13 +127,27 @@ export async function enqueueJob(
  * (mirrors finance's findResumableJobs) — the caller builds a per-org CoreCtx
  * and does all real work through withOrgCore.
  */
-export async function findDueJobs(limit = 3): Promise<Array<{ jobId: string; orgId: string; kind: string }>> {
+export async function findDueJobs(
+  limit = 3,
+): Promise<Array<{ jobId: string; orgId: string; kind: string }>> {
   const db = getCoreDb();
   const rows = await db
     .select({ jobId: metaSyncJobs.id, orgId: metaSyncJobs.orgId, kind: metaSyncJobs.kind })
     .from(metaSyncJobs)
-    .where(or(eq(metaSyncJobs.status, 'queued'), and(eq(metaSyncJobs.status, 'running'), lt(metaSyncJobs.startedAt, staleClause))))
-    .orderBy(metaSyncJobs.createdAt)
+    .where(
+      or(
+        eq(metaSyncJobs.status, 'queued'),
+        and(eq(metaSyncJobs.status, 'running'), lt(metaSyncJobs.startedAt, staleClause)),
+      ),
+    )
+    .orderBy(
+      sql`case
+        when ${metaSyncJobs.kind} = 'messages_tail' then 0
+        when ${metaSyncJobs.kind} = 'messages' then 1
+        else 2
+      end`,
+      metaSyncJobs.createdAt,
+    )
     .limit(limit);
   return rows;
 }
@@ -136,7 +162,10 @@ export async function claimJob(ctx: CoreCtx, jobId: string): Promise<boolean> {
         and(
           eq(metaSyncJobs.id, jobId),
           eq(metaSyncJobs.orgId, ctx.tenantId),
-          or(eq(metaSyncJobs.status, 'queued'), and(eq(metaSyncJobs.status, 'running'), lt(metaSyncJobs.startedAt, staleClause))),
+          or(
+            eq(metaSyncJobs.status, 'queued'),
+            and(eq(metaSyncJobs.status, 'running'), lt(metaSyncJobs.startedAt, staleClause)),
+          ),
         ),
       )
       .returning({ id: metaSyncJobs.id });

--- a/src/server/services/meta/meta-sync-jobs.service.ts
+++ b/src/server/services/meta/meta-sync-jobs.service.ts
@@ -142,7 +142,6 @@ export async function findDueJobs(
     )
     .orderBy(
       sql`case
-        when ${metaSyncJobs.createdAt} < now() - interval '15 minutes' then 0
         when ${metaSyncJobs.kind} = 'messages_tail' then 0
         when ${metaSyncJobs.kind} = 'messages' then 1
         else 2
@@ -151,6 +150,31 @@ export async function findDueJobs(
     )
     .limit(limit);
   return rows;
+}
+
+/** Keep the high-frequency freshness lane bounded without touching active
+ * work or the recent audit window. Runs on the bypass-RLS scheduler
+ * connection for the same cross-org reason as findDueJobs. */
+export async function pruneTerminalTailJobs(olderThanDays = 7, limit = 2000): Promise<number> {
+  const days = Math.min(365, Math.max(1, Math.trunc(olderThanDays)));
+  const rowLimit = Math.min(10_000, Math.max(1, Math.trunc(limit)));
+  const db = getCoreDb();
+  const deleted = (await db.execute(sql`
+    with doomed as (
+      select id
+      from meta_sync_jobs
+      where kind = 'messages_tail'
+        and status in ('succeeded', 'failed')
+        and finished_at < now() - (${days} * interval '1 day')
+      order by finished_at
+      limit ${rowLimit}
+    )
+    delete from meta_sync_jobs job
+    using doomed
+    where job.id = doomed.id
+    returning job.id
+  `)) as unknown as Array<{ id: string }>;
+  return deleted.length;
 }
 
 /** Flip queued→running, or re-claim a stuck running job past STALE_MS. */

--- a/src/server/services/meta/meta-sync-jobs.service.ts
+++ b/src/server/services/meta/meta-sync-jobs.service.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, lt, or, sql } from 'drizzle-orm';
+import { and, desc, eq, lt, ne, or, sql } from 'drizzle-orm';
 import { withOrgCore } from '$server/db/with-org-core';
 import { getCoreDb } from '$server/db/pg-client';
 import type { CoreCtx } from '$server/auth/core-ctx';
@@ -126,30 +126,40 @@ export async function enqueueJob(
  * STALE_MS, across ALL orgs. Runs on the bare bypass-RLS connection BY DESIGN
  * (mirrors finance's findResumableJobs) — the caller builds a per-org CoreCtx
  * and does all real work through withOrgCore.
+ *
+ * The tail lane re-enqueues one job per connected org on every tick, so a
+ * single priority ordering would let it own every claim slot once there are
+ * more orgs than slots and freeze posts/ads/messages forever. Each side is
+ * therefore drawn separately: the tail lane leads with half the slots
+ * reserved, backlog lanes take the rest, and whichever side is short gives
+ * its unused capacity to the other.
  */
 export async function findDueJobs(
   limit = 3,
 ): Promise<Array<{ jobId: string; orgId: string; kind: string }>> {
   const db = getCoreDb();
-  const rows = await db
-    .select({ jobId: metaSyncJobs.id, orgId: metaSyncJobs.orgId, kind: metaSyncJobs.kind })
-    .from(metaSyncJobs)
-    .where(
-      or(
-        eq(metaSyncJobs.status, 'queued'),
-        and(eq(metaSyncJobs.status, 'running'), lt(metaSyncJobs.startedAt, staleClause)),
-      ),
-    )
-    .orderBy(
-      sql`case
-        when ${metaSyncJobs.kind} = 'messages_tail' then 0
-        when ${metaSyncJobs.kind} = 'messages' then 1
-        else 2
-      end`,
-      metaSyncJobs.createdAt,
-    )
-    .limit(limit);
-  return rows;
+  const due = or(
+    eq(metaSyncJobs.status, 'queued'),
+    and(eq(metaSyncJobs.status, 'running'), lt(metaSyncJobs.startedAt, staleClause)),
+  );
+  const lane = (tail: boolean) =>
+    db
+      .select({ jobId: metaSyncJobs.id, orgId: metaSyncJobs.orgId, kind: metaSyncJobs.kind })
+      .from(metaSyncJobs)
+      .where(
+        and(
+          due,
+          tail ? eq(metaSyncJobs.kind, 'messages_tail') : ne(metaSyncJobs.kind, 'messages_tail'),
+        ),
+      )
+      .orderBy(
+        sql`case when ${metaSyncJobs.kind} = 'messages' then 0 else 1 end`,
+        metaSyncJobs.createdAt,
+      )
+      .limit(limit);
+  const [tail, backlog] = await Promise.all([lane(true), lane(false)]);
+  const reserved = Math.max(1, Math.floor(limit / 2));
+  return [...tail.slice(0, reserved), ...backlog, ...tail.slice(reserved)].slice(0, limit);
 }
 
 /** Keep the high-frequency freshness lane bounded without touching active

--- a/src/server/services/meta/meta-sync.service.test.ts
+++ b/src/server/services/meta/meta-sync.service.test.ts
@@ -35,7 +35,11 @@ const igMediaInsights = vi.fn();
 const listIgMedia = vi.fn();
 const listAdsWithStoryIds =
   vi.fn<
-    (...a: unknown[]) => Promise<GraphResult<Array<{ adId: string; storyId: string | null; thumbnailUrl?: string | null }>>>
+    (
+      ...a: unknown[]
+    ) => Promise<
+      GraphResult<Array<{ adId: string; storyId: string | null; thumbnailUrl?: string | null }>>
+    >
   >();
 const adInsightsMock = vi.fn();
 const listConversations = vi.fn();
@@ -56,7 +60,10 @@ vi.mock('./graph-read', async (orig) => {
 });
 
 vi.mock('../messages.service', () => ({ insertMessages: vi.fn(async () => 0) }));
-vi.mock('$server/auth/crypto', () => ({ decrypt: (ciphertext: string) => ciphertext, encrypt: vi.fn() }));
+vi.mock('$server/auth/crypto', () => ({
+  decrypt: (ciphertext: string) => ciphertext,
+  encrypt: vi.fn(),
+}));
 
 // ---------------------------------------------------------------------------
 // Mocks for the thumbnail-mirror-pass tests (spec
@@ -80,7 +87,10 @@ vi.mock('$server/storage/blob', () => ({
   getStorage: vi.fn(),
 }));
 
-const fetchImageSafely = vi.fn<(...a: unknown[]) => Promise<{ data: Uint8Array; contentType: string; fileName: string }>>();
+const fetchImageSafely =
+  vi.fn<
+    (...a: unknown[]) => Promise<{ data: Uint8Array; contentType: string; fileName: string }>
+  >();
 vi.mock('../ssrf-guard', () => ({
   fetchImageSafely: (...a: unknown[]) => fetchImageSafely(...a),
 }));
@@ -109,12 +119,22 @@ import { normalizeIgConvo } from './graph-read';
 
 const PAGE_ID = 'page-1';
 const CUSTOMER_ID = 'customer-1';
-const participants = { data: [{ id: PAGE_ID, name: 'FACES' }, { id: CUSTOMER_ID, name: 'Customer' }] };
+const participants = {
+  data: [
+    { id: PAGE_ID, name: 'FACES' },
+    { id: CUSTOMER_ID, name: 'Customer' },
+  ],
+};
 
 describe('toMetaIngestRow', () => {
   it('maps an inbound message: chatId/senderId = the customer, direction inbound', () => {
     const row = toMetaIngestRow({
-      message: { id: 'm1', from: { id: CUSTOMER_ID, name: 'Customer' }, created_time: '2026-07-01T10:00:00+0000', message: 'hi' },
+      message: {
+        id: 'm1',
+        from: { id: CUSTOMER_ID, name: 'Customer' },
+        created_time: '2026-07-01T10:00:00+0000',
+        message: 'hi',
+      },
       participants,
       pageExternalId: PAGE_ID,
       channel: 'messenger',
@@ -134,17 +154,32 @@ describe('toMetaIngestRow', () => {
 
   it('maps an outbound message: chatId stays the customer, senderId flips to the page', () => {
     const row = toMetaIngestRow({
-      message: { id: 'm2', from: { id: PAGE_ID }, created_time: '2026-07-01T10:05:00+0000', message: 'thanks for reaching out' },
+      message: {
+        id: 'm2',
+        from: { id: PAGE_ID },
+        created_time: '2026-07-01T10:05:00+0000',
+        message: 'thanks for reaching out',
+      },
       participants,
       pageExternalId: PAGE_ID,
       channel: 'messenger',
     });
-    expect(row).toMatchObject({ direction: 'outbound', chatId: CUSTOMER_ID, senderId: PAGE_ID, accountId: PAGE_ID });
+    expect(row).toMatchObject({
+      direction: 'outbound',
+      chatId: CUSTOMER_ID,
+      senderId: PAGE_ID,
+      accountId: PAGE_ID,
+    });
   });
 
   it('inbound senderName resolves from the participants list', () => {
     const row = toMetaIngestRow({
-      message: { id: 'm1n', from: { id: CUSTOMER_ID }, created_time: '2026-07-01T10:00:00+0000', message: 'hi' },
+      message: {
+        id: 'm1n',
+        from: { id: CUSTOMER_ID },
+        created_time: '2026-07-01T10:00:00+0000',
+        message: 'hi',
+      },
       participants,
       pageExternalId: PAGE_ID,
       channel: 'messenger',
@@ -196,7 +231,12 @@ describe('toMetaIngestRow', () => {
   });
 
   it('skips a message with no resolvable author', () => {
-    const row = toMetaIngestRow({ message: { id: 'm4' }, participants, pageExternalId: PAGE_ID, channel: 'messenger' });
+    const row = toMetaIngestRow({
+      message: { id: 'm4' },
+      participants,
+      pageExternalId: PAGE_ID,
+      channel: 'messenger',
+    });
     expect(row).toBeNull();
   });
 
@@ -227,15 +267,50 @@ describe('toMetaIngestRow', () => {
       },
       messages: {
         data: [
-          { id: 'g1', from: { id: CUST, username: 'tatiana.peralta15' }, message: 'Tengo dudas', created_time: '2026-07-17T02:36:42+0000' },
-          { id: 'g2', from: { id: SELF, username: 'facesculptors' }, message: 'Hola', created_time: '2026-07-17T02:36:44+0000' },
+          {
+            id: 'g1',
+            from: { id: CUST, username: 'tatiana.peralta15' },
+            message: 'Tengo dudas',
+            created_time: '2026-07-17T02:36:42+0000',
+          },
+          {
+            id: 'g2',
+            from: { id: SELF, username: 'facesculptors' },
+            message: 'Hola',
+            created_time: '2026-07-17T02:36:44+0000',
+          },
         ],
       },
     });
-    const inbound = toMetaIngestRow({ message: convo.messages!.data![0], participants: convo.participants, pageExternalId: SELF, channel: 'instagram', pageName: 'facesculptors' });
-    expect(inbound).toMatchObject({ direction: 'inbound', channel: 'instagram', accountId: SELF, chatId: CUST, senderName: 'tatiana.peralta15', content: 'Tengo dudas', clientId: 'meta:instagram:g1' });
-    const outbound = toMetaIngestRow({ message: convo.messages!.data![1], participants: convo.participants, pageExternalId: SELF, channel: 'instagram', pageName: 'facesculptors' });
-    expect(outbound).toMatchObject({ direction: 'outbound', chatId: CUST, senderId: SELF, senderName: 'facesculptors' });
+    const inbound = toMetaIngestRow({
+      message: convo.messages!.data![0],
+      participants: convo.participants,
+      pageExternalId: SELF,
+      channel: 'instagram',
+      pageName: 'facesculptors',
+    });
+    expect(inbound).toMatchObject({
+      direction: 'inbound',
+      channel: 'instagram',
+      accountId: SELF,
+      chatId: CUST,
+      senderName: 'tatiana.peralta15',
+      content: 'Tengo dudas',
+      clientId: 'meta:instagram:g1',
+    });
+    const outbound = toMetaIngestRow({
+      message: convo.messages!.data![1],
+      participants: convo.participants,
+      pageExternalId: SELF,
+      channel: 'instagram',
+      pageName: 'facesculptors',
+    });
+    expect(outbound).toMatchObject({
+      direction: 'outbound',
+      chatId: CUST,
+      senderId: SELF,
+      senderName: 'facesculptors',
+    });
   });
 });
 
@@ -294,7 +369,12 @@ describe('adInsightRowToInsert', () => {
   });
 
   it('returns null when the row is missing the unique-index columns (ad_id/date)', () => {
-    expect(adInsightRowToInsert({ spend: '1' }, { orgId: 'org-1', adAccountId: 'act_1', currency: null })).toBeNull();
+    expect(
+      adInsightRowToInsert(
+        { spend: '1' },
+        { orgId: 'org-1', adAccountId: 'act_1', currency: null },
+      ),
+    ).toBeNull();
   });
 });
 
@@ -382,7 +462,12 @@ describe('fallbackEngagementRows — engagement-count fallback (read_insights un
     expect(rows).toHaveLength(3);
     expect(rows).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ metric: 'reactions_total', value: '5', postId: 'post-1', period: 'lifetime' }),
+        expect.objectContaining({
+          metric: 'reactions_total',
+          value: '5',
+          postId: 'post-1',
+          period: 'lifetime',
+        }),
         expect.objectContaining({ metric: 'comments_total', value: '2', postId: 'post-1' }),
         expect.objectContaining({ metric: 'shares_total', value: '1', postId: 'post-1' }),
       ]),
@@ -516,9 +601,27 @@ describe('runJob(posts) — promoted-post labeling + insights-call skip-after-fi
       ok: true,
       status: 200,
       data: [
-        { id: 'page-1_100', permalink_url: 'https://fb/1', message: 'promoted', created_time: '2026-07-01T00:00:00+0000', shares: { count: 2 } },
-        { id: 'page-1_200', permalink_url: 'https://fb/2', message: 'organic', created_time: '2026-07-01T00:00:00+0000', shares: { count: 1 } },
-        { id: 'page-1_300', permalink_url: 'https://fb/3', message: 'organic 2', created_time: '2026-07-01T00:00:00+0000', shares: { count: 0 } },
+        {
+          id: 'page-1_100',
+          permalink_url: 'https://fb/1',
+          message: 'promoted',
+          created_time: '2026-07-01T00:00:00+0000',
+          shares: { count: 2 },
+        },
+        {
+          id: 'page-1_200',
+          permalink_url: 'https://fb/2',
+          message: 'organic',
+          created_time: '2026-07-01T00:00:00+0000',
+          shares: { count: 1 },
+        },
+        {
+          id: 'page-1_300',
+          permalink_url: 'https://fb/3',
+          message: 'organic 2',
+          created_time: '2026-07-01T00:00:00+0000',
+          shares: { count: 0 },
+        },
       ],
     });
     postInsights.mockResolvedValue({ ok: false, status: 400, error: 'permission denied' });
@@ -537,7 +640,11 @@ describe('runJob(posts) — promoted-post labeling + insights-call skip-after-fi
       'job-1',
       expect.objectContaining({
         pageCursor: null,
-        countsDelta: expect.objectContaining({ postsProcessed: 3, metricsDenied: 1, metricsSkipped: 2 }),
+        countsDelta: expect.objectContaining({
+          postsProcessed: 3,
+          metricsDenied: 1,
+          metricsSkipped: 2,
+        }),
       }),
     );
     expect(finishJob).toHaveBeenCalledWith(ctx, 'job-1', 'succeeded');
@@ -554,7 +661,11 @@ describe('runJob(posts) — promoted-post labeling + insights-call skip-after-fi
   });
 
   it('never touches meta_ad_posts when no ad has a story id', async () => {
-    listAdsWithStoryIds.mockResolvedValue({ ok: true, status: 200, data: [{ adId: 'ad-2', storyId: null }] });
+    listAdsWithStoryIds.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: [{ adId: 'ad-2', storyId: null }],
+    });
     const { db } = createMockDb();
     const ctx = { db: db as never, tenantId: 'org-1' };
 
@@ -565,7 +676,11 @@ describe('runJob(posts) — promoted-post labeling + insights-call skip-after-fi
   });
 
   it('a failed listAdsWithStoryIds fetch degrades exactly as before — no throw, isPromoted stays false, job still succeeds', async () => {
-    listAdsWithStoryIds.mockResolvedValue({ ok: false, status: 500, error: 'graph request failed' });
+    listAdsWithStoryIds.mockResolvedValue({
+      ok: false,
+      status: 500,
+      error: 'graph request failed',
+    });
     const { db } = createMockDb();
     const ctx = { db: db as never, tenantId: 'org-1' };
 
@@ -612,7 +727,10 @@ describe('runJob(posts) — promoted-post labeling + insights-call skip-after-fi
 
     await runJob(ctx, 'job-1');
 
-    expect(recordPostMedia).not.toHaveBeenCalledWith(ctx, expect.objectContaining({ sourceUrl: 'https://cdn/dark.jpg' }));
+    expect(recordPostMedia).not.toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ sourceUrl: 'https://cdn/dark.jpg' }),
+    );
   });
 
   it('skips recording when thumbnailUrl is null (nothing to mirror)', async () => {
@@ -626,7 +744,10 @@ describe('runJob(posts) — promoted-post labeling + insights-call skip-after-fi
 
     await runJob(ctx, 'job-1');
 
-    expect(recordPostMedia).not.toHaveBeenCalledWith(ctx, expect.objectContaining({ postId: 'page-1_999' }));
+    expect(recordPostMedia).not.toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ postId: 'page-1_999' }),
+    );
   });
 
   it('dedupes: two ads sharing one story id record that post exactly once', async () => {
@@ -643,7 +764,9 @@ describe('runJob(posts) — promoted-post labeling + insights-call skip-after-fi
 
     await runJob(ctx, 'job-1');
 
-    const darkPostCalls = recordPostMedia.mock.calls.filter((c) => (c[1] as { postId?: string })?.postId === 'page-1_999');
+    const darkPostCalls = recordPostMedia.mock.calls.filter(
+      (c) => (c[1] as { postId?: string })?.postId === 'page-1_999',
+    );
     expect(darkPostCalls).toHaveLength(1);
   });
 });
@@ -754,8 +877,52 @@ describe('runJob — connection-by-kind selection (spec 2026-07-05-instagram-log
     const ctx = { db: db as never, tenantId: 'org-1' };
     await runJob(ctx, 'job-ads');
 
-    expect(adInsightsMock).toHaveBeenCalledWith('act_1', 'user-token', expect.anything(), expect.anything());
+    expect(adInsightsMock).toHaveBeenCalledWith(
+      'act_1',
+      'user-token',
+      expect.anything(),
+      expect.anything(),
+    );
     expect(finishJob).toHaveBeenCalledWith(ctx, 'job-ads', 'succeeded');
+  });
+
+  it('messages_tail samples only the newest page for each channel and finishes', async () => {
+    listConnections.mockResolvedValue([flbConnection]);
+    listAssets.mockResolvedValue([pageAsset]);
+    getJobById.mockResolvedValue({
+      id: 'job-messages-tail',
+      orgId: 'org-1',
+      kind: 'messages_tail',
+      status: 'running',
+      pageCursor: null,
+      since: null,
+      until: null,
+      counts: {},
+      error: null,
+      startedAt: new Date(),
+      finishedAt: null,
+      createdAt: new Date(),
+    } as unknown as MetaSyncJob);
+    listConversations.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: [],
+      nextCursor: 'older-page',
+    });
+
+    const { db } = createMockDb();
+    const ctx = { db: db as never, tenantId: 'org-1' };
+    await runJob(ctx, 'job-messages-tail');
+
+    expect(listConversations).toHaveBeenCalledTimes(2);
+    expect(fetchNextPage).not.toHaveBeenCalled();
+    expect(recordProgress).toHaveBeenCalledWith(
+      ctx,
+      'job-messages-tail',
+      expect.objectContaining({ pageCursor: null }),
+    );
+    expect(requeue).not.toHaveBeenCalled();
+    expect(finishJob).toHaveBeenCalledWith(ctx, 'job-messages-tail', 'succeeded');
   });
 
   it('posts job: reads the FLB page with its own page token AND the IG-Login asset with its connection token', async () => {
@@ -795,7 +962,12 @@ describe('runJob — connection-by-kind selection (spec 2026-07-05-instagram-log
     const ctx = { db: db as never, tenantId: 'org-1' };
     await runJob(ctx, 'job-posts-both');
 
-    expect(listPagePosts).toHaveBeenCalledWith('page-1', 'page-token', expect.anything(), expect.anything());
+    expect(listPagePosts).toHaveBeenCalledWith(
+      'page-1',
+      'page-token',
+      expect.anything(),
+      expect.anything(),
+    );
     // IG-Login reads /me/media (the OAuth user id is not a valid media-node
     // path on graph.instagram.com) with NO `since` (unsupported there) —
     // live-verified 2026-07-05.
@@ -904,9 +1076,16 @@ describe('syncPosts — thumbnail mirror pass (spec 2026-07-05-meta-post-thumbna
 
     expect(recordPostMedia).toHaveBeenCalledWith(
       ctx,
-      expect.objectContaining({ postId: 'post-with-pic', sourceUrl: 'https://cdn.example/pic.jpg', platform: 'fb' }),
+      expect.objectContaining({
+        postId: 'post-with-pic',
+        sourceUrl: 'https://cdn.example/pic.jpg',
+        platform: 'fb',
+      }),
     );
-    expect(recordPostMedia).toHaveBeenCalledWith(ctx, expect.objectContaining({ postId: 'post-text-only', sourceUrl: null }));
+    expect(recordPostMedia).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ postId: 'post-text-only', sourceUrl: null }),
+    );
   });
 
   it('no-op mirror pass when storage is not configured — never claims, counts mediaSkipped, never fails the job', async () => {
@@ -961,7 +1140,11 @@ describe('syncPosts — thumbnail mirror pass (spec 2026-07-05-meta-post-thumbna
     fetchImageSafely.mockImplementation(async (...args: unknown[]) => {
       const url = args[0] as string;
       if (url.includes('bad')) throw new Error('upstream 403');
-      return { data: new Uint8Array([1, 2, 3]), contentType: 'image/jpeg', fileName: 'post-ok.jpg' };
+      return {
+        data: new Uint8Array([1, 2, 3]),
+        contentType: 'image/jpeg',
+        fileName: 'post-ok.jpg',
+      };
     });
     uploadFile.mockResolvedValue('file-xyz');
 
@@ -1012,7 +1195,9 @@ describe('adTimeWindows — chunked ad-insights ranges', () => {
   });
 
   it('a short incremental range stays a single window', () => {
-    expect(adTimeWindows('2026-06-01', '2026-07-05')).toEqual([{ since: '2026-06-01', until: '2026-07-05' }]);
+    expect(adTimeWindows('2026-06-01', '2026-07-05')).toEqual([
+      { since: '2026-06-01', until: '2026-07-05' },
+    ]);
   });
 
   it('degrades to the raw pair on unparseable/inverted input', () => {

--- a/src/server/services/meta/meta-sync.service.test.ts
+++ b/src/server/services/meta/meta-sync.service.test.ts
@@ -113,12 +113,31 @@ import {
   FULL_HISTORY_SINCE,
   adStoryLinksToRows,
   runJob,
+  sanitizeGraphPagingUrl,
 } from './meta-sync.service';
 
 import { normalizeIgConvo } from './graph-read';
 
 const PAGE_ID = 'page-1';
 const CUSTOMER_ID = 'customer-1';
+
+describe('durable Meta paging cursors', () => {
+  it('removes Graph credentials before a paging URL is persisted', () => {
+    const sanitized = sanitizeGraphPagingUrl(
+      'https://graph.instagram.com/conversations?after=abc&access_token=secret&appsecret_proof=proof&limit=25',
+    );
+    const url = new URL(sanitized!);
+
+    expect(url.searchParams.get('after')).toBe('abc');
+    expect(url.searchParams.get('limit')).toBe('25');
+    expect(url.searchParams.has('access_token')).toBe(false);
+    expect(url.searchParams.has('appsecret_proof')).toBe(false);
+  });
+
+  it('fails closed instead of persisting an unparseable cursor', () => {
+    expect(sanitizeGraphPagingUrl('not a URL')).toBeUndefined();
+  });
+});
 const participants = {
   data: [
     { id: PAGE_ID, name: 'FACES' },

--- a/src/server/services/meta/meta-sync.service.ts
+++ b/src/server/services/meta/meta-sync.service.ts
@@ -8,7 +8,9 @@
  * Resume state across slices is a small JSON blob in `meta_sync_jobs
  * .page_cursor`: `{ i, next? }` — `i` indexes into a deterministic
  * (sorted-by-external-id) target list, `next` is Graph's own pagination
- * cursor for whichever target was mid-page when the slice ended.
+ * cursor for whichever target was mid-page when the slice ended. Secrets are
+ * removed before persistence and restored from the encrypted connection token
+ * only when the next slice issues the request.
  *
  * Connections/assets are read via meta-connections.service.ts (WP4) — this
  * file only WRITES meta_post_insights / meta_ad_insights / messages and the
@@ -164,7 +166,20 @@ export function adTimeWindows(
   }
   return out;
 }
-const serializeResume = (r: Resume): string => JSON.stringify(r);
+export function sanitizeGraphPagingUrl(nextUrl: string | undefined): string | undefined {
+  if (!nextUrl) return undefined;
+  try {
+    const url = new URL(nextUrl);
+    url.searchParams.delete('access_token');
+    url.searchParams.delete('appsecret_proof');
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+const serializeResume = (r: Resume): string =>
+  JSON.stringify({ ...r, next: sanitizeGraphPagingUrl(r.next) });
 
 function decryptOrNull(
   ciphertext: string | null | undefined,
@@ -732,7 +747,7 @@ async function syncPosts(
     const fetchOpts = isIgLogin
       ? { baseUrl: 'https://graph.instagram.com', versioned: false }
       : graphAuthOpts();
-    const pageOpts = isIgLogin ? {} : graphAuthOpts();
+    const pageOpts = { ...(isIgLogin ? {} : graphAuthOpts()), accessToken: token };
 
     // IG-Login (graph.instagram.com) reads the token owner's media at
     // `/me/media` — the OAuth-returned user id is NOT a valid media-node path
@@ -891,7 +906,11 @@ async function syncAds(
     for (let w = w0; w < windows.length; w++) {
       let page =
         resumedAccount && w === w0 && resume.next
-          ? await fetchNextPage<AdInsightRow>(resume.next, { ...graphAuthOpts(), ...adTimeout })
+          ? await fetchNextPage<AdInsightRow>(resume.next, {
+              ...graphAuthOpts(),
+              ...adTimeout,
+              accessToken: userToken,
+            })
           : await adInsights(asset.externalId, userToken, windows[w], {
               ...graphAuthOpts(),
               ...adTimeout,
@@ -934,6 +953,7 @@ async function syncAds(
         page = await fetchNextPage<AdInsightRow>(page.nextCursor, {
           ...graphAuthOpts(),
           ...adTimeout,
+          accessToken: userToken,
         });
       }
       if (accountFailed) break; // skip this account's remaining windows, move to the next account
@@ -979,8 +999,6 @@ async function syncMessages(
   for (let i = resume.i; i < targets.length; i++) {
     const { asset, platform, igLogin } = targets[i];
     const channel = platform === 'messenger' ? 'messenger' : 'instagram';
-    // graph.instagram.com paging.next links are self-contained (no proof/version) — same as media sync.
-    const nextOpts = igLogin ? {} : graphAuthOpts();
 
     let accountId = asset.externalId;
     let pageName = asset.name;
@@ -1014,6 +1032,7 @@ async function syncMessages(
       token = decryptOrNull(asset.pageTokenCiphertext, asset.pageTokenIv);
       if (!token) continue;
     }
+    const nextOpts = { ...(igLogin ? {} : graphAuthOpts()), accessToken: token };
 
     let page =
       i === resume.i && resume.next

--- a/src/server/services/meta/meta-sync.service.ts
+++ b/src/server/services/meta/meta-sync.service.ts
@@ -55,7 +55,12 @@ import {
 } from './graph-read';
 import { insertMessages, type IngestRow } from '../messages.service';
 import { claimJob, finishJob, getJobById, recordProgress, requeue } from './meta-sync-jobs.service';
-import { recordPostMedia, claimPendingMedia, markMirrored, markFailed } from './meta-post-media.service';
+import {
+  recordPostMedia,
+  claimPendingMedia,
+  markMirrored,
+  markFailed,
+} from './meta-post-media.service';
 import { upsertAdPosts, type AdPostInsertRow } from './meta-ad-posts.service';
 
 /**
@@ -92,7 +97,7 @@ export function computeAdsUntil(now: Date = new Date()): string {
 // Full-history "Sync now" windows (POST /api/meta/sync/run?full=1)
 // ---------------------------------------------------------------------------
 
-export type SyncKind = 'posts' | 'ads' | 'messages';
+export type SyncKind = 'posts' | 'ads' | 'messages' | 'messages_tail';
 
 /** Facebook's founding year — Graph accepts an arbitrarily old `since`, so this is effectively "everything". */
 export const FULL_HISTORY_SINCE = '2004-01-01';
@@ -141,7 +146,11 @@ function parseResume(pageCursor: string | null): Resume {
  * Meta rejects daily×ad-level insights over long ranges with "Please reduce
  * the amount of data you're asking for" (code 1) — pull quarter-sized windows.
  */
-export function adTimeWindows(since: string, until: string, chunkDays = 90): Array<{ since: string; until: string }> {
+export function adTimeWindows(
+  since: string,
+  until: string,
+  chunkDays = 90,
+): Array<{ since: string; until: string }> {
   const DAY = 86_400_000;
   const iso = (t: number) => new Date(t).toISOString().slice(0, 10);
   const end = Date.parse(`${until}T00:00:00Z`);
@@ -157,7 +166,10 @@ export function adTimeWindows(since: string, until: string, chunkDays = 90): Arr
 }
 const serializeResume = (r: Resume): string => JSON.stringify(r);
 
-function decryptOrNull(ciphertext: string | null | undefined, iv: string | null | undefined): string | null {
+function decryptOrNull(
+  ciphertext: string | null | undefined,
+  iv: string | null | undefined,
+): string | null {
   if (!ciphertext || !iv) return null;
   try {
     return decrypt(ciphertext, iv);
@@ -207,7 +219,9 @@ function extractParticipantNames(participants: unknown): Map<string, string> {
   return map;
 }
 
-type ConvoMessage = NonNullable<Conversation['messages']>['data'] extends Array<infer M> | undefined ? M : never;
+type ConvoMessage = NonNullable<Conversation['messages']>['data'] extends Array<infer M> | undefined
+  ? M
+  : never;
 
 /**
  * `chatId` is always the customer's participant id (both directions — matches
@@ -230,7 +244,9 @@ export function toMetaIngestRow(args: {
   if (!fromId) return null;
   const direction: 'inbound' | 'outbound' = fromId === args.pageExternalId ? 'outbound' : 'inbound';
   const participantIds = extractParticipantIds(args.participants);
-  const customerId = participantIds.find((id) => id !== args.pageExternalId) ?? (direction === 'inbound' ? fromId : null);
+  const customerId =
+    participantIds.find((id) => id !== args.pageExternalId) ??
+    (direction === 'inbound' ? fromId : null);
   if (!customerId) return null; // can't resolve the non-page side (e.g. malformed participants) — skip
   const occurredAt = args.message.created_time ? Date.parse(args.message.created_time) : NaN;
   // Outbound = the page authored it → its catalog name. Inbound = the
@@ -426,7 +442,12 @@ async function upsertPostInsights(ctx: CoreCtx, rows: PostInsightRow[]): Promise
         .insert(metaPostInsights)
         .values(chunk)
         .onConflictDoUpdate({
-          target: [metaPostInsights.orgId, metaPostInsights.postId, metaPostInsights.metric, metaPostInsights.period],
+          target: [
+            metaPostInsights.orgId,
+            metaPostInsights.postId,
+            metaPostInsights.metric,
+            metaPostInsights.period,
+          ],
           set: {
             value: sql`excluded.value`,
             permalink: sql`excluded.permalink`,
@@ -623,12 +644,19 @@ async function collectPromotedStoryIds(
       // that post → flags it 'boosted' via the same is_promoted path as FB story
       // ids. Dark IG creatives (most ads) match no organic post — harmless no-op.
       if (link.igMediaId) storyIds.add(link.igMediaId);
-      if (link.storyId && link.thumbnailUrl) darkPostThumbnails.set(link.storyId, link.thumbnailUrl);
+      if (link.storyId && link.thumbnailUrl)
+        darkPostThumbnails.set(link.storyId, link.thumbnailUrl);
     }
     await upsertAdPosts(ctx, adStoryLinksToRows(ctx.tenantId, links));
   }
   for (const [postId, thumbnailUrl] of darkPostThumbnails) {
-    await recordPostMedia(ctx, { orgId: ctx.tenantId, platform: 'fb', postId, sourceUrl: thumbnailUrl, mediaType: null });
+    await recordPostMedia(ctx, {
+      orgId: ctx.tenantId,
+      platform: 'fb',
+      postId,
+      sourceUrl: thumbnailUrl,
+      mediaType: null,
+    });
   }
   return { storyIds, failed };
 }
@@ -657,7 +685,13 @@ async function syncPosts(
 
   const since = job.since ?? defaultSinceDate();
   const resume = parseResume(job.pageCursor);
-  const counts = { postsProcessed: 0, metricsDenied: 0, metricsSkipped: 0, igSkipped: 0, adStoryFetchFailed: 0 };
+  const counts = {
+    postsProcessed: 0,
+    metricsDenied: 0,
+    metricsSkipped: 0,
+    igSkipped: 0,
+    adStoryFetchFailed: 0,
+  };
   const rowsToUpsert: PostInsightRow[] = [];
 
   // read_insights is permanently unobtainable for this app (spec §10) — the
@@ -678,7 +712,9 @@ async function syncPosts(
     // instagram_business_account) always has parentPageId set.
     const isIgLogin = platform === 'ig' && !asset.parentPageId;
     const parentPage =
-      platform === 'ig' && asset.parentPageId ? pageAssets.find((p) => p.externalId === asset.parentPageId) : undefined;
+      platform === 'ig' && asset.parentPageId
+        ? pageAssets.find((p) => p.externalId === asset.parentPageId)
+        : undefined;
     const token =
       platform === 'fb'
         ? decryptOrNull(asset.pageTokenCiphertext, asset.pageTokenIv)
@@ -693,7 +729,9 @@ async function syncPosts(
     // IG-Login media reads hit graph.instagram.com directly (unversioned, no
     // Page/appsecret_proof in the loop) — see graph-read.ts's `versioned` opt
     // and the spec's §2.6 appsecret_proof caveat (default OFF for this host).
-    const fetchOpts = isIgLogin ? { baseUrl: 'https://graph.instagram.com', versioned: false } : graphAuthOpts();
+    const fetchOpts = isIgLogin
+      ? { baseUrl: 'https://graph.instagram.com', versioned: false }
+      : graphAuthOpts();
     const pageOpts = isIgLogin ? {} : graphAuthOpts();
 
     // IG-Login (graph.instagram.com) reads the token owner's media at
@@ -713,7 +751,12 @@ async function syncPosts(
     for (;;) {
       if (!page.ok) {
         if (page.error === 'token_expired') {
-          return { cursor: null, counts, tokenExpired: true, expiredConnectionId: asset.connectionId };
+          return {
+            cursor: null,
+            counts,
+            tokenExpired: true,
+            expiredConnectionId: asset.connectionId,
+          };
         }
         break; // permission/other error on this asset — tolerate, move to next target
       }
@@ -763,12 +806,20 @@ async function syncPosts(
               : await igMediaInsights(post.id, token, mediaType ?? 'IMAGE', graphAuthOpts());
           if (!insights.ok) {
             if (insights.error === 'token_expired') {
-              return { cursor: null, counts, tokenExpired: true, expiredConnectionId: asset.connectionId };
+              return {
+                cursor: null,
+                counts,
+                tokenExpired: true,
+                expiredConnectionId: asset.connectionId,
+              };
             }
             counts.metricsDenied++;
             insightsDenied = true;
           } else {
-            const { rows } = metricInsightsToRows(insights.data ?? [], { ...postMeta, postId: post.id });
+            const { rows } = metricInsightsToRows(insights.data ?? [], {
+              ...postMeta,
+              postId: post.id,
+            });
             rowsToUpsert.push(...rows);
           }
         }
@@ -802,8 +853,15 @@ async function safeMirrorPendingMedia(ctx: CoreCtx, counts: Record<string, numbe
   }
 }
 
-async function syncAds(ctx: CoreCtx, userToken: string, assets: MetaAsset[], job: MetaSyncJob): Promise<SliceResult> {
-  const targets = assets.filter((a) => a.kind === 'ad_account').sort((a, b) => a.externalId.localeCompare(b.externalId));
+async function syncAds(
+  ctx: CoreCtx,
+  userToken: string,
+  assets: MetaAsset[],
+  job: MetaSyncJob,
+): Promise<SliceResult> {
+  const targets = assets
+    .filter((a) => a.kind === 'ad_account')
+    .sort((a, b) => a.externalId.localeCompare(b.externalId));
   const resume = parseResume(job.pageCursor);
   const counts: { adRowsUpserted: number; accountsSkipped: number; skipErrors?: string[] } = {
     adRowsUpserted: 0,
@@ -834,7 +892,10 @@ async function syncAds(ctx: CoreCtx, userToken: string, assets: MetaAsset[], job
       let page =
         resumedAccount && w === w0 && resume.next
           ? await fetchNextPage<AdInsightRow>(resume.next, { ...graphAuthOpts(), ...adTimeout })
-          : await adInsights(asset.externalId, userToken, windows[w], { ...graphAuthOpts(), ...adTimeout });
+          : await adInsights(asset.externalId, userToken, windows[w], {
+              ...graphAuthOpts(),
+              ...adTimeout,
+            });
 
       let accountFailed = false;
       for (;;) {
@@ -844,13 +905,19 @@ async function syncAds(ctx: CoreCtx, userToken: string, assets: MetaAsset[], job
           // Swallowed per-asset errors have twice hidden real regressions — keep
           // the first few (sanitized upstream by graph-read) in the job counts.
           if ((counts.skipErrors ??= []).length < 3) {
-            counts.skipErrors.push(`${asset.externalId} ${windows[w].since}: ${page.error ?? `status ${page.status}`}`);
+            counts.skipErrors.push(
+              `${asset.externalId} ${windows[w].since}: ${page.error ?? `status ${page.status}`}`,
+            );
           }
           accountFailed = true;
           break;
         }
         for (const row of page.data ?? []) {
-          const insertRow = adInsightRowToInsert(row, { orgId: ctx.tenantId, adAccountId: asset.externalId, currency: asset.currency });
+          const insertRow = adInsightRowToInsert(row, {
+            orgId: ctx.tenantId,
+            adAccountId: asset.externalId,
+            currency: asset.currency,
+          });
           if (insertRow) {
             rowsToUpsert.push(insertRow);
             counts.adRowsUpserted++;
@@ -858,10 +925,16 @@ async function syncAds(ctx: CoreCtx, userToken: string, assets: MetaAsset[], job
         }
         if (counts.adRowsUpserted >= MAX_AD_ROWS_PER_SLICE) {
           await upsertAdInsights(ctx, rowsToUpsert);
-          return { cursor: serializeResume({ i, next: page.nextCursor, cs: windows[w].since }), counts };
+          return {
+            cursor: serializeResume({ i, next: page.nextCursor, cs: windows[w].since }),
+            counts,
+          };
         }
         if (!page.nextCursor) break;
-        page = await fetchNextPage<AdInsightRow>(page.nextCursor, { ...graphAuthOpts(), ...adTimeout });
+        page = await fetchNextPage<AdInsightRow>(page.nextCursor, {
+          ...graphAuthOpts(),
+          ...adTimeout,
+        });
       }
       if (accountFailed) break; // skip this account's remaining windows, move to the next account
     }
@@ -876,6 +949,7 @@ async function syncMessages(
   job: MetaSyncJob,
   tokensByConnection: Map<string, string | null>,
 ): Promise<SliceResult> {
+  const tailOnly = job.kind === 'messages_tail';
   // FB-Login pages carry BOTH Messenger and page-linked-IG conversations; an
   // IG-Login `ig` asset (parentPageId null) carries the account's own IG DMs
   // via graph.instagram.com. `igLogin` flags the latter — its token lives on
@@ -887,8 +961,14 @@ async function syncMessages(
         { asset: a, platform: 'messenger' as const, igLogin: false },
         { asset: a, platform: 'instagram' as const, igLogin: false },
       ]),
-    ...assets.filter((a) => a.kind === 'ig' && !a.parentPageId).map((a) => ({ asset: a, platform: 'instagram' as const, igLogin: true })),
-  ].sort((a, b) => (a.asset.externalId + a.platform + a.igLogin).localeCompare(b.asset.externalId + b.platform + b.igLogin));
+    ...assets
+      .filter((a) => a.kind === 'ig' && !a.parentPageId)
+      .map((a) => ({ asset: a, platform: 'instagram' as const, igLogin: true })),
+  ].sort((a, b) =>
+    (a.asset.externalId + a.platform + a.igLogin).localeCompare(
+      b.asset.externalId + b.platform + b.igLogin,
+    ),
+  );
   const resume = parseResume(job.pageCursor);
   const counts = { conversationsProcessed: 0, messagesInserted: 0, instagramSkipped: 0 };
   // IG-Login self-identity (professional-account id + handle), fetched once per
@@ -915,7 +995,13 @@ async function syncMessages(
       if (!self) {
         const who = await getIgLoginUser(token);
         if (!who.ok || !who.data) {
-          if (who.error === 'token_expired') return { cursor: null, counts, tokenExpired: true, expiredConnectionId: asset.connectionId };
+          if (who.error === 'token_expired')
+            return {
+              cursor: null,
+              counts,
+              tokenExpired: true,
+              expiredConnectionId: asset.connectionId,
+            };
           counts.instagramSkipped++;
           continue;
         }
@@ -939,7 +1025,12 @@ async function syncMessages(
     for (;;) {
       if (!page.ok) {
         if (page.error === 'token_expired') {
-          return { cursor: null, counts, tokenExpired: true, expiredConnectionId: igLogin ? asset.connectionId : undefined };
+          return {
+            cursor: null,
+            counts,
+            tokenExpired: true,
+            expiredConnectionId: igLogin ? asset.connectionId : undefined,
+          };
         }
         // IG conversation read needs manage_messages (until the app is Live +
         // reconnected) — tolerate, Messenger still lands. Any per-target error
@@ -953,7 +1044,9 @@ async function syncMessages(
         // `username` shape; normalize to `name` so toMetaIngestRow resolves the
         // customer handle. Idempotent, so FB-Login convos could pass through too
         // — but they already carry `name`, so only pay it for igLogin.
-        const convo = igLogin ? normalizeIgConvo(rawConvo as Parameters<typeof normalizeIgConvo>[0]) : rawConvo;
+        const convo = igLogin
+          ? normalizeIgConvo(rawConvo as Parameters<typeof normalizeIgConvo>[0])
+          : rawConvo;
         for (const msg of convo.messages?.data ?? []) {
           const row = toMetaIngestRow({
             message: msg,
@@ -966,7 +1059,12 @@ async function syncMessages(
         }
         counts.conversationsProcessed++;
       }
-      if (ingestRows.length > 0) counts.messagesInserted += await insertMessages(ctx.tenantId, null, ingestRows);
+      if (ingestRows.length > 0)
+        counts.messagesInserted += await insertMessages(ctx.tenantId, null, ingestRows);
+      // The freshness lane samples the newest Graph page for every connected
+      // account and finishes. Historical pagination continues independently
+      // in the durable `messages` job.
+      if (tailOnly) break;
       if (counts.conversationsProcessed >= MAX_CONVERSATIONS_PER_SLICE) {
         return { cursor: serializeResume({ i, next: page.nextCursor }), counts };
       }
@@ -1007,7 +1105,11 @@ function classifyExpiry(tokenExpiresAt: Date | null): 'ok' | 'expiring' | 'expir
   return 'ok';
 }
 
-async function markConnectionStatus(ctx: CoreCtx, connectionId: string, status: 'expiring' | 'expired'): Promise<void> {
+async function markConnectionStatus(
+  ctx: CoreCtx,
+  connectionId: string,
+  status: 'expiring' | 'expired',
+): Promise<void> {
   await withOrgCore(ctx, (tx) =>
     tx
       .update(metaConnections)
@@ -1024,7 +1126,10 @@ async function markConnectionStatus(ctx: CoreCtx, connectionId: string, status: 
  * into the existing tick cadence at the `classifyExpiry` "expiring" (<7d)
  * threshold — no new scheduled job (spec §7 "Token refresh hook").
  */
-async function refreshIgConnectionToken(ctx: CoreCtx, connection: MetaConnection): Promise<MetaConnection | null> {
+async function refreshIgConnectionToken(
+  ctx: CoreCtx,
+  connection: MetaConnection,
+): Promise<MetaConnection | null> {
   const token = decryptOrNull(connection.tokenCiphertext, connection.tokenIv);
   if (!token) return null;
   const refreshed = await refreshIgToken({ token });
@@ -1036,16 +1141,30 @@ async function refreshIgConnectionToken(ctx: CoreCtx, connection: MetaConnection
   await withOrgCore(ctx, (tx) =>
     tx
       .update(metaConnections)
-      .set({ tokenCiphertext: ciphertext, tokenIv: iv, tokenExpiresAt, status: 'active', updatedAt: new Date() })
+      .set({
+        tokenCiphertext: ciphertext,
+        tokenIv: iv,
+        tokenExpiresAt,
+        status: 'active',
+        updatedAt: new Date(),
+      })
       .where(and(eq(metaConnections.id, connection.id), eq(metaConnections.orgId, ctx.tenantId))),
   );
-  return { ...connection, tokenCiphertext: ciphertext, tokenIv: iv, tokenExpiresAt, status: 'active' };
+  return {
+    ...connection,
+    tokenCiphertext: ciphertext,
+    tokenIv: iv,
+    tokenExpiresAt,
+    status: 'active',
+  };
 }
 
 /** Cross-org: orgs with a non-revoked Meta connection — feeds the tick's enqueue-if-stale sweep. */
 export async function listConnectedOrgIds(): Promise<string[]> {
   const db = getCoreDb();
-  const rows = (await db.execute(sql`select distinct org_id from meta_connections where status != 'revoked'`)) as unknown as Array<{
+  const rows = (await db.execute(
+    sql`select distinct org_id from meta_connections where status != 'revoked'`,
+  )) as unknown as Array<{
     org_id: string;
   }>;
   return rows.map((r) => r.org_id);
@@ -1078,9 +1197,11 @@ export async function runJob(ctx: CoreCtx, jobId: string): Promise<void> {
       continue;
     }
     if (expiry === 'expiring') {
-      const refreshed = connection.kind === 'ig_login' ? await refreshIgConnectionToken(ctx, connection) : null;
+      const refreshed =
+        connection.kind === 'ig_login' ? await refreshIgConnectionToken(ctx, connection) : null;
       if (refreshed) connection = refreshed;
-      else if (connection.status !== 'expiring') await markConnectionStatus(ctx, connection.id, 'expiring');
+      else if (connection.status !== 'expiring')
+        await markConnectionStatus(ctx, connection.id, 'expiring');
     }
     usable.push(connection);
   }
@@ -1093,7 +1214,9 @@ export async function runJob(ctx: CoreCtx, jobId: string): Promise<void> {
   // assets across every usable connection (an FLB page/ig asset AND an
   // IG-Login ig asset can coexist for one org). `listAssets(ctx)` with no
   // connectionId returns every org asset; filter to the connections still in play.
-  const assets = (await listAssets(ctx)).filter((a) => a.enabled && usable.some((c) => c.id === a.connectionId));
+  const assets = (await listAssets(ctx)).filter(
+    (a) => a.enabled && usable.some((c) => c.id === a.connectionId),
+  );
   const tokensByConnection = new Map<string, string | null>();
   for (const c of usable) tokensByConnection.set(c.id, decryptOrNull(c.tokenCiphertext, c.tokenIv));
 
@@ -1113,15 +1236,19 @@ export async function runJob(ctx: CoreCtx, jobId: string): Promise<void> {
 
   let result: SliceResult;
   try {
-    if (job.kind === 'posts') result = await syncPosts(ctx, job, assets, primaryToken, tokensByConnection);
+    if (job.kind === 'posts')
+      result = await syncPosts(ctx, job, assets, primaryToken, tokensByConnection);
     else if (job.kind === 'ads') result = await syncAds(ctx, primaryToken, assets, job);
-    else if (job.kind === 'messages') result = await syncMessages(ctx, assets, job, tokensByConnection);
+    else if (job.kind === 'messages' || job.kind === 'messages_tail')
+      result = await syncMessages(ctx, assets, job, tokensByConnection);
     else {
       await finishJob(ctx, jobId, 'failed', { error: `unknown job kind: ${job.kind}` });
       return;
     }
   } catch (e) {
-    await finishJob(ctx, jobId, 'failed', { error: e instanceof Error ? e.message : 'sync failed' });
+    await finishJob(ctx, jobId, 'failed', {
+      error: e instanceof Error ? e.message : 'sync failed',
+    });
     return;
   }
 

--- a/supabase/migrations/20260725030000_qdrant_owned_embeddings.sql
+++ b/supabase/migrations/20260725030000_qdrant_owned_embeddings.sql
@@ -30,6 +30,12 @@ as $$
   limit 1;
 $$;
 
+-- A worker ack DELETES the outbox row, so "no outbox row" is ambiguous: it is
+-- either a chunk that has been indexed, or a chunk that was written before the
+-- generation started enqueueing and has therefore never reached Qdrant. Only a
+-- completed reconcile cycle proves the whole corpus was swept, so until the
+-- active generation reports one, a chunk with no outbox row counts as pending
+-- rather than falling through to 'ready'.
 create or replace function public.brain_vector_app_source_state(p_source_id uuid)
 returns text
 language sql
@@ -37,13 +43,27 @@ stable
 security definer
 set search_path = pg_catalog, public
 as $$
+  with active as (
+    select generation.generation, reconcile.last_completed_at
+    from public.brain_vector_generations generation
+    left join public.brain_vector_reconcile_state reconcile
+      on reconcile.collection_generation = generation.generation
+    where generation.is_active and generation.enqueue_enabled
+    limit 1
+  ), swept as (
+    select exists (select 1 from active where active.last_completed_at is not null) as ok
+  )
   select case
     when count(*) filter (where job.status = 'dead') > 0 then 'failed'
     when count(*) filter (where job.status in ('queued', 'running')) > 0 then 'queued'
+    when count(*) filter (where job.chunk_id is null) > 0 and not (select ok from swept)
+      then 'queued'
     else 'ready'
   end
   from public.knowledge_chunks chunk
-  join public.brain_vector_outbox job on job.chunk_id = chunk.id
+  left join public.brain_vector_outbox job
+    on job.chunk_id = chunk.id
+    and job.collection_generation = (select generation from active)
   where chunk.org_id = current_setting('app.current_org_id', true)
     and chunk.source_id = p_source_id;
 $$;
@@ -55,12 +75,27 @@ stable
 security definer
 set search_path = pg_catalog, public
 as $$
+  with active as (
+    select generation.generation, reconcile.last_completed_at
+    from public.brain_vector_generations generation
+    left join public.brain_vector_reconcile_state reconcile
+      on reconcile.collection_generation = generation.generation
+    where generation.is_active and generation.enqueue_enabled
+    limit 1
+  ), swept as (
+    select exists (select 1 from active where active.last_completed_at is not null) as ok
+  )
   select count(*)
   from public.knowledge_chunks chunk
-  join public.brain_vector_outbox job on job.chunk_id = chunk.id
+  left join public.brain_vector_outbox job
+    on job.chunk_id = chunk.id
+    and job.collection_generation = (select generation from active)
   where chunk.org_id = current_setting('app.current_org_id', true)
     and chunk.source_id = p_source_id
-    and job.status in ('queued', 'running', 'dead');
+    and (
+      job.status in ('queued', 'running', 'dead')
+      or (job.chunk_id is null and not (select ok from swept))
+    );
 $$;
 
 revoke all on function public.brain_vector_app_generation_mode()

--- a/supabase/migrations/20260725030000_qdrant_owned_embeddings.sql
+++ b/supabase/migrations/20260725030000_qdrant_owned_embeddings.sql
@@ -16,3 +16,59 @@ alter table public.brain_vector_generations
 
 comment on column public.brain_vector_generations.storage_mode is
   'pgvector keeps canonical vectors in Postgres; qdrant keeps only canonical text and durable outbox metadata in Postgres.';
+
+create or replace function public.brain_vector_app_generation_mode()
+returns text
+language sql
+stable
+security definer
+set search_path = pg_catalog, public
+as $$
+  select generation.storage_mode
+  from public.brain_vector_generations generation
+  where generation.is_active and generation.enqueue_enabled
+  limit 1;
+$$;
+
+create or replace function public.brain_vector_app_source_state(p_source_id uuid)
+returns text
+language sql
+stable
+security definer
+set search_path = pg_catalog, public
+as $$
+  select case
+    when count(*) filter (where job.status = 'dead') > 0 then 'failed'
+    when count(*) filter (where job.status in ('queued', 'running')) > 0 then 'queued'
+    else 'ready'
+  end
+  from public.knowledge_chunks chunk
+  join public.brain_vector_outbox job on job.chunk_id = chunk.id
+  where chunk.org_id = current_setting('app.current_org_id', true)
+    and chunk.source_id = p_source_id;
+$$;
+
+create or replace function public.brain_vector_app_source_pending_count(p_source_id uuid)
+returns bigint
+language sql
+stable
+security definer
+set search_path = pg_catalog, public
+as $$
+  select count(*)
+  from public.knowledge_chunks chunk
+  join public.brain_vector_outbox job on job.chunk_id = chunk.id
+  where chunk.org_id = current_setting('app.current_org_id', true)
+    and chunk.source_id = p_source_id
+    and job.status in ('queued', 'running', 'dead');
+$$;
+
+revoke all on function public.brain_vector_app_generation_mode()
+  from public, anon, authenticated;
+revoke all on function public.brain_vector_app_source_state(uuid)
+  from public, anon, authenticated;
+revoke all on function public.brain_vector_app_source_pending_count(uuid)
+  from public, anon, authenticated;
+grant execute on function public.brain_vector_app_generation_mode() to app_ledger;
+grant execute on function public.brain_vector_app_source_state(uuid) to app_ledger;
+grant execute on function public.brain_vector_app_source_pending_count(uuid) to app_ledger;

--- a/supabase/migrations/20260725030000_qdrant_owned_embeddings.sql
+++ b/supabase/migrations/20260725030000_qdrant_owned_embeddings.sql
@@ -17,6 +17,57 @@ alter table public.brain_vector_generations
 comment on column public.brain_vector_generations.storage_mode is
   'pgvector keeps canonical vectors in Postgres; qdrant keeps only canonical text and durable outbox metadata in Postgres.';
 
+-- Serving-index receipt. A worker ack DELETES the outbox row, so a drained
+-- outbox alone cannot tell "this chunk is in Qdrant" from "nothing ever
+-- enqueued this chunk". The ack now records WHICH content it indexed, which is
+-- the only signal that both catches never-indexed chunks and drains back to
+-- zero once the worker has caught up. Not in the trigger's UPDATE OF column
+-- list, so writing it never re-enqueues the chunk it acknowledges.
+alter table public.knowledge_chunks
+  add column if not exists vector_indexed_hash text;
+
+comment on column public.knowledge_chunks.vector_indexed_hash is
+  'content_hash the serving-index worker last confirmed for this chunk; null or stale means the chunk is not in the serving index at its current content.';
+
+create or replace function public.ack_brain_vector_job(
+  chunk_id uuid,
+  generation text,
+  revision bigint
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  acked public.brain_vector_outbox%rowtype;
+  indexed_hash text;
+begin
+  delete from public.brain_vector_outbox o
+  where o.chunk_id = ack_brain_vector_job.chunk_id
+    and o.collection_generation = ack_brain_vector_job.generation
+    and o.revision = ack_brain_vector_job.revision
+    and o.status = 'running'
+  returning o.* into acked;
+
+  if not found then
+    return false;
+  end if;
+
+  indexed_hash := case
+    when acked.desired_operation = 'upsert' then acked.desired_content_hash
+  end;
+
+  update public.knowledge_chunks chunk
+  set vector_indexed_hash = indexed_hash
+  where chunk.id = ack_brain_vector_job.chunk_id
+    and chunk.org_id = acked.org_id
+    and chunk.vector_indexed_hash is distinct from indexed_hash;
+
+  return true;
+end;
+$$;
+
 create or replace function public.brain_vector_app_generation_mode()
 returns text
 language sql
@@ -30,13 +81,10 @@ as $$
   limit 1;
 $$;
 
--- A worker ack DELETES the outbox row, so "no outbox row" is ambiguous: it is
--- either a chunk that has been indexed, or a chunk that never reached Qdrant
--- because nothing enqueued it. The only proof is a reconcile cycle that
--- completed AFTER the chunk was last written — last_completed_at is monotonic,
--- so its mere presence proves nothing about later writes. A chunk with no
--- outbox row newer than the last completed sweep therefore counts as pending
--- instead of falling through to 'ready'.
+-- Pending means "this chunk's current content is not in the serving index":
+-- either the outbox still owes work for it, or no ack has ever confirmed its
+-- present content_hash. Both halves matter — outbox rows alone go silent once
+-- drained, and the receipt alone lags a re-chunked document by one worker pass.
 create or replace function public.brain_vector_app_source_state(p_source_id uuid)
 returns text
 language sql
@@ -45,20 +93,17 @@ security definer
 set search_path = pg_catalog, public
 as $$
   with active as (
-    select generation.generation, reconcile.last_completed_at
+    select generation.generation
     from public.brain_vector_generations generation
-    left join public.brain_vector_reconcile_state reconcile
-      on reconcile.collection_generation = generation.generation
     where generation.is_active and generation.enqueue_enabled
     limit 1
-  ), swept as (
-    select coalesce((select last_completed_at from active), '-infinity'::timestamptz) as at
   )
   select case
     when count(*) filter (where job.status = 'dead') > 0 then 'failed'
-    when count(*) filter (where job.status in ('queued', 'running')) > 0 then 'queued'
-    when max(chunk.updated_at) filter (where job.chunk_id is null) > (select at from swept)
-      then 'queued'
+    when count(*) filter (
+      where job.status in ('queued', 'running')
+        or chunk.vector_indexed_hash is distinct from chunk.content_hash
+    ) > 0 then 'queued'
     else 'ready'
   end
   from public.knowledge_chunks chunk
@@ -77,14 +122,10 @@ security definer
 set search_path = pg_catalog, public
 as $$
   with active as (
-    select generation.generation, reconcile.last_completed_at
+    select generation.generation
     from public.brain_vector_generations generation
-    left join public.brain_vector_reconcile_state reconcile
-      on reconcile.collection_generation = generation.generation
     where generation.is_active and generation.enqueue_enabled
     limit 1
-  ), swept as (
-    select coalesce((select last_completed_at from active), '-infinity'::timestamptz) as at
   )
   select count(*)
   from public.knowledge_chunks chunk
@@ -95,7 +136,7 @@ as $$
     and chunk.source_id = p_source_id
     and (
       job.status in ('queued', 'running', 'dead')
-      or (job.chunk_id is null and chunk.updated_at > (select at from swept))
+      or chunk.vector_indexed_hash is distinct from chunk.content_hash
     );
 $$;
 

--- a/supabase/migrations/20260725030000_qdrant_owned_embeddings.sql
+++ b/supabase/migrations/20260725030000_qdrant_owned_embeddings.sql
@@ -19,15 +19,21 @@ comment on column public.brain_vector_generations.storage_mode is
 
 -- Serving-index receipt. A worker ack DELETES the outbox row, so a drained
 -- outbox alone cannot tell "this chunk is in Qdrant" from "nothing ever
--- enqueued this chunk". The ack now records WHICH content it indexed, which is
--- the only signal that both catches never-indexed chunks and drains back to
--- zero once the worker has caught up. Not in the trigger's UPDATE OF column
--- list, so writing it never re-enqueues the chunk it acknowledges.
+-- enqueued this chunk". The ack records WHICH content it indexed and INTO WHICH
+-- collection generation — a receipt earned under a retired generation says
+-- nothing about the one now serving, so both halves are needed for a rotation
+-- to read as pending until its backfill reaches each chunk. Neither column is
+-- in the trigger's UPDATE OF list, so writing them never re-enqueues the chunk
+-- being acknowledged.
 alter table public.knowledge_chunks
   add column if not exists vector_indexed_hash text;
+alter table public.knowledge_chunks
+  add column if not exists vector_indexed_generation text;
 
 comment on column public.knowledge_chunks.vector_indexed_hash is
   'content_hash the serving-index worker last confirmed for this chunk; null or stale means the chunk is not in the serving index at its current content.';
+comment on column public.knowledge_chunks.vector_indexed_generation is
+  'collection generation that confirmed vector_indexed_hash; a receipt from any other generation does not count as indexed.';
 
 create or replace function public.ack_brain_vector_job(
   chunk_id uuid,
@@ -42,6 +48,7 @@ as $$
 declare
   acked public.brain_vector_outbox%rowtype;
   indexed_hash text;
+  indexed_generation text;
 begin
   delete from public.brain_vector_outbox o
   where o.chunk_id = ack_brain_vector_job.chunk_id
@@ -57,12 +64,19 @@ begin
   indexed_hash := case
     when acked.desired_operation = 'upsert' then acked.desired_content_hash
   end;
+  indexed_generation := case
+    when acked.desired_operation = 'upsert' then acked.collection_generation
+  end;
 
   update public.knowledge_chunks chunk
-  set vector_indexed_hash = indexed_hash
+  set vector_indexed_hash = indexed_hash,
+      vector_indexed_generation = indexed_generation
   where chunk.id = ack_brain_vector_job.chunk_id
     and chunk.org_id = acked.org_id
-    and chunk.vector_indexed_hash is distinct from indexed_hash;
+    and (
+      chunk.vector_indexed_hash is distinct from indexed_hash
+      or chunk.vector_indexed_generation is distinct from indexed_generation
+    );
 
   return true;
 end;
@@ -81,10 +95,11 @@ as $$
   limit 1;
 $$;
 
--- Pending means "this chunk's current content is not in the serving index":
--- either the outbox still owes work for it, or no ack has ever confirmed its
--- present content_hash. Both halves matter — outbox rows alone go silent once
--- drained, and the receipt alone lags a re-chunked document by one worker pass.
+-- Pending means "this chunk's current content is not in the ACTIVE serving
+-- index": either the outbox still owes work for it, or no ack from the active
+-- generation has confirmed its present content_hash. Both halves matter —
+-- outbox rows alone go silent once drained, and the receipt alone lags a
+-- re-chunked document by one worker pass.
 create or replace function public.brain_vector_app_source_state(p_source_id uuid)
 returns text
 language sql
@@ -103,6 +118,7 @@ as $$
     when count(*) filter (
       where job.status in ('queued', 'running')
         or chunk.vector_indexed_hash is distinct from chunk.content_hash
+        or chunk.vector_indexed_generation is distinct from (select generation from active)
     ) > 0 then 'queued'
     else 'ready'
   end
@@ -137,6 +153,7 @@ as $$
     and (
       job.status in ('queued', 'running', 'dead')
       or chunk.vector_indexed_hash is distinct from chunk.content_hash
+      or chunk.vector_indexed_generation is distinct from (select generation from active)
     );
 $$;
 

--- a/supabase/migrations/20260725030000_qdrant_owned_embeddings.sql
+++ b/supabase/migrations/20260725030000_qdrant_owned_embeddings.sql
@@ -31,11 +31,12 @@ as $$
 $$;
 
 -- A worker ack DELETES the outbox row, so "no outbox row" is ambiguous: it is
--- either a chunk that has been indexed, or a chunk that was written before the
--- generation started enqueueing and has therefore never reached Qdrant. Only a
--- completed reconcile cycle proves the whole corpus was swept, so until the
--- active generation reports one, a chunk with no outbox row counts as pending
--- rather than falling through to 'ready'.
+-- either a chunk that has been indexed, or a chunk that never reached Qdrant
+-- because nothing enqueued it. The only proof is a reconcile cycle that
+-- completed AFTER the chunk was last written — last_completed_at is monotonic,
+-- so its mere presence proves nothing about later writes. A chunk with no
+-- outbox row newer than the last completed sweep therefore counts as pending
+-- instead of falling through to 'ready'.
 create or replace function public.brain_vector_app_source_state(p_source_id uuid)
 returns text
 language sql
@@ -51,12 +52,12 @@ as $$
     where generation.is_active and generation.enqueue_enabled
     limit 1
   ), swept as (
-    select exists (select 1 from active where active.last_completed_at is not null) as ok
+    select coalesce((select last_completed_at from active), '-infinity'::timestamptz) as at
   )
   select case
     when count(*) filter (where job.status = 'dead') > 0 then 'failed'
     when count(*) filter (where job.status in ('queued', 'running')) > 0 then 'queued'
-    when count(*) filter (where job.chunk_id is null) > 0 and not (select ok from swept)
+    when max(chunk.updated_at) filter (where job.chunk_id is null) > (select at from swept)
       then 'queued'
     else 'ready'
   end
@@ -83,7 +84,7 @@ as $$
     where generation.is_active and generation.enqueue_enabled
     limit 1
   ), swept as (
-    select exists (select 1 from active where active.last_completed_at is not null) as ok
+    select coalesce((select last_completed_at from active), '-infinity'::timestamptz) as at
   )
   select count(*)
   from public.knowledge_chunks chunk
@@ -94,7 +95,7 @@ as $$
     and chunk.source_id = p_source_id
     and (
       job.status in ('queued', 'running', 'dead')
-      or (job.chunk_id is null and not (select ok from swept))
+      or (job.chunk_id is null and chunk.updated_at > (select at from swept))
     );
 $$;
 

--- a/supabase/migrations/20260725030000_qdrant_owned_embeddings.sql
+++ b/supabase/migrations/20260725030000_qdrant_owned_embeddings.sql
@@ -1,0 +1,18 @@
+-- Record the canonical storage boundary used by the private brain-vector
+-- worker. The worker deployment applies the corresponding least-privilege RPC
+-- upgrades before this mode is changed from its backward-compatible default.
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+alter table public.brain_vector_generations
+  add column if not exists storage_mode text not null default 'pgvector';
+
+alter table public.brain_vector_generations
+  drop constraint if exists brain_vector_generations_storage_mode_check;
+alter table public.brain_vector_generations
+  add constraint brain_vector_generations_storage_mode_check
+  check (storage_mode in ('pgvector', 'qdrant'));
+
+comment on column public.brain_vector_generations.storage_mode is
+  'pgvector keeps canonical vectors in Postgres; qdrant keeps only canonical text and durable outbox metadata in Postgres.';


### PR DESCRIPTION
## Summary

- generalize the conversation corpus from WhatsApp-only to all 1:1 human chat channels, including Instagram
- enqueue durable corpus refresh work after message ingestion and add a five-minute Meta `messages_tail` freshness lane alongside historical pagination
- support Qdrant-owned embeddings without writing vectors to Supabase, guarded by the database's active storage mode
- expose minimal org-scoped application status RPCs and generation-scoped per-chunk indexing receipts instead of granting the Hub access to private worker tables
- reserve bounded claim capacity for both freshness and backlog lanes so tail polling cannot starve historical messages, posts, or ads
- keep Graph access tokens out of durable paging cursors, retain legacy corpus-job compatibility, and bound freshness-job history
- keep searchable conversation context within CRM field-level scope; finance/POS/member PII is not copied into vector text or document metadata

## Verification

- full suite: 2,360 tests passed
- focused Graph pagination, Meta tail, corpus, legacy-job, and migration suite: 132 tests passed
- real PostgreSQL evidence harness: corpus backfill; queued → acknowledged → ready; active-generation rotation; least-privilege RPC access; Meta tail and dirty-corpus freshness lanes
- `svelte-check`: 0 errors, 0 warnings
- exact migration applied against production PostgreSQL under `app_ledger`, RPCs exercised, then fully rolled back

## Rollout

`BRAIN_VECTOR_STORAGE_MODE` remains unset during the initial deploy. It is switched to `qdrant` only after the vector service completes per-org seed, schema-v2 restore drill, activation, Qdrant ownership, parity, and snapshot gates. The worker-owned text-only outbox trigger/RPC upgrade is an explicit prerequisite.
