### PR TITLE
fix(meta): inclusive ad-performance date bound + retry failed ads sync windows

### DIFF
--- a/src/server/services/meta/ad-performance.service.ts
+++ b/src/server/services/meta/ad-performance.service.ts
@@ -58,7 +58,7 @@ async function rollup(tx: Tx, orgId: string, r: DateRange, level: 'campaign' | '
              where a->>'action_type' = ${CONVO_ACTION}
            )), 0)::float8 conversations_started
     from meta_ad_insights mai
-    where mai.org_id = ${orgId} and mai.date >= ${r.from} and mai.date < ${r.to}
+    where mai.org_id = ${orgId} and mai.date >= ${r.from} and mai.date <= ${r.to}
     group by ${groupBy}
     order by conversations_started desc, spend desc
     limit 500

--- a/src/server/services/meta/meta-sync.service.ts
+++ b/src/server/services/meta/meta-sync.service.ts
@@ -131,17 +131,22 @@ export function computeAdsSince(lastSyncedDate: string | null, now: Date = new D
   return new Date(Math.max(restated, floor)).toISOString().slice(0, 10);
 }
 
-/** `cs` = the ads sync's current time-window since-date (chunked pulls only). */
-type Resume = { i: number; next?: string; cs?: string };
+/** `cs` = the ads sync's current time-window since-date (chunked pulls only);
+ *  `f` = consecutive failed attempts at that window (parked-for-retry). */
+type Resume = { i: number; next?: string; cs?: string; f?: number };
 function parseResume(pageCursor: string | null): Resume {
   if (!pageCursor) return { i: 0 };
   try {
     const p = JSON.parse(pageCursor) as Partial<Resume>;
-    return typeof p.i === 'number' ? { i: p.i, next: p.next, cs: p.cs } : { i: 0 };
+    return typeof p.i === 'number' ? { i: p.i, next: p.next, cs: p.cs, f: p.f } : { i: 0 };
   } catch {
     return { i: 0 };
   }
 }
+
+/** Total tries per ads time-window before it's skipped (transient Graph
+ *  failures — rate limits, 5xx — park the job and retry on a later tick). */
+const MAX_WINDOW_ATTEMPTS = 3;
 
 /**
  * Split [since, until] into consecutive ≤chunkDays windows (inclusive dates).
@@ -916,10 +921,23 @@ async function syncAds(
               ...adTimeout,
             });
 
-      let accountFailed = false;
       for (;;) {
         if (!page.ok) {
           if (page.error === 'token_expired') return { cursor: null, counts, tokenExpired: true };
+          const priorFails =
+            resumedAccount && resume.cs === windows[w].since ? (resume.f ?? 0) : 0;
+          if (priorFails + 1 < MAX_WINDOW_ATTEMPTS) {
+            // Transient Graph failure (rate limit, 5xx): park the job at this
+            // window and let a later tick retry it. Skipping ahead on first
+            // failure is what silently dropped 18 months of history on the
+            // 2026-07-05 full sync (rate-limited at the 2024-09-27 window,
+            // every later window discarded, job still "succeeded").
+            await upsertAdInsights(ctx, rowsToUpsert);
+            return {
+              cursor: serializeResume({ i, cs: windows[w].since, f: priorFails + 1 }),
+              counts,
+            };
+          }
           counts.accountsSkipped++;
           // Swallowed per-asset errors have twice hidden real regressions — keep
           // the first few (sanitized upstream by graph-read) in the job counts.
@@ -928,8 +946,7 @@ async function syncAds(
               `${asset.externalId} ${windows[w].since}: ${page.error ?? `status ${page.status}`}`,
             );
           }
-          accountFailed = true;
-          break;
+          break; // give up on THIS window only — remaining windows still run
         }
         for (const row of page.data ?? []) {
           const insertRow = adInsightRowToInsert(row, {
@@ -956,7 +973,6 @@ async function syncAds(
           accessToken: userToken,
         });
       }
-      if (accountFailed) break; // skip this account's remaining windows, move to the next account
     }
   }
   await upsertAdInsights(ctx, rowsToUpsert);


### PR DESCRIPTION
## Why

Meta ads totals in the hub (~65k) are far below Meta's all-time (~250k), and the ad-performance page dropped the last day of any date filter.

## Root causes

1. **`ad-performance.service.ts` used `date < to`** (exclusive) while every other ads surface uses `<= to` (inclusive, per the hub-wide date-controls contract). Filtering May 1–31 silently dropped May 31 on that page.
2. **`syncAds` dropped all remaining time windows when one window's Graph call failed**, then finished the job as `succeeded`. The 2026-07-05 full-history sync hit Meta's rate limit at the 2024-09-27 window and silently discarded every later window — leaving an 18-month hole (2024-10-14 → 2026-04-05, zero rows) that accounts for the missing ~185k spend.

## Fix

- Inclusive `<= to` in the ad-performance rollup.
- A failed ads window now parks the job with a resume cursor (`{cs, f}`) so the next tick retries that window; after 3 failed attempts the window alone is skipped (with the existing `skipErrors` diagnostic) and the remaining windows still run.

Tests: 63/63 meta unit tests pass; `bun run check` 0 errors. After merge, a full-history ads backfill job will be enqueued to fill the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNsGfgMQsqXdQr9djiPB8h