### PR TITLE
fix: harden Qdrant-owned production cutover

### DIFF
--- a/src/lib/automations/system-automations.ts
+++ b/src/lib/automations/system-automations.ts
@@ -37,18 +37,38 @@ export const SYSTEM_AUTOMATIONS: SystemAutomation[] = [
   { path: '/api/notifications/tick', key: 'notifications', cadence: 'minute', wiring: 'netcup' },
   { path: '/api/jobs/tick', key: 'jobs', cadence: 'minute', wiring: 'netcup' },
   { path: '/api/org-config/tick', key: 'org_config', cadence: 'hourly', wiring: 'netcup' },
-  { path: '/api/reliability/retention/tick', key: 'retention', cadence: 'semimonthly', wiring: 'netcup' },
+  {
+    path: '/api/reliability/retention/tick',
+    key: 'retention',
+    cadence: 'semimonthly',
+    wiring: 'netcup',
+  },
   { path: '/api/memberships/tick', key: 'memberships', cadence: 'hourly', wiring: 'netcup' },
 
   // ── Scheduled by Vercel (vercel.json crons) ──────────────────────────────
-  { path: '/api/finances/sync/daily', key: 'finance_daily', cadence: 'daily_3am', wiring: 'vercel' },
+  {
+    path: '/api/finances/sync/daily',
+    key: 'finance_daily',
+    cadence: 'daily_3am',
+    wiring: 'vercel',
+  },
 
   // ── Wired 2026-07-19 (were built + allowlisted but scheduled nowhere) ────
   { path: '/api/crm/dni-validation/tick', key: 'dni', cadence: 'hourly', wiring: 'netcup' },
   { path: '/api/meta/sync/tick', key: 'meta_sync', cadence: 'minute', wiring: 'netcup' },
   { path: '/api/email-ledger/tick', key: 'email_ledger', cadence: 'daily_3am', wiring: 'netcup' },
-  { path: '/api/crm/conversations/vectorize/tick', key: 'vectorize', cadence: 'hourly', wiring: 'netcup' },
-  { path: '/api/crm/conversations/analyze/tick', key: 'analyze', cadence: 'hourly', wiring: 'netcup' },
+  {
+    path: '/api/crm/conversations/vectorize/tick',
+    key: 'vectorize',
+    cadence: 'hourly',
+    wiring: 'netcup',
+  },
+  {
+    path: '/api/crm/conversations/analyze/tick',
+    key: 'analyze',
+    cadence: 'hourly',
+    wiring: 'netcup',
+  },
 ];
 
 /** Scheduled first, unscheduled last — the gaps are what need attention. */

