### PR TITLE
feat(realtime): org-scoped message broadcast

### DIFF
--- a/src/lib/realtime/org-events.test.ts
+++ b/src/lib/realtime/org-events.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  let broadcastHandler: ((payload: unknown) => void) | null = null;
+  let subscribeHandler: ((status: string, error?: Error) => void) | null = null;
+  const channel = {
+    on: vi.fn((_type: string, _filter: unknown, handler: (payload: unknown) => void) => {
+      broadcastHandler = handler;
+      return channel;
+    }),
+    subscribe: vi.fn((handler: (status: string, error?: Error) => void) => {
+      subscribeHandler = handler;
+      return channel;
+    }),
+  };
+  const client = {
+    channel: vi.fn(() => channel),
+    removeChannel: vi.fn(async () => 'ok'),
+    realtime: { setAuth: vi.fn(async () => {}) },
+  };
+  return {
+    channel,
+    client,
+    getBroadcastHandler: () => broadcastHandler,
+    getSubscribeHandler: () => subscribeHandler,
+    resetHandlers: () => {
+      broadcastHandler = null;
+      subscribeHandler = null;
+    },
+  };
+});
+
+vi.mock('$lib/supabase/client', () => ({
+  supabaseBrowser: () => mocks.client,
+}));
+
+import { disconnectOrgRealtime, orgRealtimeTopic, subscribeMessageCommitted } from './org-events';
+
+describe('org realtime channel', () => {
+  beforeEach(() => {
+    disconnectOrgRealtime();
+    mocks.resetHandlers();
+    vi.clearAllMocks();
+  });
+
+  it('shares one private channel and one auth join per org', async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const unsubscribeFirst = subscribeMessageCommitted('org-1', first);
+    const unsubscribeSecond = subscribeMessageCommitted('org-1', second);
+
+    await Promise.resolve();
+
+    expect(mocks.client.channel).toHaveBeenCalledTimes(1);
+    expect(mocks.client.channel).toHaveBeenCalledWith(orgRealtimeTopic('org-1'), {
+      config: { private: true },
+    });
+    expect(mocks.client.realtime.setAuth).toHaveBeenCalledTimes(1);
+    expect(mocks.channel.subscribe).toHaveBeenCalledTimes(1);
+
+    unsubscribeFirst();
+    expect(mocks.client.removeChannel).not.toHaveBeenCalled();
+    unsubscribeSecond();
+    expect(mocks.client.removeChannel).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches only valid message.committed payloads', async () => {
+    const handler = vi.fn();
+    subscribeMessageCommitted('org-1', handler);
+    await Promise.resolve();
+
+    mocks.getBroadcastHandler()?.({
+      event: 'message.committed',
+      payload: {
+        version: 1,
+        id: 'message-1',
+        clientId: 'client-1',
+        channel: 'whatsapp',
+        accountId: 'account-1',
+        chatId: 'chat-1',
+        direction: 'inbound',
+        occurredAt: '2026-07-25T22:30:00.000Z',
+      },
+    });
+    mocks.getBroadcastHandler()?.({
+      event: 'message.committed',
+      payload: { version: 1, id: 'incomplete' },
+    });
+    mocks.getBroadcastHandler()?.({
+      event: 'some.future.event',
+      payload: {},
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ id: 'message-1' }));
+  });
+
+  it('reports private-channel status without creating another channel', async () => {
+    const status = vi.fn();
+    subscribeMessageCommitted('org-1', vi.fn(), status);
+    await Promise.resolve();
+
+    expect(status).toHaveBeenCalledWith('CONNECTING');
+    mocks.getSubscribeHandler()?.('SUBSCRIBED');
+    expect(status).toHaveBeenLastCalledWith('SUBSCRIBED', undefined);
+  });
+});

