### PR TITLE
fix(personal-agent): server-side self-heal provisioning + resilient principal resolution

### DIFF
--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -7,6 +7,7 @@ import { canonicalPath } from '$lib/canonical-path';
 import { loadWorkspacesForUser } from '$server/services/workspaces.service';
 import { loadOrganizationsForUser } from '$server/services/organizations.service';
 import { loadPersonalAgentForUser } from '$server/services/personal-agent.service';
+import { ensureActivePersonalAgent } from '$server/services/personal-agent-provisioner';
 import { getTenant } from '$server/services/tenant.service';
 import { loadHostsForUser } from '$server/services/hosts.service';
 import { loadUserPreferences } from '$server/services/preferences.service';
@@ -168,12 +169,31 @@ export const load: LayoutServerLoad = async ({ locals, depends, url, cookies }) 
     );
   }
 
-  // Redirect to onboarding if user hasn't completed it yet
+  // Personal-agent guarantee: provisioning is a MANDATORY part of user
+  // creation, so an authenticated user must never dead-end on a "not
+  // provisioned yet" screen. When the agent is missing or not yet active,
+  // self-heal inline (server-side gateway provisioning — same privileged path
+  // as /api/personal-agent/create); only if that fails do we fall back to the
+  // /onboarding manual-retry UI. Rare path: runs only while non-active.
+  let personalAgentBundle = personalAgent;
   if (
     !canonicalPath(url.pathname).startsWith('/onboarding') &&
     (!personalAgent.agent || personalAgent.agent.provisioningStatus !== 'active')
   ) {
-    throw redirect(303, '/onboarding');
+    const coreCtx = await getCoreCtx(locals);
+    const healed = coreCtx
+      ? await traceLayoutLoad(
+          'personal-agent-self-heal',
+          ensureActivePersonalAgent(coreCtx, { userId: user.id, email: user.email ?? '' }).catch(
+            (err) => {
+              console.error('[app-layout] personal-agent self-heal failed', err);
+              return false;
+            },
+          ),
+        )
+      : false;
+    if (!healed) throw redirect(303, '/onboarding');
+    personalAgentBundle = await loadPersonalAgentForUser(locals, user.id, user.supabaseId);
   }
 
   const loadMs = Date.now() - loadStartedAt;
@@ -188,7 +208,7 @@ export const load: LayoutServerLoad = async ({ locals, depends, url, cookies }) 
     organizations: organizations.organizations,
     activeOrgId: organizations.activeOrgId,
     activeOrgKind: activeTenant?.kind ?? 'business',
-    personalAgent,
+    personalAgent: personalAgentBundle,
     hosts,
     preferences,
     brainAgentIds,

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -145,10 +145,7 @@ export const load: LayoutServerLoad = async ({ locals, depends, url, cookies }) 
 
   const activeOrgId = organizations.activeOrgId;
   const activeTenant = activeOrgId
-    ? await traceLayoutLoad(
-        'active-tenant-kind',
-        getTenant({ db: getDb(), tenantId: activeOrgId }),
-      )
+    ? await traceLayoutLoad('active-tenant-kind', getTenant({ db: getDb(), tenantId: activeOrgId }))
     : null;
 
   // Central route-policy guard. The serializable policy registry also drives

--- a/src/server/auth/assistant-principal.ts
+++ b/src/server/auth/assistant-principal.ts
@@ -8,21 +8,20 @@ import { resolveCapabilities, type Capabilities } from '$server/services/rbac.se
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 /** Managing-agent id pattern for AI-Brains agents (`deriveBrainAgentId` in
  *  brain-agents.service.ts) — `brain-<brainUuid>`. */