--- a/src/lib/automations/system-automations.ts
+++ b/src/lib/automations/system-automations.ts
@@ -45,7 +45,7 @@ export const SYSTEM_AUTOMATIONS: SystemAutomation[] = [
 
   // ── Wired 2026-07-19 (were built + allowlisted but scheduled nowhere) ────
   { path: '/api/crm/dni-validation/tick', key: 'dni', cadence: 'hourly', wiring: 'netcup' },
-  { path: '/api/meta/sync/tick', key: 'meta_sync', cadence: 'hourly', wiring: 'netcup' },
+  { path: '/api/meta/sync/tick', key: 'meta_sync', cadence: 'minute', wiring: 'netcup' },
   { path: '/api/email-ledger/tick', key: 'email_ledger', cadence: 'daily_3am', wiring: 'netcup' },
   { path: '/api/crm/conversations/vectorize/tick', key: 'vectorize', cadence: 'hourly', wiring: 'netcup' },
   { path: '/api/crm/conversations/analyze/tick', key: 'analyze', cadence: 'hourly', wiring: 'netcup' },

--- a/src/lib/automations/system-automations.ts
+++ b/src/lib/automations/system-automations.ts
@@ -29,7 +29,7 @@ export interface SystemAutomation {
   wiring: AutomationWiring;
 }
 
-/** Verified against `crontab -l` on 152.53.91.108 + vercel.json on 2026-07-19. */
+/** Verified against `crontab -l` on 152.53.91.108 + vercel.json on 2026-07-25. */
 export const SYSTEM_AUTOMATIONS: SystemAutomation[] = [
   // ── Scheduled on netcup — cadence verified against `crontab -l` ──────────
   { path: '/api/scheduling/reminders/tick', key: 'reminders', cadence: 'minute', wiring: 'netcup' },
@@ -53,7 +53,7 @@ export const SYSTEM_AUTOMATIONS: SystemAutomation[] = [
     wiring: 'vercel',
   },
 
-  // ── Wired 2026-07-19 (were built + allowlisted but scheduled nowhere) ────
+  // ── Additional netcup schedules — cadence re-verified 2026-07-25 ─────────
   { path: '/api/crm/dni-validation/tick', key: 'dni', cadence: 'hourly', wiring: 'netcup' },
   { path: '/api/meta/sync/tick', key: 'meta_sync', cadence: 'minute', wiring: 'netcup' },
   { path: '/api/email-ledger/tick', key: 'email_ledger', cadence: 'daily_3am', wiring: 'netcup' },

--- a/src/routes/api/meta/sync/tick/+server.ts
+++ b/src/routes/api/meta/sync/tick/+server.ts
@@ -23,7 +23,8 @@ const STALE_ENQUEUE_MS = 6 * 60 * 60_000; // spec §6: re-enqueue a kind once it
  * here can beat the scheduler period.
  */
 const MESSAGE_TAIL_STALE_MS = 0;
-/** Up to one cheap tail slice per connected org, capped at 24 orgs per tick.
+/** Up to one cheap tail slice per org with a non-revoked Meta connection,
+ * capped at 24 orgs per tick.
  * Backlog slices are orders of magnitude more expensive (up to 150 posts / 100
  * conversations / 90 ad rows each, run sequentially in this one request), so
  * that lane stays at a small fixed cap no matter how many orgs connect — it is

--- a/src/routes/api/meta/sync/tick/+server.ts
+++ b/src/routes/api/meta/sync/tick/+server.ts
@@ -18,16 +18,16 @@ const SYNC_KINDS = ['posts', 'ads', 'messages', 'messages_tail'] as const;
 const STALE_ENQUEUE_MS = 6 * 60 * 60_000; // spec §6: re-enqueue a kind once its last success is >6h old
 /**
  * The tail lane is topped up on EVERY tick, so message freshness equals the
- * cron period of this route — hourly today (src/lib/automations/system-automations.ts,
- * netcup crontab). Tightening freshness below an hour is a scheduling change,
- * not a code change; no staleness constant here can beat the cron period.
+ * scheduler period for this route (netcup crontab in production). Tightening
+ * freshness is a scheduling change, not a code change; no staleness constant
+ * here can beat the scheduler period.
  */
 const MESSAGE_TAIL_STALE_MS = 0;
-/** One cheap tail slice per connected org, so a tick covers every org's
- * freshness lane. Backlog slices are orders of magnitude more expensive (up to
- * 150 posts / 100 conversations / 90 ad rows each, run sequentially in this one
- * request), so that lane stays at a small fixed cap no matter how many orgs
- * connect — it is catch-up work, not latency-sensitive. */
+/** Up to one cheap tail slice per connected org, capped at 24 orgs per tick.
+ * Backlog slices are orders of magnitude more expensive (up to 150 posts / 100
+ * conversations / 90 ad rows each, run sequentially in this one request), so
+ * that lane stays at a small fixed cap no matter how many orgs connect — it is
+ * catch-up work, not latency-sensitive. */
 const TAIL_CLAIM_MIN = 3;
 const TAIL_CLAIM_MAX = 24;
 const BACKLOG_CLAIM_LIMIT = 3;

--- a/src/server/db/qdrant-owned-embeddings-migration.test.ts
+++ b/src/server/db/qdrant-owned-embeddings-migration.test.ts
@@ -61,9 +61,7 @@ describe('Qdrant-owned embedding storage migration', () => {
     expect(reconciliation).toContain('brain_vector_app_generation_mode()');
     expect(reconciliation).toContain('brain_vector_app_source_state(p_source_id uuid)');
     expect(reconciliation).toContain('brain_vector_app_source_pending_count(p_source_id uuid)');
-    expect(reconciliation).toContain(
-      "chunk.org_id = current_setting('app.current_org_id', true)",
-    );
+    expect(reconciliation).toContain("chunk.org_id = current_setting('app.current_org_id', true)");
     expect(reconciliation).toContain(
       'grant execute on function public.brain_vector_app_source_state(uuid) to app_ledger',
     );

--- a/src/server/db/qdrant-owned-embeddings-migration.test.ts
+++ b/src/server/db/qdrant-owned-embeddings-migration.test.ts
@@ -8,6 +8,13 @@ const migration = readFileSync(
   ),
   'utf8',
 );
+const reconciliation = readFileSync(
+  new URL(
+    '../../../supabase/migrations/20260725183500_qdrant_owned_receipts_reconcile.sql',
+    import.meta.url,
+  ),
+  'utf8',
+);
 
 describe('Qdrant-owned embedding storage migration', () => {
   it('defaults existing generations to pgvector and requires an explicit Qdrant cutover', () => {
@@ -17,7 +24,7 @@ describe('Qdrant-owned embedding storage migration', () => {
   });
 
   it('records an ack receipt per chunk so the pending signal both catches and drains', () => {
-    const ack = migration
+    const ack = reconciliation
       .split('create or replace function')
       .find((fn) => fn.includes('public.ack_brain_vector_job'));
     expect(ack).toBeDefined();
@@ -35,7 +42,7 @@ describe('Qdrant-owned embedding storage migration', () => {
   });
 
   it('calls a chunk pending until the ACTIVE generation confirms its current content', () => {
-    const statusFns = migration
+    const statusFns = reconciliation
       .split('create or replace function')
       .filter((fn) => /brain_vector_app_source_(state|pending_count)/u.test(fn));
     expect(statusFns).toHaveLength(2);
@@ -51,11 +58,13 @@ describe('Qdrant-owned embedding storage migration', () => {
   });
 
   it('exposes only org-scoped application status RPCs to app_ledger', () => {
-    expect(migration).toContain('brain_vector_app_generation_mode()');
-    expect(migration).toContain('brain_vector_app_source_state(p_source_id uuid)');
-    expect(migration).toContain('brain_vector_app_source_pending_count(p_source_id uuid)');
-    expect(migration).toContain("chunk.org_id = current_setting('app.current_org_id', true)");
-    expect(migration).toContain(
+    expect(reconciliation).toContain('brain_vector_app_generation_mode()');
+    expect(reconciliation).toContain('brain_vector_app_source_state(p_source_id uuid)');
+    expect(reconciliation).toContain('brain_vector_app_source_pending_count(p_source_id uuid)');
+    expect(reconciliation).toContain(
+      "chunk.org_id = current_setting('app.current_org_id', true)",
+    );
+    expect(reconciliation).toContain(
       'grant execute on function public.brain_vector_app_source_state(uuid) to app_ledger',
     );
   });

--- a/src/server/services/brain-corpus.service.test.ts
+++ b/src/server/services/brain-corpus.service.test.ts
@@ -44,10 +44,12 @@ describe('brain corpus WhatsApp normalization', () => {
     const relinked = normalizeWhatsAppConversation('+51900000000', 'customer-1', rows);
 
     expect(first.externalId).toBe('conversation:+51922286663:customer-1:2026-07');
+    expect(first.title).toContain('WhatsApp');
     expect(first.rawText).toBe('Customer: Hello\nAgent: Hi!');
     expect(repeated).toEqual(first);
     expect(first.chunks[0].chunkKey).toBe('raw:000000');
     expect(first.chunks[0].contentHash).not.toBe(relinked.chunks[0].contentHash);
+    expect(first.chunks[0].contextPrefix).toContain('WhatsApp');
     expect(relinked.chunks[0].contextPrefix).toContain('+51900000000');
   });
 

--- a/src/server/services/brain-corpus.service.ts
+++ b/src/server/services/brain-corpus.service.ts
@@ -302,6 +302,7 @@ function splitLongTurn(turn: string, maxChars: number): string[] {
 }
 
 function channelLabel(channel: string): string {
+  if (channel.toLowerCase() === 'whatsapp') return 'WhatsApp';
   return channel
     .split(/[-_]/g)
     .filter(Boolean)
@@ -1642,7 +1643,11 @@ async function loadSourceAggregates(
         (
           ${
             qdrantOwnsKnowledgeEmbeddings()
-              ? sql`public.brain_vector_app_source_pending_count(source.id)`
+              ? sql`case
+                  when source.config->>'domain' = 'conversations'
+                    then public.brain_vector_app_source_pending_count(source.id)
+                  else count(chunk.id) filter (where chunk.embedding is null)
+                end`
               : sql`count(chunk.id) filter (where chunk.embedding is null)`
           }
           + count(distinct document.id) filter (

--- a/supabase/migrations/20260725183500_qdrant_owned_receipts_reconcile.sql
+++ b/supabase/migrations/20260725183500_qdrant_owned_receipts_reconcile.sql
@@ -1,0 +1,144 @@
+-- Reconcile the production schema after the already-recorded
+-- 20260725030000 migration was expanded with serving-index receipts. Migration
+-- versions are immutable once recorded, so the final receipt/RPC contract must
+-- advance under a new version even though every statement is idempotent.
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+alter table public.knowledge_chunks
+  add column if not exists vector_indexed_hash text;
+alter table public.knowledge_chunks
+  add column if not exists vector_indexed_generation text;
+
+comment on column public.knowledge_chunks.vector_indexed_hash is
+  'content_hash the serving-index worker last confirmed for this chunk; null or stale means the chunk is not in the serving index at its current content.';
+comment on column public.knowledge_chunks.vector_indexed_generation is
+  'collection generation that confirmed vector_indexed_hash; a receipt from any other generation does not count as indexed.';
+
+create or replace function public.ack_brain_vector_job(
+  chunk_id uuid,
+  generation text,
+  revision bigint
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  acked public.brain_vector_outbox%rowtype;
+  indexed_hash text;
+  indexed_generation text;
+begin
+  delete from public.brain_vector_outbox o
+  where o.chunk_id = ack_brain_vector_job.chunk_id
+    and o.collection_generation = ack_brain_vector_job.generation
+    and o.revision = ack_brain_vector_job.revision
+    and o.status = 'running'
+  returning o.* into acked;
+
+  if not found then
+    return false;
+  end if;
+
+  indexed_hash := case
+    when acked.desired_operation = 'upsert' then acked.desired_content_hash
+  end;
+  indexed_generation := case
+    when acked.desired_operation = 'upsert' then acked.collection_generation
+  end;
+
+  update public.knowledge_chunks chunk
+  set vector_indexed_hash = indexed_hash,
+      vector_indexed_generation = indexed_generation
+  where chunk.id = ack_brain_vector_job.chunk_id
+    and chunk.org_id = acked.org_id
+    and (
+      chunk.vector_indexed_hash is distinct from indexed_hash
+      or chunk.vector_indexed_generation is distinct from indexed_generation
+    );
+
+  return true;
+end;
+$$;
+
+create or replace function public.brain_vector_app_generation_mode()
+returns text
+language sql
+stable
+security definer
+set search_path = pg_catalog, public
+as $$
+  select generation.storage_mode
+  from public.brain_vector_generations generation
+  where generation.is_active and generation.enqueue_enabled
+  limit 1;
+$$;
+
+create or replace function public.brain_vector_app_source_state(p_source_id uuid)
+returns text
+language sql
+stable
+security definer
+set search_path = pg_catalog, public
+as $$
+  with active as (
+    select generation.generation
+    from public.brain_vector_generations generation
+    where generation.is_active and generation.enqueue_enabled
+    limit 1
+  )
+  select case
+    when count(*) filter (where job.status = 'dead') > 0 then 'failed'
+    when count(*) filter (
+      where job.status in ('queued', 'running')
+        or chunk.vector_indexed_hash is distinct from chunk.content_hash
+        or chunk.vector_indexed_generation is distinct from (select generation from active)
+    ) > 0 then 'queued'
+    else 'ready'
+  end
+  from public.knowledge_chunks chunk
+  left join public.brain_vector_outbox job
+    on job.chunk_id = chunk.id
+    and job.collection_generation = (select generation from active)
+  where chunk.org_id = current_setting('app.current_org_id', true)
+    and chunk.source_id = p_source_id;
+$$;
+
+create or replace function public.brain_vector_app_source_pending_count(p_source_id uuid)
+returns bigint
+language sql
+stable
+security definer
+set search_path = pg_catalog, public
+as $$
+  with active as (
+    select generation.generation
+    from public.brain_vector_generations generation
+    where generation.is_active and generation.enqueue_enabled
+    limit 1
+  )
+  select count(*)
+  from public.knowledge_chunks chunk
+  left join public.brain_vector_outbox job
+    on job.chunk_id = chunk.id
+    and job.collection_generation = (select generation from active)
+  where chunk.org_id = current_setting('app.current_org_id', true)
+    and chunk.source_id = p_source_id
+    and (
+      job.status in ('queued', 'running', 'dead')
+      or chunk.vector_indexed_hash is distinct from chunk.content_hash
+      or chunk.vector_indexed_generation is distinct from (select generation from active)
+    );
+$$;
+
+revoke all on function public.brain_vector_app_generation_mode()
+  from public, anon, authenticated;
+revoke all on function public.brain_vector_app_source_state(uuid)
+  from public, anon, authenticated;
+revoke all on function public.brain_vector_app_source_pending_count(uuid)
+  from public, anon, authenticated;
+grant execute on function public.brain_vector_app_generation_mode() to app_ledger;
+grant execute on function public.brain_vector_app_source_state(uuid) to app_ledger;
+grant execute on function public.brain_vector_app_source_pending_count(uuid) to app_ledger;


### PR DESCRIPTION
## Summary
- add a forward-only repair migration for Qdrant indexing receipts when the earlier migration version was already recorded
- scope Qdrant pending counts to conversation knowledge sources and preserve WhatsApp source labels
- document the bounded Meta tail lane and reflect the live one-minute, non-overlapping netcup schedule

## Production context
The repair migration has already been applied transactionally to production and its receipt columns/functions were verified. This PR makes the source history reproducible before enabling Qdrant-owned storage and running the Instagram corpus backfill.

## Validation
- `bun run i18n:compile`
- 124 focused Vitest tests passed
- `bun run check`: 0 errors, 0 warnings
- `git diff --check`