### PR TITLE
fix: add targeted resumable Instagram brain backfill

### DIFF
--- a/scripts/bootstrap-brain-corpus.ts
+++ b/scripts/bootstrap-brain-corpus.ts
@@ -7,6 +7,7 @@
  * are stable, so unchanged chunks are not sent to the embeddings provider.
  *
  *   bun scripts/bootstrap-brain-corpus.ts <orgId> [--batch=50] [--max-rounds=1]
+ *   bun scripts/bootstrap-brain-corpus.ts <orgId> --channel=instagram --account=<id>
  *   bun scripts/bootstrap-brain-corpus.ts --all [--batch=50]
  */
 import './_sveltekit-bun-shim.ts';
@@ -18,12 +19,22 @@ const all = args.includes('--all');
 const orgArg = args.find((arg) => !arg.startsWith('--'));
 const batchArg = args.find((arg) => arg.startsWith('--batch='));
 const maxRoundsArg = args.find((arg) => arg.startsWith('--max-rounds='));
+const channelArg = args.find((arg) => arg.startsWith('--channel='));
+const accountArg = args.find((arg) => arg.startsWith('--account='));
+const channel = channelArg?.slice('--channel='.length).trim().toLowerCase() || null;
+const accountId = accountArg?.slice('--account='.length).trim() || null;
 const batch = Math.max(1, Math.min(500, Number(batchArg?.split('=')[1] ?? 50)));
 const maxRounds = maxRoundsArg
   ? Math.max(1, Math.floor(Number(maxRoundsArg.split('=')[1]) || 1))
   : Number.POSITIVE_INFINITY;
 if (!all && !orgArg) {
   throw new Error('Pass an orgId or --all');
+}
+if ((channel && !accountId) || (!channel && accountId)) {
+  throw new Error('--channel and --account must be passed together');
+}
+if (all && channel) {
+  throw new Error('Targeted --channel/--account backfills require one orgId, not --all');
 }
 
 const url = process.env.SUPABASE_DB_URL?.trim();