-const BRAIN_AGENT_RE =
-	/^brain-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
+const BRAIN_AGENT_RE = /^brain-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
 
 export interface AssistantPrincipal {
-	/** Supabase profile uuid of the agent's owner, or (for a brain agent) the
-	 *  brain agent's own gateway agentId — see `resolveBrainAgentPrincipal`. */
-	principalId: string;
-	/** Resolved org to scope to (membership-checked for personal agents; the
-	 *  brain's own org for brain agents). */
-	orgId: string;
-	/** The principal's legacy org role ('admin' | 'owner' | 'member' | …), or
-	 *  'agent' for a brain agent (never a real org role — can't collide). */
-	role: string | null;
-	/** Effective RBAC capabilities in that org — what the agent is allowed to do. */
-	capabilities: Capabilities;
+  /** Supabase profile uuid of the agent's owner, or (for a brain agent) the
+   *  brain agent's own gateway agentId — see `resolveBrainAgentPrincipal`. */
+  principalId: string;
+  /** Resolved org to scope to (membership-checked for personal agents; the
+   *  brain's own org for brain agents). */
+  orgId: string;
+  /** The principal's legacy org role ('admin' | 'owner' | 'member' | …), or
+   *  'agent' for a brain agent (never a real org role — can't collide). */
+  role: string | null;
+  /** Effective RBAC capabilities in that org — what the agent is allowed to do. */
+  capabilities: Capabilities;
 }
 
 /**
@@ -35,14 +34,14 @@ export interface AssistantPrincipal {
  * `brains` is itself a BUSINESS_MODULES entry), no comms/scheduling actions.
  */
 function brainAgentCapabilities(): Capabilities {
-	return {
-		roles: [],
-		can: (module, action) => module === 'brains' && (action === 'view' || action === 'edit'),
-		canRunAnalytics: () => false,
-		visibleModules: () => ['brains'],
-		ownerScoped: () => false,
-		fieldLevel: () => 0,
-	};
+  return {
+    roles: [],
+    can: (module, action) => module === 'brains' && (action === 'view' || action === 'edit'),
+    canRunAnalytics: () => false,
+    visibleModules: () => ['brains'],
+    ownerScoped: () => false,
+    fieldLevel: () => 0,
+  };
 }
 
 /**
@@ -53,25 +52,30 @@ function brainAgentCapabilities(): Capabilities {
  * unknown personal agent id.
  */
 async function resolveBrainAgentPrincipal(
-	locals: App.Locals,
-	agentId: string,
+  locals: App.Locals,
+  agentId: string,
 ): Promise<AssistantPrincipal> {
-	const [row] = await getCoreDb()
-		.select({ orgId: brains.orgId })
-		.from(brains)
-		.where(eq(brains.agentId, agentId))
-		.limit(1);
-	if (!row) throw error(400, 'unresolvable principal');
+  const [row] = await getCoreDb()
+    .select({ orgId: brains.orgId })
+    .from(brains)
+    .where(eq(brains.agentId, agentId))
+    .limit(1);
+  if (!row) throw error(400, 'unresolvable principal');
 
-	const isGateway = Boolean(locals.serverId);
-	if (!isGateway) {
-		if (!locals.user) throw error(401, 'Authentication required');
-		if (locals.user.role !== 'admin' && locals.user.supabaseId !== agentId) {
-			throw error(403, 'forbidden');
-		}
-	}
+  const isGateway = Boolean(locals.serverId);
+  if (!isGateway) {
+    if (!locals.user) throw error(401, 'Authentication required');
+    if (locals.user.role !== 'admin' && locals.user.supabaseId !== agentId) {
+      throw error(403, 'forbidden');
+    }
+  }
 
-	return { principalId: agentId, orgId: row.orgId, role: 'agent', capabilities: brainAgentCapabilities() };
+  return {
+    principalId: agentId,
+    orgId: row.orgId,
+    role: 'agent',
+    capabilities: brainAgentCapabilities(),
+  };
 }
 
 /**
@@ -90,71 +94,71 @@ async function resolveBrainAgentPrincipal(
  * primary org. They can never reach an org they don't belong to.
  */
 export async function resolveAssistantPrincipal(
-	locals: App.Locals,
-	url: URL,
+  locals: App.Locals,
+  url: URL,
 ): Promise<AssistantPrincipal> {
-	const agentId = url.searchParams.get('agentId');
-	const userIdParam = url.searchParams.get('userId');
-	if (!agentId && !userIdParam) throw error(400, 'agentId or userId query param required');
+  const agentId = url.searchParams.get('agentId');
+  const userIdParam = url.searchParams.get('userId');
+  if (!agentId && !userIdParam) throw error(400, 'agentId or userId query param required');
 
-	if (agentId && BRAIN_AGENT_RE.test(agentId)) {
-		return resolveBrainAgentPrincipal(locals, agentId);
-	}
+  if (agentId && BRAIN_AGENT_RE.test(agentId)) {
+    return resolveBrainAgentPrincipal(locals, agentId);
+  }
 
-	const admin = supabaseAdmin();
+  const admin = supabaseAdmin();
 
-	let principalId: string | null = null;
-	if (agentId) {
-		const { data } = await admin
-			.from('profiles')
-			.select('id')
-			.eq('personal_agent_id', agentId)
-			.maybeSingle();
-		principalId = (data as { id: string } | null)?.id ?? null;
-		if (!principalId) {
-			// Fallback: the denormalized profiles pointer can be missing or stale
-			// (seen in prod: agent provisioned pre-GoTrue under a mixed-case legacy
-			// id, pointer never written → every tool call 400'd). `personal_agents`
-			// is the authoritative mapping; match case-insensitively because the
-			// gateway lowercases agent ids while legacy rows kept the original case.
-			const { data: paRow } = await admin
-				.from('personal_agents')
-				.select('profile_id')
-				.ilike('agent_id', agentId)
-				.maybeSingle();
-			principalId = (paRow as { profile_id: string } | null)?.profile_id ?? null;
-			if (principalId) {
-				// Self-heal the pointer (with the id the gateway actually sends) so
-				// the fast path works next time. Best-effort.
-				await admin
-					.from('profiles')
-					.update({ personal_agent_id: agentId })
-					.eq('id', principalId)
-					.then(() => undefined);
-			}
-		}
-	} else if (userIdParam && UUID_RE.test(userIdParam)) {
-		principalId = userIdParam;
-	}
-	if (!principalId) throw error(400, 'unresolvable principal');
+  let principalId: string | null = null;
+  if (agentId) {
+    const { data } = await admin
+      .from('profiles')
+      .select('id')
+      .eq('personal_agent_id', agentId)
+      .maybeSingle();
+    principalId = (data as { id: string } | null)?.id ?? null;
+    if (!principalId) {
+      // Fallback: the denormalized profiles pointer can be missing or stale
+      // (seen in prod: agent provisioned pre-GoTrue under a mixed-case legacy
+      // id, pointer never written → every tool call 400'd). `personal_agents`
+      // is the authoritative mapping; match case-insensitively because the
+      // gateway lowercases agent ids while legacy rows kept the original case.
+      const { data: paRow } = await admin
+        .from('personal_agents')
+        .select('profile_id')
+        .ilike('agent_id', agentId)
+        .maybeSingle();
+      principalId = (paRow as { profile_id: string } | null)?.profile_id ?? null;
+      if (principalId) {
+        // Self-heal the pointer (with the id the gateway actually sends) so
+        // the fast path works next time. Best-effort.
+        await admin
+          .from('profiles')
+          .update({ personal_agent_id: agentId })
+          .eq('id', principalId)
+          .then(() => undefined);
+      }
+    }
+  } else if (userIdParam && UUID_RE.test(userIdParam)) {
+    principalId = userIdParam;
+  }
+  if (!principalId) throw error(400, 'unresolvable principal');
 
-	const isGateway = Boolean(locals.serverId);
-	if (!isGateway) {
-		if (!locals.user) throw error(401, 'Authentication required');
-		if (locals.user.role !== 'admin' && locals.user.supabaseId !== principalId) {
-			throw error(403, 'forbidden');
-		}
-	}
+  const isGateway = Boolean(locals.serverId);
+  if (!isGateway) {
+    if (!locals.user) throw error(401, 'Authentication required');
+    if (locals.user.role !== 'admin' && locals.user.supabaseId !== principalId) {
+      throw error(403, 'forbidden');
+    }
+  }
 
-	const { data: mems } = await admin
-		.from('organization_members')
-		.select('organization_id, role')
-		.eq('profile_id', principalId);
-	const rows = (mems ?? []) as Array<{ organization_id: string; role: string | null }>;
-	if (rows.length === 0) throw error(404, 'no organization for user');
+  const { data: mems } = await admin
+    .from('organization_members')
+    .select('organization_id, role')
+    .eq('profile_id', principalId);
+  const rows = (mems ?? []) as Array<{ organization_id: string; role: string | null }>;
+  if (rows.length === 0) throw error(404, 'no organization for user');
 
-	const requested = url.searchParams.get('orgId');
-	const chosen = (requested && rows.find((r) => r.organization_id === requested)) || rows[0];
-	const capabilities = await resolveCapabilities(chosen.organization_id, principalId);
-	return { principalId, orgId: chosen.organization_id, role: chosen.role, capabilities };
+  const requested = url.searchParams.get('orgId');
+  const chosen = (requested && rows.find((r) => r.organization_id === requested)) || rows[0];
+  const capabilities = await resolveCapabilities(chosen.organization_id, principalId);
+  return { principalId, orgId: chosen.organization_id, role: chosen.role, capabilities };
 }

