### PR TITLE
fix(crm): enforce owner + PII-mask scope on hygiene scans and their cache keys

### DIFF
--- a/src/routes/(app)/crm/settings/+page.server.ts
+++ b/src/routes/(app)/crm/settings/+page.server.ts
@@ -3,6 +3,7 @@ import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
 import { listTags } from '$server/services/crm-contacts.service';
 import { getAccountScopeLive } from '$server/services/crm-channels.service';
+import { ownerFilter, shouldMaskSensitive } from '$server/services/rbac.service';
 import {
   scanStandardizationCached,
   findDuplicatesCached,
@@ -23,12 +24,33 @@ export const load: PageServerLoad = async ({ locals, depends }) => {
   // resilient (never rejects) so a slow/down gateway degrades, not errors.
   const tags = await listTags(ctx);
   const scope = getAccountScopeLive(ctx).catch(
-    () => ({ added: [], available: [], legacy: true }) as Awaited<ReturnType<typeof getAccountScopeLive>>,
+    () =>
+      ({ added: [], available: [], legacy: true }) as Awaited<
+        ReturnType<typeof getAccountScopeLive>
+      >,
   );
+  // Record-level (if-owner) + field-level (PII) scope for BOTH hygiene scans —
+  // dup groups and blank contacts expose dni/phone/identities, so a masked or
+  // owner-scoped caller must get a scoped (separately cached) payload.
+  const [ownerId, maskSensitive] = await Promise.all([
+    ownerFilter(locals, 'crm'),
+    shouldMaskSensitive(locals, 'crm'),
+  ]);
   // `cleanup` feeds the non-default "Hygiene" tab and runs two cached scans;
   // STREAM it too (unawaited promise) so it never blocks the default Tags tab.
-  const cleanup = Promise.all([scanStandardizationCached(ctx), findDuplicatesCached(ctx), findBlanksCached(ctx)])
+  const cleanup = Promise.all([
+    scanStandardizationCached(ctx),
+    findDuplicatesCached(ctx, { ownerId, maskSensitive }),
+    findBlanksCached(ctx, { ownerId, maskSensitive }),
+  ])
     .then(([fixes, groups, blanks]) => ({ fixes, groups, blanks }))
-    .catch(() => ({ fixes: [], groups: [], blanks: [] }) as { fixes: never[]; groups: never[]; blanks: never[] });
+    .catch(
+      () =>
+        ({ fixes: [], groups: [], blanks: [] }) as {
+          fixes: never[];
+          groups: never[];
+          blanks: never[];
+        },
+    );
   return { tags, scope, cleanup };
 };

--- a/src/routes/api/crm/cleanup/duplicates/+server.ts
+++ b/src/routes/api/crm/cleanup/duplicates/+server.ts
@@ -3,13 +3,19 @@ import { json, error } from '@sveltejs/kit';
 import { z } from 'zod';
 import { getCoreCtx } from '$server/auth/core-ctx';
 import { parseBody } from '$server/api/validate';
+import { ownerFilter, shouldMaskSensitive } from '$server/services/rbac.service';
 import { findDuplicates, mergeContacts } from '$server/services/crm-cleanup.service';
 
 /** GET /api/crm/cleanup/duplicates — likely-duplicate groups (by DNI / name). */
 export const GET: RequestHandler = async ({ locals }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401);
-  return json({ groups: await findDuplicates(ctx) });
+  // Same record-level + field-level scope as the /crm/settings page load.
+  const [ownerId, maskSensitive] = await Promise.all([
+    ownerFilter(locals, 'crm'),
+    shouldMaskSensitive(locals, 'crm'),
+  ]);
+  return json({ groups: await findDuplicates(ctx, { ownerId, maskSensitive }) });
 };
 
 const postSchema = z.object({

--- a/src/server/services/crm-cleanup.service.test.ts
+++ b/src/server/services/crm-cleanup.service.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// The scans only use tx.execute — return the fixture rows for every query.
+let fixtureRows: unknown[] = [];
+vi.mock('$server/db/with-org-core', () => ({
+  withOrgCore: (_ctx: unknown, fn: (tx: unknown) => unknown) =>
+    fn({ execute: async () => fixtureRows }),
+}));
+
+import { findBlanks, findDuplicates } from './crm-cleanup.service';
+import type { CoreCtx } from '$server/auth/core-ctx';
+
+const ctx = { tenantId: 'org-1' } as unknown as CoreCtx;
+
+const blankRow = {
+  id: 'c1',
+  display_name: '.',
+  dni: '12345678',
+  phone: '997703234',
+  messages: 3,
+  identities: [
+    { channel: 'whatsapp', value: '997703234', externalId: '51997703234', handle: '997703234' },
+  ],
+};
+
+const dupRows = [
+  {
+    id: 'c1',
+    display_name: 'Ana Perez',
+    dni: '12345678',
+    phone: '997703234',
+    custom_fields: { dni: '12345678', distrito: 'Lima' },
+    messages: 3,
+    identities: [
+      { channel: 'whatsapp', value: '997703234', externalId: '51997703234', handle: '997703234' },
+    ],
+  },
+  {
+    id: 'c2',
+    display_name: 'Ana P.',
+    dni: '12345678',
+    phone: '997703235',
+    custom_fields: {},
+    messages: 1,
+    identities: [],
+  },
+];
+
+describe('cleanup scans: field-level PII masking', () => {
+  it('findBlanks returns raw PII for an unmasked caller', async () => {
+    fixtureRows = [blankRow];
+    const [b] = await findBlanks(ctx);
+    expect(b.dni).toBe('12345678');
+    expect(b.phone).toBe('997703234');
+    expect(b.identities[0].handle).toBe('997703234');
+  });
+
+  it('findBlanks redacts dni, phone, and every identity field when masked', async () => {
+    fixtureRows = [blankRow];
+    const [b] = await findBlanks(ctx, { maskSensitive: true });
+    expect(b.dni).not.toContain('1234567');
+    expect(b.phone).not.toContain('99770');
+    for (const i of b.identities) {
+      expect(i.value).not.toContain('99770');
+      expect(i.externalId).not.toContain('99770');
+      expect(i.handle).not.toContain('99770');
+    }
+    // Redaction keeps a recognizable tail, not the full value.
+    expect(b.dni).toMatch(/•/);
+  });
+
+  it('findDuplicates redacts contacts, custom_fields PII keys, and the DNI group key when masked', async () => {
+    fixtureRows = dupRows;
+    const groups = await findDuplicates(ctx, { maskSensitive: true });
+    const dniGroup = groups.find((g) => g.reason === 'dni');
+    expect(dniGroup).toBeDefined();
+    expect(dniGroup!.key).not.toBe('12345678');
+    for (const c of dniGroup!.contacts) {
+      expect(c.dni).not.toBe('12345678');
+      expect(String(c.customFields['dni'] ?? '')).not.toBe('12345678');
+      for (const i of c.identities) {
+        expect(i.value).not.toContain('99770');
+        expect(i.handle ?? '').not.toContain('99770');
+      }
+    }
+    // Non-PII custom fields survive untouched.
+    expect(dniGroup!.contacts[0].customFields['distrito']).toBe('Lima');
+  });
+
+  it('findDuplicates leaves everything raw for an unmasked caller', async () => {
+    fixtureRows = dupRows;
+    const groups = await findDuplicates(ctx);
+    const dniGroup = groups.find((g) => g.reason === 'dni');
+    expect(dniGroup!.key).toBe('12345678');
+    expect(dniGroup!.contacts[0].dni).toBe('12345678');
+  });
+});

--- a/src/server/services/crm-cleanup.service.ts
+++ b/src/server/services/crm-cleanup.service.ts
@@ -2,6 +2,7 @@ import { sql } from 'drizzle-orm';
 import { cached, invalidateTags, keys, tags } from '@minion-stack/cache';
 import { withOrgCore } from '$server/db/with-org-core';
 import type { CoreCtx } from '$server/auth/core-ctx';
+import { maskPii, maskContactFields } from '$lib/pii';
 import { proposeName, nameKey, isUnnamed, type NameIssue } from './crm-standardize';
 
 /**
@@ -28,19 +29,38 @@ export function scanStandardizationCached(ctx: CoreCtx): Promise<NameFix[]> {
   );
 }
 
-export function findDuplicatesCached(ctx: CoreCtx): Promise<DupGroup[]> {
+/** Record-level (if-owner) + field-level (PII) RBAC scope for the hygiene scans. */
+export interface CleanupScanScope {
+  ownerId?: string;
+  maskSensitive?: boolean;
+}
+
+/** Fold owner + mask into the tenant key — an if-owner-scoped or PII-masked
+ *  caller must never read/poison the org-wide cached payload (full dni/phone/
+ *  identities). The org-level invalidation tag still busts all variants. */
+function scopedTenantKey(tenantId: string, { ownerId, maskSensitive }: CleanupScanScope): string {
+  return `${tenantId}${ownerId ? `:${ownerId}` : ''}${maskSensitive ? ':m' : ''}`;
+}
+
+export function findDuplicatesCached(
+  ctx: CoreCtx,
+  scope: CleanupScanScope = {},
+): Promise<DupGroup[]> {
   return cached(
-    keys.hub('crm-duplicates', { t: ctx.tenantId }),
+    keys.hub('crm-duplicates', { t: scopedTenantKey(ctx.tenantId, scope) }),
     { ttl: '2m', swr: '30s', tags: [...tags.tenantDomain(ctx.tenantId, 'crm')] },
-    () => findDuplicates(ctx),
+    () => findDuplicates(ctx, scope),
   );
 }
 
-export function findBlanksCached(ctx: CoreCtx): Promise<BlankContact[]> {
+export function findBlanksCached(
+  ctx: CoreCtx,
+  scope: CleanupScanScope = {},
+): Promise<BlankContact[]> {
   return cached(
-    keys.hub('crm-blanks', { t: ctx.tenantId }),
+    keys.hub('crm-blanks', { t: scopedTenantKey(ctx.tenantId, scope) }),
     { ttl: '2m', swr: '30s', tags: [...tags.tenantDomain(ctx.tenantId, 'crm')] },
-    () => findBlanks(ctx),
+    () => findBlanks(ctx, scope),
   );
 }
 
@@ -118,7 +138,8 @@ export async function applyStandardization(
         insert into crm_activities (org_id, contact_id, kind, data)
         values ${sql.join(
           examples.map(
-            (e) => sql`(${ctx.tenantId}, ${e.id}::uuid, 'name_fix', ${JSON.stringify({ before: e.before, after: e.name })}::jsonb)`,
+            (e) =>
+              sql`(${ctx.tenantId}, ${e.id}::uuid, 'name_fix', ${JSON.stringify({ before: e.before, after: e.name })}::jsonb)`,
           ),
           sql`, `,
         )}
@@ -130,7 +151,10 @@ export async function applyStandardization(
 }
 
 /** Recent accepted before→after name fixes for this org — few-shot examples for AI review. */
-export async function recentNameFixes(ctx: CoreCtx, limit = 40): Promise<Array<{ before: string; after: string }>> {
+export async function recentNameFixes(
+  ctx: CoreCtx,
+  limit = 40,
+): Promise<Array<{ before: string; after: string }>> {
   const rows = (await withOrgCore(ctx, (tx) =>
     tx.execute(sql`
       select distinct on (data->>'before') data->>'before' as before, data->>'after' as after
@@ -199,7 +223,14 @@ function nameGroupConfidence(key: string, contacts: DupContact[]): number {
  * secondary = identical normalized name. Groups are deduped (a pair sharing both
  * DNI and name reports once, under DNI) and sorted most-confident first.
  */
-export async function findDuplicates(ctx: CoreCtx): Promise<DupGroup[]> {
+export async function findDuplicates(
+  ctx: CoreCtx,
+  scope: CleanupScanScope = {},
+): Promise<DupGroup[]> {
+  const { ownerId, maskSensitive = false } = scope;
+  // Record-level (if-owner) scope, same as rankContacts — a scoped caller must
+  // only see duplicate groups among contacts they own.
+  const ownerClause = ownerId ? sql`and c.owner_id = ${ownerId}` : sql``;
   const rows = (await withOrgCore(ctx, (tx) =>
     tx.execute(sql`
       with msgs as (
@@ -221,7 +252,7 @@ export async function findDuplicates(ctx: CoreCtx): Promise<DupGroup[]> {
         from crm_contact_identities i
         where i.org_id = c.org_id and i.contact_id = c.id
       ) ids on true
-      where c.org_id = ${ctx.tenantId} and c.deleted_at is null
+      where c.org_id = ${ctx.tenantId} and c.deleted_at is null ${ownerClause}
     `),
   )) as unknown as Array<{
     id: string;
@@ -233,15 +264,27 @@ export async function findDuplicates(ctx: CoreCtx): Promise<DupGroup[]> {
     identities: ContactIdentity[] | null;
   }>;
 
+  // Field-level: a masked caller gets redacted dni/phone/identities and
+  // PII-masked customFields — this hygiene view must never leak what the
+  // roster/detail page hide.
   const mk = (r: (typeof rows)[number]): DupContact => ({
     id: r.id,
     name: r.display_name,
-    dni: r.dni,
-    phone: r.phone,
+    dni: maskSensitive ? maskPii(r.dni) || null : r.dni,
+    phone: maskSensitive ? maskPii(r.phone) || null : r.phone,
     score: 0,
     messages: Number(r.messages) || 0,
-    identities: (Array.isArray(r.identities) ? r.identities : []).filter((i) => i && i.value),
-    customFields: r.custom_fields && typeof r.custom_fields === 'object' ? r.custom_fields : {},
+    identities: maskIdentities(
+      (Array.isArray(r.identities) ? r.identities : []).filter((i) => i && i.value),
+      maskSensitive,
+    ),
+    customFields: maskSensitive
+      ? maskContactFields(
+          r.custom_fields && typeof r.custom_fields === 'object' ? r.custom_fields : {},
+        )
+      : r.custom_fields && typeof r.custom_fields === 'object'
+        ? r.custom_fields
+        : {},
   });
 
   const byDni = new Map<string, DupContact[]>();
@@ -256,14 +299,25 @@ export async function findDuplicates(ctx: CoreCtx): Promise<DupGroup[]> {
   const seen = new Set<string>(); // contact ids already grouped under DNI
   for (const [key, contacts] of byDni) {
     if (contacts.length > 1) {
-      groups.push({ reason: 'dni', key, contacts, confidence: 0.9 });
+      // The group key IS the shared DNI — redact it for a masked caller.
+      groups.push({
+        reason: 'dni',
+        key: maskSensitive ? maskPii(key) : key,
+        contacts,
+        confidence: 0.9,
+      });
       contacts.forEach((c) => seen.add(c.id));
     }
   }
   for (const [key, contacts] of byName) {
     const fresh = contacts.filter((c) => !seen.has(c.id));
     if (fresh.length > 1) {
-      groups.push({ reason: 'name', key, contacts: fresh, confidence: nameGroupConfidence(key, fresh) });
+      groups.push({
+        reason: 'name',
+        key,
+        contacts: fresh,
+        confidence: nameGroupConfidence(key, fresh),
+      });
     }
   }
   // Most-confident first; tie-break on bigger groups.
@@ -287,7 +341,12 @@ export interface BlankContact {
  * emoji-only) — un-auto-fixable, surfaced for MANUAL naming with cross-reference
  * metadata (phone/DNI/channel identities). Most-active first.
  */
-export async function findBlanks(ctx: CoreCtx): Promise<BlankContact[]> {
+export async function findBlanks(
+  ctx: CoreCtx,
+  scope: CleanupScanScope = {},
+): Promise<BlankContact[]> {
+  const { ownerId, maskSensitive = false } = scope;
+  const ownerClause = ownerId ? sql`and c.owner_id = ${ownerId}` : sql``;
   const rows = (await withOrgCore(ctx, (tx) =>
     tx.execute(sql`
       with msgs as (
@@ -308,7 +367,7 @@ export async function findBlanks(ctx: CoreCtx): Promise<BlankContact[]> {
         from crm_contact_identities i
         where i.org_id = c.org_id and i.contact_id = c.id
       ) ids on true
-      where c.org_id = ${ctx.tenantId} and c.deleted_at is null
+      where c.org_id = ${ctx.tenantId} and c.deleted_at is null ${ownerClause}
         and char_length(regexp_replace(coalesce(c.display_name, ''), '[^[:alnum:]]+', '', 'g')) <= 1
       order by coalesce(mm.n, 0) desc
     `),
@@ -324,10 +383,25 @@ export async function findBlanks(ctx: CoreCtx): Promise<BlankContact[]> {
   return rows.map((r) => ({
     id: r.id,
     name: r.display_name,
-    dni: r.dni,
-    phone: r.phone,
+    dni: maskSensitive ? maskPii(r.dni) || null : r.dni,
+    phone: maskSensitive ? maskPii(r.phone) || null : r.phone,
     messages: Number(r.messages) || 0,
-    identities: (Array.isArray(r.identities) ? r.identities : []).filter((i) => i && i.value),
+    identities: maskIdentities(
+      (Array.isArray(r.identities) ? r.identities : []).filter((i) => i && i.value),
+      maskSensitive,
+    ),
+  }));
+}
+
+/** Redact every channel identity field (value, externalId, handle) for a
+ *  PII-masked caller — identity handles ARE phone numbers on WhatsApp. */
+function maskIdentities(identities: ContactIdentity[], maskSensitive: boolean): ContactIdentity[] {
+  if (!maskSensitive) return identities;
+  return identities.map((i) => ({
+    ...i,
+    value: maskPii(i.value),
+    externalId: i.externalId ? maskPii(i.externalId) : i.externalId,
+    handle: i.handle ? maskPii(i.handle) : i.handle,
   }));
 }
 
@@ -401,7 +475,9 @@ export async function mergeContacts(
       if (overrides.displayName != null && overrides.displayName !== '')
         sets.push(sql`display_name = ${overrides.displayName}`);
       if (overrides.customFields && Object.keys(overrides.customFields).length > 0)
-        sets.push(sql`custom_fields = coalesce(custom_fields, '{}'::jsonb) || ${JSON.stringify(overrides.customFields)}::jsonb`);
+        sets.push(
+          sql`custom_fields = coalesce(custom_fields, '{}'::jsonb) || ${JSON.stringify(overrides.customFields)}::jsonb`,
+        );
       if (sets.length)
         await tx.execute(sql`
           update crm_contacts set ${sql.join(sets, sql`, `)}


### PR DESCRIPTION
## Problem (live PII leak)
`findBlanks`/`findDuplicates` returned raw `dni`, `phone`, and channel identities to every authenticated caller and cached the payload under a **tenant-only** key. A field-level-masked or if-owner-scoped user got — and shared, via cache — the org-wide unmasked data on `/crm/settings` (Hygiene tab) and `GET /api/crm/cleanup/duplicates`.

## Fix
- Both scans take `CleanupScanScope` (`{ownerId, maskSensitive}`); `owner_id` clause mirrors `rankContacts`.
- Masked callers get `maskPii`-redacted dni/phone, identity `value`/`externalId`/`handle`, `custom_fields` PII keys (`maskContactFields`), and the DNI dup-group key.
- Scope folds into the cache key (`scopedTenantKey`) so scoped callers never read/poison the org-wide payload; org-level invalidation tag still busts all variants.
- Callers updated: `/crm/settings` page load + duplicates API GET.

## Tests
New `crm-cleanup.service.test.ts` (4 tests: masked/unmasked × blanks/duplicates, incl. group key + identity `handle`). `bun run check` ✅ 0/0, full `bun run test` ✅.

## Merge note
`feat/level-2026-07-30` carries commit `203375e4` with its own duplicates masking — these hunks will conflict; resolve toward whichever masks more (this branch also masks identity `handle` and the DNI group key, which `203375e4` misses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xJxVeuuJUWwUNwaSKofGe