### PR TITLE
fix: unify Qdrant ACK receipt and vector release

### DIFF
--- a/src/server/db/qdrant-owned-embeddings-migration.test.ts
+++ b/src/server/db/qdrant-owned-embeddings-migration.test.ts
@@ -17,7 +17,7 @@ const reconciliation = readFileSync(
 );
 const receiptVectorRelease = readFileSync(
   new URL(
-    '../../../supabase/migrations/20260725193500_qdrant_ack_receipt_vector_release.sql',
+    '../../../supabase/migrations/20260725195000_qdrant_ack_active_generation_guard.sql',
     import.meta.url,
   ),
   'utf8',
@@ -52,10 +52,12 @@ describe('Qdrant-owned embedding storage migration', () => {
     expect(receiptVectorRelease).toContain('returning o.* into acked');
     expect(receiptVectorRelease).toContain('set vector_indexed_hash = indexed_hash');
     expect(receiptVectorRelease).toContain('vector_indexed_generation = indexed_generation');
+    expect(receiptVectorRelease).toContain('active.is_active');
     expect(receiptVectorRelease).toContain("active.storage_mode = 'qdrant'");
     expect(receiptVectorRelease).toContain('set embedding = null');
     expect(receiptVectorRelease).toContain('embedding_model = null');
     expect(receiptVectorRelease).toContain('chunk.org_id = acked.org_id');
+    expect(receiptVectorRelease).toContain('set local search_path = pg_catalog, public');
   });
 
   it('calls a chunk pending until the ACTIVE generation confirms its current content', () => {

--- a/src/server/db/qdrant-owned-embeddings-migration.test.ts
+++ b/src/server/db/qdrant-owned-embeddings-migration.test.ts
@@ -15,6 +15,13 @@ const reconciliation = readFileSync(
   ),
   'utf8',
 );
+const receiptVectorRelease = readFileSync(
+  new URL(
+    '../../../supabase/migrations/20260725193500_qdrant_ack_receipt_vector_release.sql',
+    import.meta.url,
+  ),
+  'utf8',
+);
 
 describe('Qdrant-owned embedding storage migration', () => {
   it('defaults existing generations to pgvector and requires an explicit Qdrant cutover', () => {
@@ -39,6 +46,16 @@ describe('Qdrant-owned embedding storage migration', () => {
     expect(ack).toContain('vector_indexed_generation = indexed_generation');
     expect(ack).toContain('chunk.org_id = acked.org_id');
     expect(ack).toContain('chunk.vector_indexed_generation is distinct from indexed_generation');
+  });
+
+  it('keeps the receipt and Qdrant-owned vector release in the same ACK', () => {
+    expect(receiptVectorRelease).toContain('returning o.* into acked');
+    expect(receiptVectorRelease).toContain('set vector_indexed_hash = indexed_hash');
+    expect(receiptVectorRelease).toContain('vector_indexed_generation = indexed_generation');
+    expect(receiptVectorRelease).toContain("active.storage_mode = 'qdrant'");
+    expect(receiptVectorRelease).toContain('set embedding = null');
+    expect(receiptVectorRelease).toContain('embedding_model = null');
+    expect(receiptVectorRelease).toContain('chunk.org_id = acked.org_id');
   });
 
   it('calls a chunk pending until the ACTIVE generation confirms its current content', () => {

--- a/supabase/migrations/20260725193500_qdrant_ack_receipt_vector_release.sql
+++ b/supabase/migrations/20260725193500_qdrant_ack_receipt_vector_release.sql
@@ -1,0 +1,70 @@
+-- Keep the Qdrant serving-index receipt and Supabase vector release in one
+-- revision-safe ACK. The Hub receipt repair and the serving worker migration
+-- previously replaced this function with complementary, incomplete bodies.
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+set local search_path = public, pg_catalog;
+
+create or replace function public.ack_brain_vector_job(
+  chunk_id uuid,
+  generation text,
+  revision bigint
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  acked public.brain_vector_outbox%rowtype;
+  indexed_hash text;
+  indexed_generation text;
+begin
+  delete from public.brain_vector_outbox o
+  where o.chunk_id = ack_brain_vector_job.chunk_id
+    and o.collection_generation = ack_brain_vector_job.generation
+    and o.revision = ack_brain_vector_job.revision
+    and o.status = 'running'
+  returning o.* into acked;
+
+  if not found then
+    return false;
+  end if;
+
+  indexed_hash := case
+    when acked.desired_operation = 'upsert' then acked.desired_content_hash
+  end;
+  indexed_generation := case
+    when acked.desired_operation = 'upsert' then acked.collection_generation
+  end;
+
+  update public.knowledge_chunks chunk
+  set vector_indexed_hash = indexed_hash,
+      vector_indexed_generation = indexed_generation
+  where chunk.id = ack_brain_vector_job.chunk_id
+    and chunk.org_id = acked.org_id
+    and (
+      chunk.vector_indexed_hash is distinct from indexed_hash
+      or chunk.vector_indexed_generation is distinct from indexed_generation
+    );
+
+  update public.knowledge_chunks chunk
+  set embedding = null,
+      embedding_model = null,
+      updated_at = now()
+  from public.brain_vector_generations active
+  where active.generation = ack_brain_vector_job.generation
+    and active.storage_mode = 'qdrant'
+    and chunk.id = ack_brain_vector_job.chunk_id
+    and chunk.org_id = acked.org_id
+    and (chunk.embedding is not null or chunk.embedding_model is not null);
+
+  return true;
+end;
+$$;
+
+revoke all on function public.ack_brain_vector_job(uuid, text, bigint)
+  from public, anon, authenticated, app_ledger;
+grant execute on function public.ack_brain_vector_job(uuid, text, bigint)
+  to brain_vector_worker;

--- a/supabase/migrations/20260725195000_qdrant_ack_active_generation_guard.sql
+++ b/supabase/migrations/20260725195000_qdrant_ack_active_generation_guard.sql
@@ -1,0 +1,72 @@
+-- Preserve pgvector for inactive/historical generations. Migration
+-- 20260725193500 unified receipt writes and vector release; this forward-only
+-- correction requires the Qdrant generation to also be active before releasing
+-- the canonical Supabase embedding.
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+set local search_path = pg_catalog, public;
+
+create or replace function public.ack_brain_vector_job(
+  chunk_id uuid,
+  generation text,
+  revision bigint
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  acked public.brain_vector_outbox%rowtype;
+  indexed_hash text;
+  indexed_generation text;
+begin
+  delete from public.brain_vector_outbox o
+  where o.chunk_id = ack_brain_vector_job.chunk_id
+    and o.collection_generation = ack_brain_vector_job.generation
+    and o.revision = ack_brain_vector_job.revision
+    and o.status = 'running'
+  returning o.* into acked;
+
+  if not found then
+    return false;
+  end if;
+
+  indexed_hash := case
+    when acked.desired_operation = 'upsert' then acked.desired_content_hash
+  end;
+  indexed_generation := case
+    when acked.desired_operation = 'upsert' then acked.collection_generation
+  end;
+
+  update public.knowledge_chunks chunk
+  set vector_indexed_hash = indexed_hash,
+      vector_indexed_generation = indexed_generation
+  where chunk.id = ack_brain_vector_job.chunk_id
+    and chunk.org_id = acked.org_id
+    and (
+      chunk.vector_indexed_hash is distinct from indexed_hash
+      or chunk.vector_indexed_generation is distinct from indexed_generation
+    );
+
+  update public.knowledge_chunks chunk
+  set embedding = null,
+      embedding_model = null,
+      updated_at = now()
+  from public.brain_vector_generations active
+  where active.generation = ack_brain_vector_job.generation
+    and active.is_active
+    and active.storage_mode = 'qdrant'
+    and chunk.id = ack_brain_vector_job.chunk_id
+    and chunk.org_id = acked.org_id
+    and (chunk.embedding is not null or chunk.embedding_model is not null);
+
+  return true;
+end;
+$$;
+
+revoke all on function public.ack_brain_vector_job(uuid, text, bigint)
+  from public, anon, authenticated, app_ledger;
+grant execute on function public.ack_brain_vector_job(uuid, text, bigint)
+  to brain_vector_worker;


### PR DESCRIPTION
## Summary
- add a forward-only migration that records Qdrant serving-index receipts and releases Supabase pgvector in the same revision-safe ACK
- preserve organization scoping and worker-only execution
- add a migration contract test covering both responsibilities

## Production state
Migration `20260725193500` has already been applied transactionally and recorded in production. Live function inspection confirms it is receipt-aware and releases pgvector only for Qdrant-owned storage.

## Validation
- focused migration tests: 5/5 passed
- `bun run check`: 0 errors, 0 warnings
- `git diff --check`