--- a/src/server/auth/assistant-principal.ts
+++ b/src/server/auth/assistant-principal.ts
@@ -111,6 +111,28 @@ export async function resolveAssistantPrincipal(
 			.eq('personal_agent_id', agentId)
 			.maybeSingle();
 		principalId = (data as { id: string } | null)?.id ?? null;
+		if (!principalId) {
+			// Fallback: the denormalized profiles pointer can be missing or stale
+			// (seen in prod: agent provisioned pre-GoTrue under a mixed-case legacy
+			// id, pointer never written → every tool call 400'd). `personal_agents`
+			// is the authoritative mapping; match case-insensitively because the
+			// gateway lowercases agent ids while legacy rows kept the original case.
+			const { data: paRow } = await admin
+				.from('personal_agents')
+				.select('profile_id')
+				.ilike('agent_id', agentId)
+				.maybeSingle();
+			principalId = (paRow as { profile_id: string } | null)?.profile_id ?? null;
+			if (principalId) {
+				// Self-heal the pointer (with the id the gateway actually sends) so
+				// the fast path works next time. Best-effort.
+				await admin
+					.from('profiles')
+					.update({ personal_agent_id: agentId })
+					.eq('id', principalId)
+					.then(() => undefined);
+			}
+		}
 	} else if (userIdParam && UUID_RE.test(userIdParam)) {
 		principalId = userIdParam;
 	}