@@ -32,7 +43,7 @@ const client = postgres(url, { prepare: false, max: 5 });
 const db = drizzle(client);
 
 async function bootstrapOrg(orgId: string) {
-  const { bootstrapBrainCorpus, backfillConversations } =
+  const { bootstrapBrainCorpus, backfillConversations, backfillConversationSource } =
     await import('../src/server/services/brain-corpus.service.ts');
   const ctx = { db, tenantId: orgId } as unknown as import('../src/server/auth/core-ctx').CoreCtx;
   let cursor: string | null = null;
@@ -41,7 +52,20 @@ async function bootstrapOrg(orgId: string) {
   let changedChunks = 0;
   let embeddedChunks = 0;
 
-  const initial = await bootstrapBrainCorpus(ctx, { cursor, limit: batch });
+  const runPage = channel
+    ? (pageCursor: string | null) =>
+        backfillConversationSource(ctx, channel, accountId!, {
+          cursor: pageCursor,
+          limit: batch,
+        })
+    : (pageCursor: string | null) =>
+        backfillConversations(ctx, { cursor: pageCursor, limit: batch });
+  const initial = channel
+    ? {
+        sources: [{ id: `${channel}:${accountId}` }],
+        backfill: await runPage(cursor),
+      }
+    : await bootstrapBrainCorpus(ctx, { cursor, limit: batch });
   rounds += 1;
   processed += initial.backfill.processed;
   changedChunks += initial.backfill.changedChunks;
@@ -52,7 +76,7 @@ async function bootstrapOrg(orgId: string) {
   );
 
   while (cursor && rounds < maxRounds) {
-    const page = await backfillConversations(ctx, { cursor, limit: batch });
+    const page = await runPage(cursor);
     rounds += 1;
     processed += page.processed;
     changedChunks += page.changedChunks;

--- a/scripts/bootstrap-brain-corpus.ts
+++ b/scripts/bootstrap-brain-corpus.ts
@@ -8,9 +8,12 @@
  *
  *   bun scripts/bootstrap-brain-corpus.ts <orgId> [--batch=50] [--max-rounds=1]
  *   bun scripts/bootstrap-brain-corpus.ts <orgId> --channel=instagram --account=<id>
+ *     [--checkpoint=/absolute/path/to/cursor.json] [--cursor=<opaque-cursor>]
  *   bun scripts/bootstrap-brain-corpus.ts --all [--batch=50]
  */
 import './_sveltekit-bun-shim.ts';
+import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 
@@ -21,8 +24,12 @@ const batchArg = args.find((arg) => arg.startsWith('--batch='));
 const maxRoundsArg = args.find((arg) => arg.startsWith('--max-rounds='));
 const channelArg = args.find((arg) => arg.startsWith('--channel='));
 const accountArg = args.find((arg) => arg.startsWith('--account='));
+const cursorArg = args.find((arg) => arg.startsWith('--cursor='));
+const checkpointArg = args.find((arg) => arg.startsWith('--checkpoint='));
 const channel = channelArg?.slice('--channel='.length).trim().toLowerCase() || null;
 const accountId = accountArg?.slice('--account='.length).trim() || null;
+const explicitCursor = cursorArg?.slice('--cursor='.length).trim() || null;
+const checkpointPath = checkpointArg?.slice('--checkpoint='.length).trim() || null;
 const batch = Math.max(1, Math.min(500, Number(batchArg?.split('=')[1] ?? 50)));
 const maxRounds = maxRoundsArg
   ? Math.max(1, Math.floor(Number(maxRoundsArg.split('=')[1]) || 1))
@@ -36,17 +43,76 @@ if ((channel && !accountId) || (!channel && accountId)) {
 if (all && channel) {
   throw new Error('Targeted --channel/--account backfills require one orgId, not --all');
 }
+if (all && (explicitCursor || checkpointPath)) {
+  throw new Error('--cursor/--checkpoint require one orgId, not --all');
+}
+if (explicitCursor && checkpointPath) {
+  throw new Error('Pass either --cursor or --checkpoint, not both');
+}
 
 const url = process.env.SUPABASE_DB_URL?.trim();
 if (!url) throw new Error('SUPABASE_DB_URL not set');
-const client = postgres(url, { prepare: false, max: 5 });
+// The operator is page-serial; one connection avoids competing with production
+// serverless traffic while the backfill is running.
+const client = postgres(url, { prepare: false, max: 1 });
 const db = drizzle(client);
+
+interface BackfillCheckpoint {
+  version: 1;
+  orgId: string;
+  channel: string | null;
+  accountId: string | null;
+  cursor: string;
+}
+
+async function loadCheckpoint(orgId: string): Promise<string | null> {
+  if (explicitCursor) return explicitCursor;
+  if (!checkpointPath) return null;
+  try {
+    const checkpoint = JSON.parse(await readFile(checkpointPath, 'utf8')) as BackfillCheckpoint;
+    if (
+      checkpoint.version !== 1 ||
+      checkpoint.orgId !== orgId ||
+      checkpoint.channel !== channel ||
+      checkpoint.accountId !== accountId ||
+      typeof checkpoint.cursor !== 'string' ||
+      !checkpoint.cursor
+    ) {
+      throw new Error('checkpoint does not match the requested org/channel/account');
+    }
+    return checkpoint.cursor;
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw cause;
+  }
+}
+
+async function saveCheckpoint(orgId: string, cursor: string | null): Promise<void> {
+  if (!checkpointPath) return;
+  if (!cursor) {
+    await unlink(checkpointPath).catch((cause: NodeJS.ErrnoException) => {
+      if (cause.code !== 'ENOENT') throw cause;
+    });
+    return;
+  }
+  await mkdir(dirname(checkpointPath), { recursive: true });
+  const temporaryPath = `${checkpointPath}.${process.pid}.tmp`;
+  const checkpoint: BackfillCheckpoint = {
+    version: 1,
+    orgId,
+    channel,
+    accountId,
+    cursor,
+  };
+  await writeFile(temporaryPath, `${JSON.stringify(checkpoint)}\n`, { mode: 0o600 });
+  await rename(temporaryPath, checkpointPath);
+}
 
 async function bootstrapOrg(orgId: string) {
   const { bootstrapBrainCorpus, backfillConversations, backfillConversationSource } =
     await import('../src/server/services/brain-corpus.service.ts');
   const ctx = { db, tenantId: orgId } as unknown as import('../src/server/auth/core-ctx').CoreCtx;
-  let cursor: string | null = null;
+  let cursor = await loadCheckpoint(orgId);
   let rounds = 0;
   let processed = 0;
   let changedChunks = 0;
@@ -71,6 +137,7 @@ async function bootstrapOrg(orgId: string) {
   changedChunks += initial.backfill.changedChunks;
   embeddedChunks += initial.backfill.embeddedChunks;
   cursor = initial.backfill.nextCursor;
+  await saveCheckpoint(orgId, cursor);
   console.log(
     `[${orgId}] round=${rounds} sources=${initial.sources.length} processed=${initial.backfill.processed} changed_chunks=${initial.backfill.changedChunks} embedded=${initial.backfill.embeddedChunks}`,
   );
@@ -82,6 +149,7 @@ async function bootstrapOrg(orgId: string) {
     changedChunks += page.changedChunks;
     embeddedChunks += page.embeddedChunks;
     cursor = page.nextCursor;
+    await saveCheckpoint(orgId, cursor);
     console.log(
       `[${orgId}] round=${rounds} processed=${page.processed} changed_chunks=${page.changedChunks} embedded=${page.embeddedChunks} has_more=${page.hasMore}`,
     );

--- a/src/server/services/brain-corpus.service.test.ts
+++ b/src/server/services/brain-corpus.service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  assertConversationSourceCursor,
   canPromoteVerifiedEmptyWhatsAppSource,
   decodeConversationCursor,
   decodeWhatsAppCursor,
@@ -235,6 +236,21 @@ describe('brain corpus all-channel cursor', () => {
       accountId: '+51922286663',
       chatId: '51911111111@s.whatsapp.net',
     });
+  });
+
+  it('rejects a resume cursor from another channel or account source', () => {
+    const cursor = {
+      channel: 'instagram',
+      accountId: 'faces',
+      chatId: 'ig-chat-1',
+    };
+    expect(() => assertConversationSourceCursor(cursor, 'instagram', 'faces')).not.toThrow();
+    expect(() => assertConversationSourceCursor(cursor, 'instagram', 'another-account')).toThrow(
+      'does not belong to the requested source',
+    );
+    expect(() => assertConversationSourceCursor(cursor, 'whatsapp', 'faces')).toThrow(
+      'does not belong to the requested source',
+    );
   });
 });
 

--- a/src/server/services/brain-corpus.service.ts
+++ b/src/server/services/brain-corpus.service.ts
@@ -533,6 +533,16 @@ export function decodeConversationCursor(cursor?: string | null): ConversationCu
   }
 }
 
+export function assertConversationSourceCursor(
+  cursor: ConversationCursor | null,
+  channel: string,
+  accountId: string,
+): void {
+  if (cursor && (cursor.channel !== channel || cursor.accountId !== accountId)) {
+    throw new Error('conversation source backfill cursor does not belong to the requested source');
+  }
+}
+
 /** One canonical eligibility predicate for discovery, reconciliation, reads,
  * and verified-empty source promotion. Keeping this shared prevents source
  * health from drifting away from the corpus population rules. */
@@ -1398,7 +1408,7 @@ async function runPreparedBatch(
  */
 export async function reconcileDeletedConversationDocuments(
   ctx: CoreCtx,
-  only?: { channel: string; accountId: string; chatId: string; months?: string[] },
+  only?: { channel: string; accountId: string; chatId?: string; months?: string[] },
 ): Promise<WhatsAppReconcileResult> {
   return withOrgCore(ctx, async (tx) => {
     const monthScope = only?.months?.length
@@ -1407,10 +1417,11 @@ export async function reconcileDeletedConversationDocuments(
           or document.metadata->>'segmentMonth' = any(${textArray(only.months)})
         )`
       : sql``;
+    const chatScope = only?.chatId ? sql`and document.metadata->>'chatId' = ${only.chatId}` : sql``;
     const specific = only
       ? sql`and source.connector = ${only.channel}
             and source.external_key = ${only.accountId}
-            and document.metadata->>'chatId' = ${only.chatId}
+            ${chatScope}
             ${monthScope}`
       : sql``;
     const tombstones = (await tx.execute(sql`
@@ -1511,6 +1522,57 @@ export function backfillWhatsAppConversations(
   opts?: { cursor?: string | null; limit?: number },
 ): Promise<WhatsAppBackfillResult> {
   return backfillConversations(ctx, opts);
+}
+
+/**
+ * Cursor-driven backfill for one already-known channel/account source.
+ *
+ * Unlike backfillConversations(), this path intentionally avoids the full
+ * all-channel discovery aggregate on every page. It is the production-safe
+ * repair path for large sources such as an Instagram account: resumable,
+ * idempotent, and bounded by the same page limit.
+ */
+export async function backfillConversationSource(
+  ctx: CoreCtx,
+  channel: string,
+  accountId: string,
+  opts?: { cursor?: string | null; limit?: number },
+): Promise<WhatsAppBackfillResult> {
+  const normalizedChannel = channel.trim().toLowerCase();
+  const normalizedAccountId = accountId.trim();
+  const limit = Math.max(1, Math.min(500, Math.floor(opts?.limit ?? DEFAULT_CONVERSATION_BATCH)));
+  const source = await ensureConversationSource(ctx, normalizedChannel, normalizedAccountId);
+  const sourceByChannelAccount = new Map([
+    [`${normalizedChannel}\u0000${normalizedAccountId}`, source.id],
+  ]);
+  const cursor = decodeConversationCursor(opts?.cursor);
+  assertConversationSourceCursor(cursor, normalizedChannel, normalizedAccountId);
+  const preparedPage = await withOrgCore(ctx, async (tx) => {
+    const page = await scanConversationKeys(tx, sourceByChannelAccount, cursor, limit);
+    return { ...page, prepared: await prepareConversations(tx, page.keys) };
+  });
+  const counts = await runPreparedBatch(ctx, preparedPage.prepared);
+  const last = preparedPage.keys.at(-1) ?? null;
+  let reconciled = { deletedDocuments: 0, deletedChunks: 0 };
+  if (!preparedPage.hasMore) {
+    reconciled = await reconcileDeletedConversationDocuments(ctx, {
+      channel: normalizedChannel,
+      accountId: normalizedAccountId,
+    });
+  }
+  return {
+    ...counts,
+    deletedChunks: counts.deletedChunks + reconciled.deletedChunks,
+    nextCursor:
+      preparedPage.hasMore && last
+        ? encodeConversationCursor({
+            channel: last.channel,
+            accountId: last.accountId,
+            chatId: last.chatId,
+          })
+        : null,
+    hasMore: preparedPage.hasMore,
+  };
 }
 
 /** Event-hook target: rebuild exactly one channel/account-scoped conversation. */

--- a/src/server/services/brain-corpus.service.ts
+++ b/src/server/services/brain-corpus.service.ts
@@ -932,6 +932,43 @@ async function scanConversationKeys(
   };
 }
 
+async function scanConversationSourceKeys(
+  tx: CoreTx,
+  sourceId: string,
+  channel: string,
+  accountId: string,
+  cursor: ConversationCursor | null,
+  limit: number,
+): Promise<{ keys: WhatsAppConversationKey[]; hasMore: boolean }> {
+  const accountFilter =
+    accountId === 'default'
+      ? sql`coalesce(nullif(trim(m.account_id), ''), 'default') = 'default'`
+      : sql`m.account_id = ${accountId}`;
+  const cursorFilter = cursor ? sql`and m.chat_id > ${cursor.chatId}` : sql``;
+  const rows = (await tx.execute(sql`
+    select m.chat_id
+    from messages m
+    where m.org_id = current_setting('app.current_org_id', true)
+      and m.channel = ${channel}
+      and ${accountFilter}
+      and ${eligibleConversationMessagePredicate('m')}
+      ${cursorFilter}
+    group by m.chat_id
+    order by m.chat_id
+    limit ${limit + 1}
+  `)) as unknown as Array<{ chat_id: string }>;
+  const hasMore = rows.length > limit;
+  return {
+    keys: rows.slice(0, limit).map((row) => ({
+      channel,
+      accountId,
+      chatId: row.chat_id,
+      sourceId,
+    })),
+    hasMore,
+  };
+}
+
 function keyValues(keys: WhatsAppConversationKey[]) {
   return sql.join(
     keys.map((key) => sql`(${key.channel}::text, ${key.accountId}::text, ${key.chatId}::text)`),
@@ -957,12 +994,24 @@ async function loadConversationRows(
   tx: CoreTx,
   keys: WhatsAppConversationKey[],
   onlyMonths?: string[],
+  exactSource = false,
 ): Promise<Map<string, WhatsAppMessageInput[]>> {
   const out = new Map<string, WhatsAppMessageInput[]>();
   if (keys.length === 0) return out;
   const monthFilter = onlyMonths?.length
     ? sql`where to_char(coalesce(occurred_at, created_at) at time zone 'UTC', 'YYYY-MM') = any(${textArray(onlyMonths)})`
     : sql``;
+  const sourceFilter = exactSource
+    ? sql`(
+          m.channel,
+          coalesce(nullif(m.account_id, ''), 'default'),
+          m.chat_id
+        ) in (${keyValues(keys)})`
+    : sql`(
+          lower(trim(m.channel)),
+          coalesce(nullif(trim(m.account_id), ''), 'default'),
+          m.chat_id
+        ) in (${keyValues(keys)})`;
   const rows = (await tx.execute(sql`
     select normalized_channel as channel, normalized_account_id as account_id,
       chat_id, id::text as id, message_id, direction, content,
@@ -979,11 +1028,7 @@ async function loadConversationRows(
       from messages m
       where m.org_id = current_setting('app.current_org_id', true)
         and ${eligibleConversationMessagePredicate('m')}
-        and (
-          lower(trim(m.channel)),
-          coalesce(nullif(trim(m.account_id), ''), 'default'),
-          m.chat_id
-        ) in (${keyValues(keys)})
+        and ${sourceFilter}
       order by lower(trim(m.channel)),
         coalesce(nullif(trim(m.account_id), ''), 'default'),
         m.chat_id,
@@ -1113,9 +1158,10 @@ async function prepareConversations(
   tx: CoreTx,
   keys: WhatsAppConversationKey[],
   onlyMonths?: string[],
+  exactSource = false,
 ): Promise<PreparedConversation[]> {
   const [rowsByKey, contextByKey] = await Promise.all([
-    loadConversationRows(tx, keys, onlyMonths),
+    loadConversationRows(tx, keys, onlyMonths, exactSource),
     loadConversationRelationshipContexts(tx, keys),
   ]);
   const normalized = keys
@@ -1557,14 +1603,18 @@ export async function backfillConversationSource(
   const normalizedAccountId = accountId.trim();
   const limit = Math.max(1, Math.min(500, Math.floor(opts?.limit ?? DEFAULT_CONVERSATION_BATCH)));
   const source = await ensureConversationSource(ctx, normalizedChannel, normalizedAccountId);
-  const sourceByChannelAccount = new Map([
-    [`${normalizedChannel}\u0000${normalizedAccountId}`, source.id],
-  ]);
   const cursor = decodeConversationCursor(opts?.cursor);
   assertConversationSourceCursor(cursor, normalizedChannel, normalizedAccountId);
   const preparedPage = await withOrgCore(ctx, async (tx) => {
-    const page = await scanConversationKeys(tx, sourceByChannelAccount, cursor, limit);
-    return { ...page, prepared: await prepareConversations(tx, page.keys) };
+    const page = await scanConversationSourceKeys(
+      tx,
+      source.id,
+      normalizedChannel,
+      normalizedAccountId,
+      cursor,
+      limit,
+    );
+    return { ...page, prepared: await prepareConversations(tx, page.keys, undefined, true) };
   });
   const counts = await runPreparedBatch(ctx, preparedPage.prepared);
   const last = preparedPage.keys.at(-1) ?? null;
@@ -1604,7 +1654,7 @@ export async function syncConversation(
   const source = await ensureConversationSource(ctx, channel, accountId);
   const key = { channel, accountId, chatId, sourceId: source.id };
   const months = opts?.months?.filter((month) => /^\d{4}-\d{2}$/.test(month));
-  const prepared = await withOrgCore(ctx, (tx) => prepareConversations(tx, [key], months));
+  const prepared = await withOrgCore(ctx, (tx) => prepareConversations(tx, [key], months, true));
   if (prepared.length === 0) {
     const reconciled = await reconcileDeletedConversationDocuments(ctx, {
       channel,

--- a/src/server/services/brain-corpus.service.ts
+++ b/src/server/services/brain-corpus.service.ts
@@ -1338,30 +1338,45 @@ async function persistConversations(
     }
 
     const sourceIds = Array.from(new Set(prepared.map((item) => item.key.sourceId)));
-    await tx.execute(sql`
-      update knowledge_sources
-      set status = case
-            when coalesce((watermark->>'expectedDocuments')::int, 0) > (
-              select count(*)::int from knowledge_documents document
-              where document.org_id = knowledge_sources.org_id
-                and document.source_id = knowledge_sources.id and document.status <> 'deleted'
-            ) then 'queued'
-            when ${qdrantStorage}
-              then public.brain_vector_app_source_state(knowledge_sources.id)
-            when exists (
-              select 1 from knowledge_chunks chunk
-              where chunk.org_id = knowledge_sources.org_id
-                and chunk.source_id = knowledge_sources.id
-                and chunk.embedding is null
-            ) then 'queued'
-            else 'ready'
-          end,
-          last_synced_at = now(), last_error = null, updated_at = now()
-      where org_id = current_setting('app.current_org_id', true)
-        and id = any(${uuidArray(sourceIds)})
-    `);
+    await refreshConversationSourceStateTx(tx, sourceIds, qdrantStorage);
     return { deletedChunks };
   });
+}
+
+async function refreshConversationSourceStateTx(
+  tx: CoreTx,
+  sourceIds: string[],
+  qdrantStorage: boolean,
+): Promise<void> {
+  if (sourceIds.length === 0) return;
+  await tx.execute(sql`
+    update knowledge_sources
+    set status = case
+          when coalesce((watermark->>'expectedDocuments')::int, 0) > (
+            select count(*)::int from knowledge_documents document
+            where document.org_id = knowledge_sources.org_id
+              and document.source_id = knowledge_sources.id and document.status <> 'deleted'
+          ) then 'queued'
+          when ${qdrantStorage}
+            then public.brain_vector_app_source_state(knowledge_sources.id)
+          when exists (
+            select 1 from knowledge_chunks chunk
+            where chunk.org_id = knowledge_sources.org_id
+              and chunk.source_id = knowledge_sources.id
+              and chunk.embedding is null
+          ) then 'queued'
+          else 'ready'
+        end,
+        last_synced_at = now(), last_error = null, updated_at = now()
+    where org_id = current_setting('app.current_org_id', true)
+      and id = any(${uuidArray(sourceIds)})
+  `);
+}
+
+async function refreshConversationSourceState(ctx: CoreCtx, sourceId: string): Promise<void> {
+  await withOrgCore(ctx, (tx) =>
+    refreshConversationSourceStateTx(tx, [sourceId], qdrantOwnsKnowledgeEmbeddings()),
+  );
 }
 
 async function runPreparedBatch(
@@ -1559,6 +1574,9 @@ export async function backfillConversationSource(
       channel: normalizedChannel,
       accountId: normalizedAccountId,
     });
+    // An empty terminal page bypasses persistConversations(), so explicitly
+    // clear the processing state established by ensureConversationSource().
+    await refreshConversationSourceState(ctx, source.id);
   }
   return {
     ...counts,


### PR DESCRIPTION
## Summary
- add a channel/account-scoped, cursor-driven conversation corpus backfill that reuses the existing source instead of repeating the all-channel discovery aggregate on every page
- bind resume cursors to the requested channel/account and reject cross-source cursors
- allow source-scoped tombstone reconciliation at the final page
- add `--channel` / `--account` support to the corpus bootstrap operator script

## Production incident
The existing Faces Instagram source has `expectedDocuments=26990`, but the generic backfill times out during repeated source discovery. A bounded production probe also exposed Supabase transaction-pool saturation caused by overlapping minute Meta sync executions. The poll cadence has been stabilized separately; this PR makes the actual IG corpus repair resumable and bounded once the pool recovers.

## Validation
- focused corpus tests: 16/16 passed
- `svelte-check`: 0 errors, 0 warnings
- `git diff --check` passed
- production writes remain Qdrant-owned when `BRAIN_VECTOR_STORAGE_MODE=qdrant`