--- a/src/lib/realtime/org-events.ts
+++ b/src/lib/realtime/org-events.ts
@@ -1,0 +1,178 @@
+import type { RealtimeChannel, SupabaseClient } from '@supabase/supabase-js';
+import { supabaseBrowser } from '$lib/supabase/client';
+
+export const MESSAGE_COMMITTED_EVENT = 'message.committed' as const;
+
+export type MessageCommittedEvent = {
+  version: 1;
+  id: string;
+  clientId: string;
+  channel: string;
+  accountId: string | null;
+  chatId: string | null;
+  direction: 'inbound' | 'outbound';
+  occurredAt: string;
+};
+
+export type OrgRealtimeStatus =
+  'CONNECTING' | 'SUBSCRIBED' | 'TIMED_OUT' | 'CLOSED' | 'CHANNEL_ERROR';
+
+type EventHandler = (payload: unknown) => void;
+type StatusHandler = (status: OrgRealtimeStatus, error?: Error) => void;
+
+type BroadcastEnvelope = {
+  event?: unknown;
+  payload?: unknown;
+};
+
+type OrgChannelEntry = {
+  client: SupabaseClient;
+  channel: RealtimeChannel;
+  handlers: Map<string, Set<EventHandler>>;
+  statusHandlers: Set<StatusHandler>;
+  status: OrgRealtimeStatus;
+  closed: boolean;
+};
+
+const orgChannels = new Map<string, OrgChannelEntry>();
+
+export function orgRealtimeTopic(orgId: string): string {
+  return `org:${orgId}:events`;
+}
+
+function dispatch(entry: OrgChannelEntry, envelope: BroadcastEnvelope): void {
+  if (typeof envelope.event !== 'string') return;
+  const handlers = entry.handlers.get(envelope.event);
+  if (!handlers) return;
+  for (const handler of handlers) handler(envelope.payload);
+}
+
+function setStatus(entry: OrgChannelEntry, status: OrgRealtimeStatus, error?: Error): void {
+  entry.status = status;
+  for (const handler of entry.statusHandlers) handler(status, error);
+}
+
+function createOrgChannel(orgId: string): OrgChannelEntry {
+  const client = supabaseBrowser() as SupabaseClient;
+  const channel = client.channel(orgRealtimeTopic(orgId), {
+    config: { private: true },
+  });
+  const entry: OrgChannelEntry = {
+    client,
+    channel,
+    handlers: new Map(),
+    statusHandlers: new Set(),
+    status: 'CONNECTING',
+    closed: false,
+  };
+
+  channel.on('broadcast', { event: '*' }, (envelope) => dispatch(entry, envelope));
+
+  // Supabase-js keeps this token updated after auth refreshes. Calling setAuth
+  // before the first private-channel join also covers a session restored from
+  // the SSR cookie on initial hydration.
+  void client.realtime
+    .setAuth()
+    .then(() => {
+      if (entry.closed) return;
+      channel.subscribe((status, error) => {
+        if (entry.closed) return;
+        setStatus(entry, status as OrgRealtimeStatus, error);
+      });
+    })
+    .catch((error: unknown) => {
+      if (entry.closed) return;
+      setStatus(entry, 'CHANNEL_ERROR', error instanceof Error ? error : new Error(String(error)));
+    });
+
+  return entry;
+}
+
+function ensureOrgChannel(orgId: string): OrgChannelEntry {
+  const existing = orgChannels.get(orgId);
+  if (existing) return existing;
+  const entry = createOrgChannel(orgId);
+  orgChannels.set(orgId, entry);
+  return entry;
+}
+
+function releaseOrgChannel(orgId: string, entry: OrgChannelEntry): void {
+  const hasHandlers = [...entry.handlers.values()].some((handlers) => handlers.size > 0);
+  if (hasHandlers || entry.statusHandlers.size > 0) return;
+  if (orgChannels.get(orgId) !== entry) return;
+  entry.closed = true;
+  orgChannels.delete(orgId);
+  void entry.client.removeChannel(entry.channel);
+}
+
+/**
+ * Subscribe to one event on the org's shared private channel.
+ *
+ * Components in the same tab/org share one channel and one authorization join.
+ * The event is a change signal; callers still fetch canonical data through the
+ * existing SvelteKit/API path, preserving RBAC and field masking.
+ */
+export function subscribeOrgBroadcast(
+  orgId: string,
+  event: string,
+  handler: EventHandler,
+  onStatus?: StatusHandler,
+): () => void {
+  if (!orgId || !event) return () => {};
+  const entry = ensureOrgChannel(orgId);
+  const handlers = entry.handlers.get(event) ?? new Set<EventHandler>();
+  handlers.add(handler);
+  entry.handlers.set(event, handlers);
+  if (onStatus) {
+    entry.statusHandlers.add(onStatus);
+    onStatus(entry.status);
+  }
+
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+    handlers.delete(handler);
+    if (handlers.size === 0) entry.handlers.delete(event);
+    if (onStatus) entry.statusHandlers.delete(onStatus);
+    releaseOrgChannel(orgId, entry);
+  };
+}
+
+export function isMessageCommittedEvent(payload: unknown): payload is MessageCommittedEvent {
+  if (!payload || typeof payload !== 'object') return false;
+  const event = payload as Partial<MessageCommittedEvent>;
+  return (
+    event.version === 1 &&
+    typeof event.id === 'string' &&
+    typeof event.clientId === 'string' &&
+    typeof event.channel === 'string' &&
+    (event.chatId === null || typeof event.chatId === 'string') &&
+    (event.direction === 'inbound' || event.direction === 'outbound') &&
+    typeof event.occurredAt === 'string'
+  );
+}
+
+export function subscribeMessageCommitted(
+  orgId: string,
+  handler: (payload: MessageCommittedEvent) => void,
+  onStatus?: StatusHandler,
+): () => void {
+  return subscribeOrgBroadcast(
+    orgId,
+    MESSAGE_COMMITTED_EVENT,
+    (payload) => {
+      if (isMessageCommittedEvent(payload)) handler(payload);
+    },
+    onStatus,
+  );
+}
+
+/** Disconnect all org channels, primarily for logout/test cleanup. */
+export function disconnectOrgRealtime(): void {
+  for (const [orgId, entry] of orgChannels) {
+    entry.handlers.clear();
+    entry.statusHandlers.clear();
+    releaseOrgChannel(orgId, entry);
+  }
+}