--- a/src/server/services/personal-agent-provisioner.ensure.test.ts
+++ b/src/server/services/personal-agent-provisioner.ensure.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getPersonalAgent: vi.fn(),
+  provisionPersonalAgent: vi.fn(),
+  updateProvisioningStatus: vi.fn(),
+  gatewayCall: vi.fn(),
+}));
+
+vi.mock('./personal-agent.service', () => ({
+  getPersonalAgent: mocks.getPersonalAgent,
+  provisionPersonalAgent: mocks.provisionPersonalAgent,
+  updateProvisioningStatus: mocks.updateProvisioningStatus,
+}));
+vi.mock('$lib/server/gateway-rpc', () => ({ gatewayCall: mocks.gatewayCall }));
+
+import { ensureActivePersonalAgent } from './personal-agent-provisioner';
+
+const ctx = { db: {} as never, tenantId: 'org-1' };
+const params = { userId: 'user-1', email: 'u@example.com' };
+
+function agentRow(status: string, retryCount = 0, lastRetryAt: number | null = null) {
+  return {
+    id: 'pa-1',
+    userId: 'user-1',
+    agentId: 'personal-user-1',
+    serverId: null,
+    displayName: '',
+    conversationName: null,
+    avatarUrl: null,
+    personalityPreset: null,
+    personalityText: null,
+    personalityConfigured: false,
+    provisioningStatus: status,
+    provisioningError: null,
+    lastRetryAt,
+    retryCount,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ensureActivePersonalAgent', () => {
+  it('returns true immediately when already active (no gateway call)', async () => {
+    mocks.getPersonalAgent.mockResolvedValue(agentRow('active'));
+    await expect(ensureActivePersonalAgent(ctx, params)).resolves.toBe(true);
+    expect(mocks.gatewayCall).not.toHaveBeenCalled();
+  });
+
+  it('provisions the row when missing, creates the gateway agent, marks active', async () => {
+    mocks.getPersonalAgent.mockResolvedValue(null);
+    mocks.provisionPersonalAgent.mockResolvedValue(agentRow('pending'));
+    mocks.gatewayCall.mockResolvedValue({});
+    await expect(ensureActivePersonalAgent(ctx, params)).resolves.toBe(true);
+    expect(mocks.provisionPersonalAgent).toHaveBeenCalledOnce();
+    expect(mocks.gatewayCall).toHaveBeenCalledWith('agents.create', {
+      name: 'personal-user-1',
+      workspace: '~/.minion/agents/personal-user-1/workspace',
+    });
+    // provisioning → active transitions, in order
+    expect(mocks.updateProvisioningStatus.mock.calls.map((c) => c[2])).toEqual([
+      'provisioning',
+      'active',
+    ]);
+  });
+
+  it('tolerates "already exists" from the gateway and still activates', async () => {
+    mocks.getPersonalAgent.mockResolvedValue(agentRow('pending'));
+    mocks.gatewayCall.mockRejectedValue(new Error('agent already exists'));
+    await expect(ensureActivePersonalAgent(ctx, params)).resolves.toBe(true);
+    expect(mocks.updateProvisioningStatus).toHaveBeenLastCalledWith(ctx, 'user-1', 'active');
+  });
+
+  it('returns false and marks error on a real gateway failure (never throws)', async () => {
+    mocks.getPersonalAgent.mockResolvedValue(agentRow('pending'));
+    mocks.gatewayCall.mockRejectedValue(new Error('gateway unreachable'));
+    await expect(ensureActivePersonalAgent(ctx, params)).resolves.toBe(false);
+    expect(mocks.updateProvisioningStatus).toHaveBeenLastCalledWith(
+      ctx,
+      'user-1',
+      'error',
+      'gateway unreachable',
+    );
+  });
+
+  it('respects the retry backoff window (returns false without calling the gateway)', async () => {
+    mocks.getPersonalAgent.mockResolvedValue(agentRow('error', 2, Date.now()));
+    await expect(ensureActivePersonalAgent(ctx, params)).resolves.toBe(false);
+    expect(mocks.gatewayCall).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/personal-agent-provisioner.ts
+++ b/src/server/services/personal-agent-provisioner.ts
@@ -1,5 +1,10 @@
 import type { PersonalAgentRow } from './personal-agent.service';
-import { getPersonalAgent, updateProvisioningStatus } from './personal-agent.service';
+import {
+  getPersonalAgent,
+  provisionPersonalAgent,
+  updateProvisioningStatus,
+} from './personal-agent.service';
+import { gatewayCall } from '$lib/server/gateway-rpc';
 import type { CoreCtx } from '$server/auth/core-ctx';
 
 const MAX_RETRIES = 5;
@@ -76,4 +81,57 @@ export async function markActive(ctx: CoreCtx, userId: string): Promise<void> {
  */
 export async function markError(ctx: CoreCtx, userId: string, error: string): Promise<void> {
   await updateProvisioningStatus(ctx, userId, 'error', error);
+}
+
+/**
+ * Guarantee the user has an ACTIVE personal agent, provisioning it server-side
+ * if needed. Personal-agent provisioning is a mandatory part of user creation —
+ * a signed-in user must never dead-end on a "not provisioned yet" screen, so
+ * the (app) layout calls this instead of bouncing straight to /onboarding.
+ *
+ * Steps (all idempotent): ensure the personal_agents row + profiles pointer
+ * exist (`provisionPersonalAgent`), then create the gateway agent with the
+ * system credentials (same privileged path as /api/personal-agent/create and
+ * brain-agents), then mark active. Identity/personality stay unconfigured —
+ * the user can personalize later in settings; that's cosmetic, not blocking.
+ *
+ * Returns true when the agent is (now) active. Returns false — WITHOUT
+ * throwing — when provisioning failed or is inside the retry backoff window,
+ * so the caller can fall back to /onboarding's manual retry UI.
+ */
+export async function ensureActivePersonalAgent(
+  ctx: CoreCtx,
+  params: { userId: string; email: string },
+): Promise<boolean> {
+  let agent = await getPersonalAgent(ctx, params.userId);
+  if (!agent) {
+    try {
+      agent = await provisionPersonalAgent(ctx, {
+        userId: params.userId,
+        email: params.email,
+        serverId: '',
+      });
+    } catch (err) {
+      console.error('[personal-agent] ensureActive: row provisioning failed', err);
+      return false;
+    }
+  }
+  if (agent.provisioningStatus === 'active') return true;
+  if (!shouldRetryAgent(agent)) return false; // backoff/max-retries — don't hammer the gateway
+
+  await markProvisioning(ctx, params.userId);
+  try {
+    try {
+      await gatewayCall('agents.create', getProvisioningPayload(agent));
+    } catch (err) {
+      if (!(err instanceof Error && /already exists/i.test(err.message))) throw err;
+    }
+    await markActive(ctx, params.userId);
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[personal-agent] ensureActive: gateway provisioning failed', message);
+    await markError(ctx, params.userId, message);
+    return false;
+  }
 }


### PR DESCRIPTION
## Problem
A FACES member's agent got **400 'unresolvable principal'** on every brain/data tool call — the agent existed on the gateway but `profiles.personal_agent_id` was never linked (pre-GoTrue provisioning; gateway lowercases agent ids while legacy rows kept mixed case). The user saw only non-answers. Separately, users with a non-active personal agent dead-end on the /onboarding screen even though provisioning is a mandatory part of user creation.

## Fix
- **`resolveAssistantPrincipal`**: on a pointer miss, fall back to the authoritative `personal_agents` table (case-insensitive `ilike` match) and self-heal the pointer. Kills this failure class permanently.
- **`ensureActivePersonalAgent`** (new, provisioner): idempotent server-side provisioning — row + pointer + privileged gateway `agents.create` (same path as `/api/personal-agent/create` / brain-agents) + markActive, respecting the existing retry/backoff state machine. Never throws.
- **(app) layout**: non-active agent → self-heal inline instead of redirecting; /onboarding is now only the manual-retry fallback when server-side provisioning fails. Speaking to your agent can no longer hit a "not provisioned yet" wall.

## Data backfill (already applied in prod)
Normalized 2 mixed-case agent ids, moved 1 wrongly-claimed pointer to its session-verified owner, reset 1 row that referenced a nonexistent gateway agent, provisioned 1 missing user. Verified: 0 pointer/row mismatches, 0 double claims, 0 profiles without an agent.

## Tests
- 5 new tests for `ensureActivePersonalAgent` (already-active short-circuit, full provision path, already-exists tolerance, gateway-failure → error state, backoff respected)
- `bun run check` 0/0 · all personal-agent suites pass (26+24+5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XghMi4RgFvrKnf687KpHDH