--- a/src/lib/supabase/client.test.ts
+++ b/src/lib/supabase/client.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  client: { id: 'browser-supabase-client' },
+  createBrowserClient: vi.fn(),
+}));
+
+mocks.createBrowserClient.mockReturnValue(mocks.client);
+
+vi.mock('@supabase/ssr', () => ({
+  createBrowserClient: mocks.createBrowserClient,
+}));
+
+import { supabaseBrowser } from './client';
+
+describe('supabaseBrowser', () => {
+  it('reuses one client so Realtime channels multiplex over one tab socket', () => {
+    const first = supabaseBrowser();
+    const second = supabaseBrowser();
+
+    expect(first).toBe(second);
+    expect(mocks.createBrowserClient).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,5 +1,21 @@
 import { createBrowserClient } from '@supabase/ssr';
 import { env } from '$env/dynamic/public';
 
-export const supabaseBrowser = () =>
-  createBrowserClient(env.PUBLIC_SUPABASE_URL ?? '', env.PUBLIC_SUPABASE_ANON_KEY ?? '');
+type BrowserSupabaseClient = ReturnType<typeof createBrowserClient>;
+
+let browserClient: BrowserSupabaseClient | null = null;
+
+/**
+ * One Supabase client per browser tab.
+ *
+ * Realtime multiplexes channels over the client's single WebSocket. Creating a
+ * client per component would create parallel sockets, duplicate auth refresh
+ * work, and multiply private-channel authorization checks as the UI grows.
+ */
+export const supabaseBrowser = (): BrowserSupabaseClient => {
+  browserClient ??= createBrowserClient(
+    env.PUBLIC_SUPABASE_URL ?? '',
+    env.PUBLIC_SUPABASE_ANON_KEY ?? '',
+  );
+  return browserClient;
+};

--- a/src/server/db/messages-realtime-broadcast-migration.test.ts
+++ b/src/server/db/messages-realtime-broadcast-migration.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const migration = readFileSync(
+  new URL(
+    '../../../supabase/migrations/20260725223000_messages_realtime_broadcast.sql',
+    import.meta.url,
+  ),
+  'utf8',
+).replace(/\s+/g, ' ');
+
+describe('messages Realtime Broadcast migration', () => {
+  it('emits one compact private event only after a new message commits', () => {
+    expect(migration).toMatch(/after insert on public\.messages/i);
+    expect(migration).toMatch(/perform realtime\.send\(/i);
+    expect(migration).toMatch(/'message\.committed'/i);
+    expect(migration).toMatch(/'org:' \|\| new\.org_id \|\| ':events'/i);
+    expect(migration).toMatch(/'occurredAt', coalesce\(new\.occurred_at, new\.created_at\)/i);
+    expect(migration).not.toMatch(/'content', new\.content/i);
+    expect(migration).not.toMatch(/after insert or update or delete/i);
+  });
+
+  it('authorizes receives by exact topic and active Supabase membership', () => {
+    expect(migration).toMatch(/for select to authenticated/i);
+    expect(migration).toMatch(/membership\.profile_id = \(select auth\.uid\(\)\)/i);
+    expect(migration).toMatch(
+      /realtime\.topic\(\)\) = 'org:' \|\| membership\.organization_id::text \|\| ':events'/i,
+    );
+    expect(migration).not.toMatch(/for insert to authenticated/i);
+  });
+});

--- a/supabase/migrations/20260725223000_messages_realtime_broadcast.sql
+++ b/supabase/migrations/20260725223000_messages_realtime_broadcast.sql
@@ -1,0 +1,65 @@
+-- Browser freshness for the canonical messages ledger.
+--
+-- This is deliberately Broadcast-from-Database, not Postgres Changes:
+--  * the payload is compact and contains no conversation body/PII;
+--  * one event is authorized once per private org-channel join rather than
+--    re-running row authorization for every subscriber/change;
+--  * the message and its change signal commit atomically.
+
+create or replace function public.hub_broadcast_message_committed()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  perform realtime.send(
+    jsonb_build_object(
+      'version', 1,
+      'id', new.id,
+      'clientId', new.client_id,
+      'channel', new.channel,
+      'accountId', new.account_id,
+      'chatId', new.chat_id,
+      'direction', new.direction,
+      'occurredAt', coalesce(new.occurred_at, new.created_at)
+    ),
+    'message.committed',
+    'org:' || new.org_id || ':events',
+    true
+  );
+  return null;
+end;
+$$;
+
+revoke all on function public.hub_broadcast_message_committed() from public;
+revoke all on function public.hub_broadcast_message_committed() from anon;
+revoke all on function public.hub_broadcast_message_committed() from authenticated;
+
+drop trigger if exists messages_realtime_broadcast on public.messages;
+create trigger messages_realtime_broadcast
+after insert on public.messages
+for each row
+execute function public.hub_broadcast_message_committed();
+
+-- Browser clients may receive database-originated Broadcasts for organizations
+-- where their Supabase profile has an active membership. No INSERT policy is
+-- created: browsers cannot publish trusted Hub change events.
+drop policy if exists org_members_receive_hub_broadcasts on realtime.messages;
+create policy org_members_receive_hub_broadcasts
+on realtime.messages
+for select
+to authenticated
+using (
+  realtime.messages.extension = 'broadcast'
+  and exists (
+    select 1
+    from public.organization_members as membership
+    where membership.profile_id = (select auth.uid())
+      and (select realtime.topic()) =
+        'org:' || membership.organization_id::text || ':events'
+  )
+);
+
+comment on function public.hub_broadcast_message_committed() is
+  'Emits a compact private message.committed change signal for Hub browser freshness.';


### PR DESCRIPTION
First scoped slice off `feat/level-2026-07-30`, which is 8 behind master and cannot be rebased safely (a rebase resurrects the `socials/ad-performance` page that PR #88 deliberately deleted). Ported as-is from `44ecc023`; 6 files, nothing else from that branch rides along.

## What it does

Browser freshness for the canonical messages ledger, via **Broadcast-from-Database** rather than Postgres Changes — the payload is compact and carries no conversation body or PII, authorization runs once per private org-channel join instead of per row per subscriber, and the message and its change signal commit atomically.

An `AFTER INSERT` trigger on `public.messages` emits `message.committed` on the private `org:<id>:events` topic. An RLS policy lets a browser receive broadcasts only for organizations where its Supabase profile has an active membership. **No INSERT policy** — browsers cannot publish trusted Hub change events. The function is `SECURITY DEFINER` with an empty `search_path` and is revoked from `public`, `anon` and `authenticated`.

## Production pre-flight

`vercel-build` runs `db:migrate` before `build`, and a failed migration aborts the deploy — so the migration's assumptions were checked against production first, not assumed:

| Check | Result |
|---|---|
| all 9 referenced `messages` columns | present |
| `organization_members.profile_id` / `.organization_id` | present, both `uuid` — so the `::text` cast in the topic comparison is required and is there |
| `messages.org_id` vs the membership uuid | `org_id` is `text`, **557,613 / 557,613** rows canonical uuid form, so the two topic strings match |
| `realtime.send`, `realtime.topic` | both exist |
| `realtime.messages` ownership | owned by `supabase_realtime_admin`, migration runs as `postgres` — `CREATE POLICY` verified to succeed anyway |
| whole migration | applied inside a transaction against production and **rolled back**; clean, nothing persisted |

The runner is idempotent per version via the `hub_migrations` ledger, applies each file in one transaction under an advisory lock, and this version is not yet recorded.

## Worth knowing

The trigger fires **per inserted row**, so bulk inserts emit one `realtime.send` each — the 5-minute `messages_tail` job inserts ~270 rows per run, which is fine, but a large WhatsApp history sync would emit proportionally. That's inherent to the row-trigger design the migration documents as deliberate; flagging it rather than changing someone else's design decision in a port.

## Gates

`bun run check` 0 errors / 0 warnings · 6 new tests pass · `lint:tokens` 0 violations · no `.svelte` files touched. `lint:design` silent-skips in a master worktree (its base defaults to the deleted `origin/dev`) — no design surface in this change either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)