### PR TITLE
feat(finances): bank statement imports

### DIFF
--- a/src/routes/api/finances/statement-imports/+server.ts
+++ b/src/routes/api/finances/statement-imports/+server.ts
@@ -1,0 +1,57 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { json, error } from '@sveltejs/kit';
+import { z } from 'zod';
+import { getCoreCtx } from '$server/auth/core-ctx';
+import { parseBody } from '$server/api/validate';
+import { isModuleEnabled } from '$server/services/modules.service';
+import { createImport, requirePersonalOrg } from '$server/services/finance-statements.service';
+
+// R5: dedicated upload endpoint — NOT raw /api/files (no finance capability/
+// MIME/size/hash checks there). Multipart 'file' → CSV; JSON { text } → pasted.
+const MAX_CSV_BYTES = 10 * 1024 * 1024; // 10 MB
+const MAX_TEXT_CHARS = 500_000; // ~500 KB pasted text
+const ALLOWED_CSV_MIME = new Set([
+  'text/csv',
+  'application/vnd.ms-excel',
+  'text/plain',
+  'application/octet-stream',
+]);
+
+const textSchema = z.object({ text: z.string().min(1).max(MAX_TEXT_CHARS) });
+
+/** POST /api/finances/statement-imports — create (or dedupe onto) an import
+ *  and enqueue the statement_ingest background job. */
+export const POST: RequestHandler = async ({ locals, request }) => {
+  const ctx = await getCoreCtx(locals);
+  if (!ctx) throw error(401);
+  if (!(await isModuleEnabled(ctx, 'finances'))) throw error(403, 'finances module disabled');
+  await requirePersonalOrg(ctx);
+
+  const contentType = request.headers.get('content-type') ?? '';
+  const createdBy = locals.user?.supabaseId ?? null;
+
+  if (contentType.includes('multipart/form-data')) {
+    const formData = await request.formData();
+    const file = formData.get('file');
+    if (!(file instanceof File)) throw error(400, 'file is required');
+    if (file.size === 0) throw error(400, 'file is empty');
+    if (file.size > MAX_CSV_BYTES) throw error(413, `file too large (max ${MAX_CSV_BYTES} bytes)`);
+    const isCsvName = file.name.toLowerCase().endsWith('.csv');
+    if (!isCsvName && !ALLOWED_CSV_MIME.has(file.type)) {
+      throw error(400, 'unsupported file type — expected CSV');
+    }
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    const result = await createImport(ctx, {
+      sourceKind: 'csv',
+      fileName: file.name,
+      contentType: file.type || 'text/csv',
+      bytes,
+      createdBy,
+    });
+    return json({ id: result.import.id, status: result.import.status, created: result.created });
+  }
+
+  const body = await parseBody(request, textSchema);
+  const result = await createImport(ctx, { sourceKind: 'text', text: body.text, createdBy });
+  return json({ id: result.import.id, status: result.import.status, created: result.created });
+};

--- a/src/routes/api/finances/statement-imports/[id]/+server.ts
+++ b/src/routes/api/finances/statement-imports/[id]/+server.ts
@@ -1,0 +1,18 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { json, error } from '@sveltejs/kit';
+import { getCoreCtx } from '$server/auth/core-ctx';
+import { isModuleEnabled } from '$server/services/modules.service';
+import { getImportStatus, requirePersonalOrg } from '$server/services/finance-statements.service';
+
+/** GET /api/finances/statement-imports/:id — status incl. counts + a bounded
+ *  sample of rejected rows (recomputed deterministically, not persisted). */
+export const GET: RequestHandler = async ({ locals, params }) => {
+  const ctx = await getCoreCtx(locals);
+  if (!ctx) throw error(401);
+  if (!(await isModuleEnabled(ctx, 'finances'))) throw error(403, 'finances module disabled');
+  await requirePersonalOrg(ctx);
+
+  const status = await getImportStatus(ctx, params.id!);
+  if (!status) throw error(404);
+  return json(status);
+};

--- a/src/routes/api/finances/statement-imports/[id]/retry/+server.ts
+++ b/src/routes/api/finances/statement-imports/[id]/retry/+server.ts
@@ -1,0 +1,19 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { json, error } from '@sveltejs/kit';
+import { getCoreCtx } from '$server/auth/core-ctx';
+import { isModuleEnabled } from '$server/services/modules.service';
+import { retryImport, requirePersonalOrg } from '$server/services/finance-statements.service';
+
+/** POST /api/finances/statement-imports/:id/retry — reuse the same import;
+ *  resumes from its existing next_chunk (no-op unless status is 'failed' or
+ *  'undone'; an undone import restarts from chunk 0). */
+export const POST: RequestHandler = async ({ locals, params }) => {
+  const ctx = await getCoreCtx(locals);
+  if (!ctx) throw error(401);
+  if (!(await isModuleEnabled(ctx, 'finances'))) throw error(403, 'finances module disabled');
+  await requirePersonalOrg(ctx);
+
+  const row = await retryImport(ctx, params.id!);
+  if (!row) throw error(404);
+  return json({ id: row.id, status: row.status });
+};

--- a/src/routes/api/finances/statement-imports/[id]/undo/+server.ts
+++ b/src/routes/api/finances/statement-imports/[id]/undo/+server.ts
@@ -1,0 +1,18 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { json, error } from '@sveltejs/kit';
+import { getCoreCtx } from '$server/auth/core-ctx';
+import { isModuleEnabled } from '$server/services/modules.service';
+import { undoImport, requirePersonalOrg } from '$server/services/finance-statements.service';
+
+/** POST /api/finances/statement-imports/:id/undo — delete every transaction
+ *  persisted for this import and reset it to a clean 'queued' state. */
+export const POST: RequestHandler = async ({ locals, params }) => {
+  const ctx = await getCoreCtx(locals);
+  if (!ctx) throw error(401);
+  if (!(await isModuleEnabled(ctx, 'finances'))) throw error(403, 'finances module disabled');
+  await requirePersonalOrg(ctx);
+
+  const row = await undoImport(ctx, params.id!);
+  if (!row) throw error(404);
+  return json({ id: row.id, status: row.status });
+};

--- a/src/server/db/pg-finance-schema.ts
+++ b/src/server/db/pg-finance-schema.ts
@@ -7,8 +7,10 @@ import {
   timestamp,
   boolean,
   integer,
+  date,
   index,
   uniqueIndex,
+  foreignKey,
 } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 
@@ -252,6 +254,82 @@ export const finSettings = pgTable('fin_settings', {
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
 });
 
+/**
+ * Personal-finance statement imports (WP4, R4/R5 of the personal-org spec).
+ * NEW tables — deliberately separate from fin_invoices (a sales document, not
+ * a bank-statement transaction). One row per uploaded/pasted statement.
+ * Idempotency: UNIQUE(org_id, content_sha256) — re-submitting identical bytes
+ * returns the existing import instead of duplicating. `next_chunk` is the
+ * resumable cursor the `statement_ingest` bg-runtime handler advances.
+ */
+export const finStatementImports = pgTable(
+  'fin_statement_imports',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    orgId: text('org_id').notNull(),
+    fileId: text('file_id'), // bridges to files.id (cuid2 text, not uuid)
+    sourceKind: text('source_kind').notNull(), // 'csv' | 'text'
+    contentSha256: text('content_sha256').notNull(),
+    parserVersion: integer('parser_version').notNull(),
+    status: text('status').notNull().default('queued'), // queued|parsing|done|failed|undone
+    nextChunk: integer('next_chunk').notNull().default(0),
+    rowCount: integer('row_count'),
+    insertedCount: integer('inserted_count'),
+    rejectedCount: integer('rejected_count'),
+    errorCode: text('error_code'),
+    errorMessage: text('error_message'),
+    createdBy: uuid('created_by'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    finishedAt: timestamp('finished_at', { withTimezone: true }),
+  },
+  (t) => ({
+    uniq: uniqueIndex('fin_statement_imports_org_sha_uniq').on(t.orgId, t.contentSha256),
+    orgIdx: index('fin_statement_imports_org_idx').on(t.orgId, t.createdAt),
+    // Composite FK target: lets fin_transactions enforce same-org parentage.
+    orgIdUniq: uniqueIndex('fin_statement_imports_org_id_uniq').on(t.orgId, t.id),
+  }),
+);
+
+/**
+ * Parsed bank-statement rows. `signedAmount` carries direction via sign (no
+ * separate direction column). `partyId` is a soft bridge to the party spine
+ * (no FK — same pattern as fin_clients.partyId), populated later by CRM
+ * cashflow matching (out of scope for this wave).
+ */
+export const finTransactions = pgTable(
+  'fin_transactions',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    orgId: text('org_id').notNull(),
+    importId: uuid('import_id').notNull(),
+    sourceRow: integer('source_row').notNull(),
+    postedOn: date('posted_on').notNull(),
+    description: text('description').notNull(),
+    signedAmount: numeric('signed_amount', { precision: 18, scale: 2 }).notNull(),
+    currency: text('currency'),
+    counterparty: text('counterparty'),
+    category: text('category'),
+    reference: text('reference'),
+    partyId: uuid('party_id'),
+    confidence: numeric('confidence'),
+    warnings: jsonb('warnings').notNull().default([]),
+    raw: jsonb('raw').notNull().default({}),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    uniq: uniqueIndex('fin_transactions_import_row_uniq').on(t.importId, t.sourceRow),
+    orgPostedIdx: index('fin_transactions_org_posted_idx').on(t.orgId, t.postedOn),
+    partyIdx: index('fin_transactions_party_idx').on(t.partyId),
+    // (org_id, import_id) → (org_id, id): a transaction cannot reference
+    // another org's import (RLS alone only checks the transaction's org_id).
+    orgImportFk: foreignKey({
+      name: 'fin_transactions_org_import_fk',
+      columns: [t.orgId, t.importId],
+      foreignColumns: [finStatementImports.orgId, finStatementImports.id],
+    }).onDelete('cascade'),
+  }),
+);
+
 export type FinInvoice = typeof finInvoices.$inferSelect;
 export type FinInvoiceItem = typeof finInvoiceItems.$inferSelect;
 export type FinPayment = typeof finPayments.$inferSelect;
@@ -260,3 +338,5 @@ export type FinProduct = typeof finProducts.$inferSelect;
 export type FinSource = typeof finSources.$inferSelect;
 export type FinSyncJob = typeof finSyncJobs.$inferSelect;
 export type FinSettingsRow = typeof finSettings.$inferSelect;
+export type FinStatementImport = typeof finStatementImports.$inferSelect;
+export type FinTransaction = typeof finTransactions.$inferSelect;

--- a/src/server/services/finance-statement-parser.test.ts
+++ b/src/server/services/finance-statement-parser.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseStatementCsv,
+  parseStatementDate,
+  parseStatementAmount,
+  normalizeStatementText,
+} from './finance-statement-parser';
+
+describe('normalizeStatementText', () => {
+  it('collapses CRLF and bare CR to LF', () => {
+    expect(normalizeStatementText('a\r\nb\rc\nd')).toBe('a\nb\nc\nd');
+  });
+});
+
+describe('parseStatementDate', () => {
+  it('parses ISO dates', () => {
+    expect(parseStatementDate('2026-03-04')).toEqual({ iso: '2026-03-04', ambiguous: false });
+  });
+  it('resolves unambiguous DD/MM/YYYY (day > 12)', () => {
+    expect(parseStatementDate('25/03/2026')).toEqual({ iso: '2026-03-25', ambiguous: false });
+  });
+  it('resolves unambiguous MM/DD/YYYY when the first slot cannot be a month', () => {
+    expect(parseStatementDate('03/25/2026')).toEqual({ iso: '2026-03-25', ambiguous: false });
+  });
+  it('defaults genuinely ambiguous dates to DD/MM/YYYY and flags it', () => {
+    expect(parseStatementDate('03/04/2026')).toEqual({ iso: '2026-04-03', ambiguous: true });
+  });
+  it('rejects invalid dates', () => {
+    expect(parseStatementDate('2026-13-40')).toBeNull();
+    expect(parseStatementDate('not a date')).toBeNull();
+  });
+});
+
+describe('parseStatementAmount', () => {
+  it('parses plain numbers', () => {
+    expect(parseStatementAmount('123.45')).toBe(123.45);
+    expect(parseStatementAmount('-123.45')).toBe(-123.45);
+  });
+  it('resolves EU format (dot thousands, comma decimal)', () => {
+    expect(parseStatementAmount('1.234,56')).toBeCloseTo(1234.56);
+  });
+  it('resolves US format (comma thousands, dot decimal)', () => {
+    expect(parseStatementAmount('1,234.56')).toBeCloseTo(1234.56);
+  });
+  it('treats a lone comma with 2 trailing digits as decimal', () => {
+    expect(parseStatementAmount('45,90')).toBeCloseTo(45.9);
+  });
+  it('treats a lone dot with 1 trailing digit as decimal, not thousands (regression: was ×10)', () => {
+    expect(parseStatementAmount('45.9')).toBeCloseTo(45.9);
+  });
+  it('treats a lone comma with 1 trailing digit as decimal', () => {
+    expect(parseStatementAmount('45,9')).toBeCloseTo(45.9);
+  });
+  it('a lone separator with exactly 3 trailing digits is structurally ambiguous (thousands vs 3-decimal amount) — refuses to guess', () => {
+    expect(parseStatementAmount('1.234')).toBeNull();
+    expect(parseStatementAmount('45,900')).toBeNull();
+  });
+  it('resolves multi-group EU thousands unambiguously (2+ repeated 3-digit groups)', () => {
+    expect(parseStatementAmount('12.345.678')).toBe(12345678);
+  });
+  it('resolves multi-group US thousands unambiguously (2+ repeated 3-digit groups)', () => {
+    expect(parseStatementAmount('1,234,567')).toBe(1234567);
+  });
+  it('parses parenthesized amounts as negative', () => {
+    expect(parseStatementAmount('(50.00)')).toBe(-50);
+  });
+  it('strips currency symbols', () => {
+    expect(parseStatementAmount('S/ 100.00')).toBe(100);
+    expect(parseStatementAmount('$1,000.00')).toBe(1000);
+  });
+  it('returns null for empty/unparseable input', () => {
+    expect(parseStatementAmount('')).toBeNull();
+    expect(parseStatementAmount('  ')).toBeNull();
+  });
+});
+
+describe('parseStatementCsv', () => {
+  it('parses a happy-path CSV with a single signed amount column', () => {
+    const csv = [
+      'Date,Description,Amount',
+      '2026-01-05,Grocery store,-45.90',
+      '2026-01-06,Salary,2500.00',
+    ].join('\n');
+    const result = parseStatementCsv(csv);
+    expect(result.rows).toHaveLength(2);
+    expect(result.rejected).toHaveLength(0);
+    expect(result.rows[0]).toMatchObject({
+      sourceRow: 1,
+      postedOn: '2026-01-05',
+      description: 'Grocery store',
+      signedAmount: '-45.90',
+    });
+    expect(result.rows[1].signedAmount).toBe('2500.00');
+  });
+
+  it('parses debit/credit columns into a signed amount (credit − debit)', () => {
+    const csv = [
+      'Fecha,Detalle,Cargo,Abono',
+      '2026-01-05,Compra,45.90,',
+      '2026-01-06,Deposito,,2500.00',
+    ].join('\n');
+    const result = parseStatementCsv(csv);
+    expect(result.rejected).toHaveLength(0);
+    expect(result.rows[0].signedAmount).toBe('-45.90');
+    expect(result.rows[1].signedAmount).toBe('2500.00');
+  });
+
+  it('handles CRLF line endings identically to LF', () => {
+    const csv = ['Date,Description,Amount', '2026-01-05,Grocery store,-45.90'].join('\r\n');
+    const result = parseStatementCsv(csv);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].description).toBe('Grocery store');
+  });
+
+  it('rejects rows with an invalid date, keeping other rows intact', () => {
+    const csv = [
+      'Date,Description,Amount',
+      'not-a-date,Grocery store,-45.90',
+      '2026-01-06,Salary,2500.00',
+    ].join('\n');
+    const result = parseStatementCsv(csv);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0]).toMatchObject({ sourceRow: 1, reason: 'invalid-date' });
+  });
+
+  it('rejects rows with an invalid/blank amount', () => {
+    const csv = ['Date,Description,Amount', '2026-01-05,Grocery store,not-a-number'].join('\n');
+    const result = parseStatementCsv(csv);
+    expect(result.rejected[0].reason).toBe('invalid-amount');
+  });
+
+  it('rejects rows with a missing description', () => {
+    const csv = ['Date,Description,Amount', '2026-01-05,,-45.90'].join('\n');
+    const result = parseStatementCsv(csv);
+    expect(result.rejected[0].reason).toBe('missing-description');
+  });
+
+  it('rejects every data row with needs-llm when columns cannot be confidently mapped', () => {
+    const csv = ['Col A,Col B,Col C', 'x,y,z', 'a,b,c'].join('\n');
+    const result = parseStatementCsv(csv);
+    expect(result.rows).toHaveLength(0);
+    expect(result.rejected).toHaveLength(2);
+    expect(result.rejected.every((r) => r.reason === 'needs-llm')).toBe(true);
+  });
+
+  it('every input data row lands in exactly one of rows/rejected', () => {
+    const csv = [
+      'Date,Description,Amount',
+      '2026-01-05,Grocery store,-45.90',
+      'bad-date,Something,10.00',
+      '2026-01-06,,5.00',
+      '2026-01-07,Salary,2500.00',
+    ].join('\n');
+    const result = parseStatementCsv(csv);
+    expect(result.rows.length + result.rejected.length).toBe(4);
+    expect(result.entries).toHaveLength(4);
+    const sourceRows = result.entries.map((e) => e.sourceRow).sort((a, b) => a - b);
+    expect(sourceRows).toEqual([1, 2, 3, 4]);
+  });
+
+  it('handles quoted fields with embedded commas', () => {
+    const csv = ['Date,Description,Amount', '2026-01-05,"Grocery, downtown",-45.90'].join('\n');
+    const result = parseStatementCsv(csv);
+    expect(result.rows[0].description).toBe('Grocery, downtown');
+  });
+
+  it('returns empty result for empty input', () => {
+    expect(parseStatementCsv('')).toEqual({
+      entries: [],
+      rows: [],
+      rejected: [],
+      headerFields: [],
+    });
+  });
+
+  it('resolves an otherwise-ambiguous single-group amount using the column-wide decimal convention established by another row', () => {
+    // Row 1's amount unambiguously reveals the file uses ',' as the decimal
+    // separator (two-separator case) — so row 2's lone "1.234" must be
+    // thousands grouping (1234), not a 3-decimal amount.
+    const csv = [
+      'Date,Description,Amount',
+      '2026-01-05,Big purchase,"1.234,56"',
+      '2026-01-06,Small charge,1.234',
+    ].join('\n');
+    const result = parseStatementCsv(csv);
+    expect(result.rejected).toHaveLength(0);
+    expect(result.rows[0].signedAmount).toBe('1234.56');
+    expect(result.rows[1].signedAmount).toBe('1234.00');
+  });
+
+  it('rejects an ambiguous amount with reason ambiguous-amount when the file gives no column-wide convention to resolve it', () => {
+    const csv = ['Date,Description,Amount', '2026-01-05,Something,1.234'].join('\n');
+    const result = parseStatementCsv(csv);
+    expect(result.rows).toHaveLength(0);
+    expect(result.rejected[0].reason).toBe('ambiguous-amount');
+  });
+
+  it('rejects a quote opened mid-field (not at field start) as malformed-quoting', () => {
+    const csv = ['Date,Description,Amount', '2026-01-05,Grocer"oops,-45.90'].join('\n');
+    const result = parseStatementCsv(csv);
+    expect(result.rows).toHaveLength(0);
+    expect(result.rejected[0].reason).toBe('malformed-quoting');
+  });
+
+  it('rejects text trailing a closed quote as malformed-quoting', () => {
+    const csv = ['Date,Description,Amount', '2026-01-05,"Grocer"oops,-45.90'].join('\n');
+    const result = parseStatementCsv(csv);
+    expect(result.rows).toHaveLength(0);
+    expect(result.rejected[0].reason).toBe('malformed-quoting');
+  });
+
+  it('rejects an unterminated quote at EOF as malformed-quoting', () => {
+    const csv = ['Date,Description,Amount', '2026-01-05,"Grocery store,-45.90'].join('\n');
+    const result = parseStatementCsv(csv);
+    expect(result.rows).toHaveLength(0);
+    expect(result.rejected[0].reason).toBe('malformed-quoting');
+  });
+
+  it('still accepts a valid escaped "" inside a quoted field', () => {
+    const csv = ['Date,Description,Amount', '2026-01-05,"Grocer""s store",-45.90'].join('\n');
+    const result = parseStatementCsv(csv);
+    expect(result.rejected).toHaveLength(0);
+    expect(result.rows[0].description).toBe('Grocer"s store');
+  });
+});

--- a/src/server/services/finance-statement-parser.ts
+++ b/src/server/services/finance-statement-parser.ts
@@ -1,0 +1,487 @@
+/**
+ * Deterministic bank-statement CSV/text parser (WP4, R5 — no LLM in this
+ * wave). Pure functions, no I/O — testable in isolation and safe to call
+ * repeatedly for the same content (used by the resumable bg-runtime chunker).
+ *
+ * Contract: every input data row lands in exactly one of `rows` (accepted) or
+ * `rejected` (with a reason). Ambiguous column mapping (can't confidently find
+ * date+description+amount) rejects EVERY data row with reason 'needs-llm' —
+ * the gateway drone fallback is a later cross-repo wave (R5/WP5).
+ */
+
+export interface StatementEntryOk {
+  sourceRow: number;
+  ok: true;
+  postedOn: string; // 'YYYY-MM-DD'
+  description: string;
+  signedAmount: string; // fixed(2) numeric string; sign = direction
+  currency: string | null;
+  counterparty: string | null;
+  category: string | null;
+  reference: string | null;
+  confidence: number | null;
+  warnings: string[];
+  raw: Record<string, string>;
+}
+
+export interface StatementEntryRejected {
+  sourceRow: number;
+  ok: false;
+  reason: string;
+  raw: Record<string, string>;
+}
+
+export type StatementEntry = StatementEntryOk | StatementEntryRejected;
+
+export interface StatementParseResult {
+  /** All data rows in original file order — the chunk cursor slices this. */
+  entries: StatementEntry[];
+  rows: StatementEntryOk[];
+  rejected: StatementEntryRejected[];
+  /** Recognized field keys detected in the header, for diagnostics. */
+  headerFields: string[];
+}
+
+/** Normalize pasted-text line endings so identical content hashes identically
+ *  regardless of the client OS clipboard (CRLF/CR → LF). */
+export function normalizeStatementText(text: string): string {
+  return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+interface CsvRow {
+  cells: string[];
+  /** A quote was opened mid-field (not at field start) or a closing quote
+   *  wasn't immediately followed by a delimiter/EOL/EOF (e.g. `"Grocer"oops`),
+   *  or a quote was never closed before EOF. The row's cells are best-effort
+   *  only — callers should reject the row rather than trust them. */
+  malformed: boolean;
+}
+
+// ── CSV tokenizer (minimal RFC4180: quoted fields, "" escape, embedded commas/newlines) ──
+function splitCsvRows(text: string): CsvRow[] {
+  const rows: CsvRow[] = [];
+  let row: string[] = [];
+  let field = '';
+  let inQuotes = false;
+  let fieldStarted = false; // has any char landed in the current field yet?
+  let rowMalformed = false;
+  let sawAny = false;
+
+  const endField = () => {
+    row.push(field);
+    field = '';
+    fieldStarted = false;
+  };
+  const endRow = () => {
+    endField();
+    rows.push({ cells: row, malformed: rowMalformed });
+    row = [];
+    rowMalformed = false;
+    sawAny = false;
+  };
+
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+          // Only a delimiter/EOL/EOF may follow a closing quote.
+          const next = text[i + 1];
+          if (next !== undefined && next !== ',' && next !== '\n' && next !== '\r') {
+            rowMalformed = true;
+          }
+        }
+      } else {
+        field += c;
+      }
+      continue;
+    }
+    // Quote mode only starts a field — a `"` appearing after the field has
+    // already begun (e.g. `Grocer"oops`) is a stray/malformed quote, not a
+    // re-entry into quoted content.
+    if (c === '"' && !fieldStarted) {
+      inQuotes = true;
+      fieldStarted = true;
+      sawAny = true;
+      continue;
+    }
+    if (c === '"') {
+      rowMalformed = true;
+      field += c;
+      fieldStarted = true;
+      sawAny = true;
+      continue;
+    }
+    if (c === ',') {
+      endField();
+      sawAny = true;
+      continue;
+    }
+    if (c === '\n') {
+      endRow();
+      continue;
+    }
+    if (c === '\r') continue; // normalize CRLF/bare-CR
+    field += c;
+    fieldStarted = true;
+    sawAny = true;
+  }
+  if (inQuotes) rowMalformed = true; // unterminated quote at EOF
+  if (sawAny || field.length > 0 || row.length > 0) {
+    endRow();
+  }
+  return rows.filter((r) => !(r.cells.length === 1 && r.cells[0].trim() === '' && !r.malformed));
+}
+
+function stripAccents(s: string): string {
+  return s.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+function normHeader(s: string): string {
+  return stripAccents(s.trim().toLowerCase()).replace(/\s+/g, ' ');
+}
+
+const FIELD_ALIASES: Record<string, string[]> = {
+  date: [
+    'date',
+    'fecha',
+    'transaction date',
+    'posted date',
+    'value date',
+    'fecha operacion',
+    'fecha de operacion',
+  ],
+  description: ['description', 'descripcion', 'detalle', 'concepto', 'memo', 'glosa'],
+  amount: ['amount', 'monto', 'importe', 'valor'],
+  debit: ['debit', 'cargo', 'debito', 'egreso'],
+  credit: ['credit', 'abono', 'credito', 'ingreso'],
+  currency: ['currency', 'moneda'],
+  counterparty: ['counterparty', 'beneficiario', 'contraparte', 'payee'],
+  category: ['category', 'categoria', 'rubro'],
+  reference: [
+    'reference',
+    'referencia',
+    'ref',
+    'nro operacion',
+    'numero de operacion',
+    'no operacion',
+  ],
+};
+
+function detectColumns(header: string[]): Partial<Record<string, number>> {
+  const map: Partial<Record<string, number>> = {};
+  header.forEach((h, idx) => {
+    const norm = normHeader(h);
+    for (const [field, aliases] of Object.entries(FIELD_ALIASES)) {
+      if (map[field] === undefined && aliases.includes(norm)) map[field] = idx;
+    }
+  });
+  return map;
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+function isValidYmd(y: number, m: number, d: number): boolean {
+  if (m < 1 || m > 12) return false;
+  const isLeap = y % 4 === 0 && (y % 100 !== 0 || y % 400 === 0);
+  const dim = [31, isLeap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return d >= 1 && d <= dim[m - 1];
+}
+
+/** Resolve ISO / DD-MM-YYYY / MM-DD-YYYY. Genuinely ambiguous two-digit-both
+ *  cases (e.g. 03/04/2026) default to DD/MM/YYYY (hub's America/Lima locale
+ *  default — see fin_settings.timezone) and are flagged `ambiguous`. */
+export function parseStatementDate(raw: string): { iso: string; ambiguous: boolean } | null {
+  const s = raw.trim();
+  let m = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(s);
+  if (m) {
+    const y = Number(m[1]);
+    const mo = Number(m[2]);
+    const d = Number(m[3]);
+    if (!isValidYmd(y, mo, d)) return null;
+    return { iso: `${y}-${pad2(mo)}-${pad2(d)}`, ambiguous: false };
+  }
+  m = /^(\d{1,2})[/-](\d{1,2})[/-](\d{4})$/.exec(s);
+  if (m) {
+    const a = Number(m[1]);
+    const b = Number(m[2]);
+    const y = Number(m[3]);
+    let day: number;
+    let month: number;
+    let ambiguous = false;
+    if (a > 12 && b <= 12) {
+      day = a;
+      month = b;
+    } else if (b > 12 && a <= 12) {
+      day = b;
+      month = a;
+    } else if (a <= 12 && b <= 12) {
+      day = a;
+      month = b;
+      ambiguous = true;
+    } else {
+      return null;
+    }
+    if (!isValidYmd(y, month, day)) return null;
+    return { iso: `${y}-${pad2(month)}-${pad2(day)}`, ambiguous };
+  }
+  return null;
+}
+
+const STRICT_GROUPING_RE = /^\d{1,3}(?:[,.]\d{3})+$/;
+
+interface AmountAnalysis {
+  negative: boolean;
+  /** Canonical dot-decimal numeric string, resolved unambiguously. Null when
+   *  unresolved (either genuinely invalid, or structurally ambiguous — see
+   *  `ambiguous`). */
+  canonical: string | null;
+  /** A single lone separator followed by exactly 3 digits (e.g. "1.234") is
+   *  structurally indistinguishable between thousands grouping (1234) and a
+   *  rare decimal amount with 3 decimal places — cannot resolve without
+   *  column-wide context. Two-or-more repeated groups (e.g. "12.345.678")
+   *  have no valid decimal reading, so those stay unambiguous thousands. */
+  ambiguous: boolean;
+  ambiguousSep?: ',' | '.';
+  ambiguousAsDecimal?: string;
+  ambiguousAsThousands?: string;
+  /** When a lone separator was unambiguously resolved (decimal via 1-2
+   *  trailing digits, or either side of a two-separator amount), the char
+   *  that served as the decimal separator — lets callers learn a column's
+   *  locale convention from its unambiguous rows. */
+  decimalChar?: ',' | '.';
+}
+
+function analyzeAmount(raw: string): AmountAnalysis {
+  let s = raw.trim();
+  if (s === '') return { negative: false, canonical: null, ambiguous: false };
+  let negative = false;
+  if (/^\(.*\)$/.test(s)) {
+    negative = true;
+    s = s.slice(1, -1);
+  }
+  s = s.replace(/[^0-9.,+-]/g, '');
+  if (s.startsWith('-')) {
+    negative = true;
+    s = s.slice(1);
+  } else if (s.endsWith('-')) {
+    negative = true;
+    s = s.slice(0, -1);
+  }
+  if (s.startsWith('+')) s = s.slice(1);
+  if (s === '') return { negative, canonical: null, ambiguous: false };
+
+  const lastComma = s.lastIndexOf(',');
+  const lastDot = s.lastIndexOf('.');
+
+  if (lastComma !== -1 && lastDot !== -1) {
+    const commaIsDecimal = lastDot < lastComma;
+    const canonical = commaIsDecimal
+      ? s.replace(/\./g, '').replace(',', '.')
+      : s.replace(/,/g, '');
+    return { negative, canonical, ambiguous: false, decimalChar: commaIsDecimal ? ',' : '.' };
+  }
+
+  if (lastComma !== -1 || lastDot !== -1) {
+    const sep: ',' | '.' = lastComma !== -1 ? ',' : '.';
+    const sepIdx = lastComma !== -1 ? lastComma : lastDot;
+    const trailing = s.length - sepIdx - 1;
+    const groupCount = s.split(sep).length - 1;
+
+    if (trailing === 1 || trailing === 2) {
+      return { negative, canonical: s.replace(sep, '.'), ambiguous: false, decimalChar: sep };
+    }
+    if (STRICT_GROUPING_RE.test(s)) {
+      if (groupCount >= 2) {
+        return { negative, canonical: s.split(sep).join(''), ambiguous: false };
+      }
+      // Exactly one group of 3 trailing digits — genuinely ambiguous.
+      return {
+        negative,
+        canonical: null,
+        ambiguous: true,
+        ambiguousSep: sep,
+        ambiguousAsDecimal: s.replace(sep, '.'),
+        ambiguousAsThousands: s.split(sep).join(''),
+      };
+    }
+    return { negative, canonical: null, ambiguous: false };
+  }
+
+  return { negative, canonical: s, ambiguous: false };
+}
+
+function toNumber(a: AmountAnalysis): number | null {
+  if (a.canonical === null) return null;
+  const n = Number(a.canonical);
+  if (!Number.isFinite(n)) return null;
+  return a.negative ? -n : n;
+}
+
+/** Resolve an ambiguous single-group amount (e.g. "1.234") using a
+ *  column-wide decimal-separator convention learned from other rows. Returns
+ *  null (unresolved) when there's no convention, or the convention doesn't
+ *  cover this separator. */
+function resolveAmbiguous(a: AmountAnalysis, convention: ',' | '.' | undefined): number | null {
+  if (!a.ambiguous || !a.ambiguousSep || !convention) return null;
+  const canonical = a.ambiguousSep === convention ? a.ambiguousAsDecimal : a.ambiguousAsThousands;
+  if (canonical === undefined) return null;
+  const n = Number(canonical);
+  if (!Number.isFinite(n)) return null;
+  return a.negative ? -n : n;
+}
+
+/** Resolve "1.234,56" (EU) vs "1,234.56" (US) vs plain thousands grouping.
+ *  Parentheses and a leading/trailing '-' mean negative. A lone separator is
+ *  read as a decimal point when 1-2 digits follow it; a lone separator with
+ *  exactly one group of 3 trailing digits (e.g. "1.234") is structurally
+ *  ambiguous and returns null here — resolve it with column context via
+ *  `parseStatementCsv` instead of guessing. */
+export function parseStatementAmount(raw: string): number | null {
+  return toNumber(analyzeAmount(raw));
+}
+
+/** Learn a column-wide decimal-separator convention from every unambiguous
+ *  cell across the given column indices, so a genuinely ambiguous single-
+ *  group amount (e.g. "1.234") in the same file can be resolved instead of
+ *  guessed. Returns undefined when no convention could be established (no
+ *  unambiguous signal, or conflicting signals across rows). */
+function detectAmountConvention(
+  table: CsvRow[],
+  colIdx: number[],
+): ',' | '.' | undefined {
+  let found: ',' | '.' | undefined;
+  for (let r = 1; r < table.length; r++) {
+    if (table[r].malformed) continue;
+    for (const idx of colIdx) {
+      const raw = table[r].cells[idx];
+      if (raw === undefined) continue;
+      const a = analyzeAmount(raw);
+      if (a.ambiguous || a.decimalChar === undefined) continue;
+      if (found === undefined) found = a.decimalChar;
+      else if (found !== a.decimalChar) return undefined; // conflicting signals
+    }
+  }
+  return found;
+}
+
+/** Resolve one amount cell against the column's learned convention. */
+function resolveAmountCell(
+  raw: string,
+  convention: ',' | '.' | undefined,
+): { value: number | null; ambiguous: boolean } {
+  const a = analyzeAmount(raw);
+  if (a.canonical !== null) return { value: toNumber(a), ambiguous: false };
+  if (a.ambiguous) {
+    const resolved = resolveAmbiguous(a, convention);
+    return resolved === null ? { value: null, ambiguous: true } : { value: resolved, ambiguous: false };
+  }
+  return { value: null, ambiguous: false };
+}
+
+export function parseStatementCsv(text: string): StatementParseResult {
+  const table = splitCsvRows(normalizeStatementText(text));
+  if (table.length === 0) return { entries: [], rows: [], rejected: [], headerFields: [] };
+
+  const header = table[0].cells;
+  const cols = detectColumns(header);
+  const hasAmountSignal =
+    cols.amount !== undefined || cols.debit !== undefined || cols.credit !== undefined;
+  const canParseDeterministically =
+    cols.date !== undefined && cols.description !== undefined && hasAmountSignal;
+
+  const amountColIdx: number[] = [];
+  if (cols.amount !== undefined) amountColIdx.push(cols.amount);
+  if (cols.debit !== undefined) amountColIdx.push(cols.debit);
+  if (cols.credit !== undefined) amountColIdx.push(cols.credit);
+  const amountConvention = canParseDeterministically
+    ? detectAmountConvention(table, amountColIdx)
+    : undefined;
+
+  const entries: StatementEntry[] = [];
+  for (let r = 1; r < table.length; r++) {
+    const sourceRow = r; // 1-based data row index, header excluded
+    const cells = table[r].cells;
+    const raw: Record<string, string> = {};
+    header.forEach((h, idx) => {
+      raw[h.trim() || `col${idx}`] = cells[idx] ?? '';
+    });
+
+    if (table[r].malformed) {
+      entries.push({ sourceRow, ok: false, reason: 'malformed-quoting', raw });
+      continue;
+    }
+    if (!canParseDeterministically) {
+      entries.push({ sourceRow, ok: false, reason: 'needs-llm', raw });
+      continue;
+    }
+    if (cells.length !== header.length) {
+      entries.push({ sourceRow, ok: false, reason: 'column-mismatch', raw });
+      continue;
+    }
+
+    const parsedDate = parseStatementDate(cells[cols.date as number] ?? '');
+    if (!parsedDate) {
+      entries.push({ sourceRow, ok: false, reason: 'invalid-date', raw });
+      continue;
+    }
+
+    const description = (cells[cols.description as number] ?? '').trim();
+    if (!description) {
+      entries.push({ sourceRow, ok: false, reason: 'missing-description', raw });
+      continue;
+    }
+
+    let signedAmount: number | null;
+    let amountAmbiguous = false;
+    if (cols.amount !== undefined) {
+      const resolved = resolveAmountCell(cells[cols.amount] ?? '', amountConvention);
+      signedAmount = resolved.value;
+      amountAmbiguous = resolved.ambiguous;
+    } else {
+      const debitRaw = cols.debit !== undefined ? (cells[cols.debit] ?? '').trim() : '';
+      const creditRaw = cols.credit !== undefined ? (cells[cols.credit] ?? '').trim() : '';
+      if (debitRaw === '' && creditRaw === '') {
+        signedAmount = null;
+      } else {
+        const debitR = debitRaw === '' ? { value: 0, ambiguous: false } : resolveAmountCell(debitRaw, amountConvention);
+        const creditR = creditRaw === '' ? { value: 0, ambiguous: false } : resolveAmountCell(creditRaw, amountConvention);
+        amountAmbiguous = debitR.ambiguous || creditR.ambiguous;
+        signedAmount = debitR.value === null || creditR.value === null ? null : creditR.value - debitR.value;
+      }
+    }
+    if (signedAmount === null || Number.isNaN(signedAmount)) {
+      entries.push({
+        sourceRow,
+        ok: false,
+        reason: amountAmbiguous ? 'ambiguous-amount' : 'invalid-amount',
+        raw,
+      });
+      continue;
+    }
+
+    entries.push({
+      sourceRow,
+      ok: true,
+      postedOn: parsedDate.iso,
+      description,
+      signedAmount: signedAmount.toFixed(2),
+      currency: cols.currency !== undefined ? (cells[cols.currency] ?? '').trim() || null : null,
+      counterparty:
+        cols.counterparty !== undefined ? (cells[cols.counterparty] ?? '').trim() || null : null,
+      category: cols.category !== undefined ? (cells[cols.category] ?? '').trim() || null : null,
+      reference: cols.reference !== undefined ? (cells[cols.reference] ?? '').trim() || null : null,
+      confidence: null, // deterministic path — confidence is an LLM-fallback concept (R5/WP5)
+      warnings: parsedDate.ambiguous ? ['date-format-ambiguous-assumed-dmy'] : [],
+      raw,
+    });
+  }
+
+  const rows = entries.filter((e): e is StatementEntryOk => e.ok);
+  const rejected = entries.filter((e): e is StatementEntryRejected => !e.ok);
+  return { entries, rows, rejected, headerFields: Object.keys(cols) };
+}

--- a/src/server/services/finance-statements.service.test.ts
+++ b/src/server/services/finance-statements.service.test.ts
@@ -1,0 +1,370 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockDb } from '$server/test-utils/mock-db';
+import { and, eq } from 'drizzle-orm';
+import { finStatementImports } from '$server/db/pg-finance-schema';
+
+vi.mock('./bg-runtime', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./bg-runtime')>();
+  return {
+    ...actual,
+    registerJobHandler: vi.fn(),
+    enqueueJob: vi.fn(async () => 'job-1'),
+    advanceJob: vi.fn(async () => {}),
+  };
+});
+
+vi.mock('./file.service', () => ({
+  uploadFile: vi.fn(async () => 'file-1'),
+  getFileUrl: vi.fn(async () => ({ url: 'https://storage.example/file-1' })),
+}));
+
+const ctx = (db: unknown) => ({ db: db as never, tenantId: 'org-1', profileId: 'user-1' });
+
+describe('createImport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('dedupes on (org_id, content_sha256): returns the existing import without uploading or inserting', async () => {
+    const { createImport } = await import('./finance-statements.service');
+    const { uploadFile } = await import('./file.service');
+    const { db, resolveSequence } = createMockDb();
+    const existing = { id: 'imp-1', orgId: 'org-1', status: 'done', contentSha256: 'x' };
+    resolveSequence([[existing]]); // findBySha select
+
+    const result = await createImport(ctx(db), { sourceKind: 'text', text: 'hello' });
+
+    expect(result.created).toBe(false);
+    expect(result.import).toBe(existing);
+    expect(uploadFile).not.toHaveBeenCalled();
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('two calls with identical pasted text (different CRLF) produce the same sha and dedupe to one import', async () => {
+    const { createImport } = await import('./finance-statements.service');
+    const dbA = createMockDb();
+    dbA.resolveSequence([[]]); // findBySha → none
+    dbA.db.insert = vi.fn(() => ({
+      values: () => ({
+        returning: async () => [
+          { id: 'imp-new', orgId: 'org-1', status: 'queued', contentSha256: 'sha' },
+        ],
+      }),
+    })) as never;
+
+    const first = await createImport(ctx(dbA.db), { sourceKind: 'text', text: 'line1\r\nline2' });
+
+    const dbB = createMockDb();
+    dbB.resolveSequence([
+      [
+        {
+          id: first.import.id,
+          orgId: 'org-1',
+          status: 'queued',
+          contentSha256: first.import.contentSha256,
+        },
+      ],
+    ]);
+    const second = await createImport(ctx(dbB.db), { sourceKind: 'text', text: 'line1\nline2' });
+
+    expect(second.created).toBe(false);
+    expect(second.import.id).toBe(first.import.id);
+  });
+
+  it('creates a new import + enqueues the job when no existing content matches', async () => {
+    const { createImport } = await import('./finance-statements.service');
+    const { uploadFile } = await import('./file.service');
+    const { enqueueJob, advanceJob } = await import('./bg-runtime');
+    const { db, resolveSequence } = createMockDb();
+    resolveSequence([
+      [], // findBySha → none
+      [{ id: 'imp-new', orgId: 'org-1', status: 'queued', contentSha256: 'sha' }], // insert().returning()
+    ]);
+
+    const result = await createImport(ctx(db), {
+      sourceKind: 'csv',
+      fileName: 's.csv',
+      bytes: new Uint8Array([1, 2, 3]),
+    });
+
+    expect(result.created).toBe(true);
+    expect(uploadFile).toHaveBeenCalledTimes(1);
+    expect(enqueueJob).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: 'org-1', type: 'statement_ingest', refId: 'imp-new' }),
+    );
+    expect(advanceJob).toHaveBeenCalledWith('job-1', Number.POSITIVE_INFINITY);
+  });
+
+  it('re-enqueues (instead of stranding) a dedupe match whose import was previously undone', async () => {
+    const { createImport } = await import('./finance-statements.service');
+    const { uploadFile } = await import('./file.service');
+    const { enqueueJob, advanceJob } = await import('./bg-runtime');
+    const { db, resolveSequence } = createMockDb();
+    resolveSequence([
+      [{ id: 'imp-1', orgId: 'org-1', status: 'undone', contentSha256: 'x' }], // findBySha
+      [{ id: 'imp-1', orgId: 'org-1', status: 'queued', contentSha256: 'x' }], // update().returning()
+    ]);
+
+    const result = await createImport(ctx(db), { sourceKind: 'text', text: 'hello' });
+
+    expect(result.created).toBe(false);
+    expect(result.import.status).toBe('queued');
+    expect(uploadFile).not.toHaveBeenCalled();
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(enqueueJob).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: 'org-1', type: 'statement_ingest', refId: 'imp-1' }),
+    );
+    expect(advanceJob).toHaveBeenCalledWith('job-1', Number.POSITIVE_INFINITY);
+  });
+});
+
+describe('persistImportChunk', () => {
+  const CSV = [
+    'Date,Description,Amount',
+    '2026-01-05,Grocery store,-45.90',
+    '2026-01-06,bad-amount,oops',
+    '2026-01-07,Salary,2500.00',
+  ].join('\n');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('inserts accepted rows for the current chunk, skips rejected ones, and marks the import done', async () => {
+    const { persistImportChunk } = await import('./finance-statements.service');
+    const { getFileUrl } = await import('./file.service');
+    (getFileUrl as ReturnType<typeof vi.fn>).mockResolvedValue({
+      url: 'https://storage.example/file-1',
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(CSV)),
+    );
+
+    const { db, resolveSequence } = createMockDb();
+    const importRow = {
+      id: 'imp-1',
+      orgId: 'org-1',
+      fileId: 'file-1',
+      status: 'queued',
+      nextChunk: 0,
+      insertedCount: 0,
+      rejectedCount: 0,
+    };
+    resolveSequence([
+      [importRow], // select import row
+      [], // insert into fin_transactions
+      [], // update import row
+    ]);
+
+    const result = await persistImportChunk(ctx(db), 'imp-1');
+
+    expect(result).toEqual({ done: true });
+    expect(db.insert).toHaveBeenCalledTimes(1);
+    expect(db.update).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
+  });
+
+  it('is idempotent: re-running the same chunk (same next_chunk) issues an identical insert set', async () => {
+    // Proves the chunk-slicing itself is deterministic — combined with
+    // onConflictDoNothing on (import_id, source_row) this makes chunk
+    // retries safe (asserted at the parser layer; DB dedup is a constraint,
+    // not app logic, so it is not re-tested here with a mock).
+    const { parseStatementCsv } = await import('./finance-statement-parser');
+    const parsedA = parseStatementCsv(CSV);
+    const parsedB = parseStatementCsv(CSV);
+    const sliceA = parsedA.entries.slice(0, 2);
+    const sliceB = parsedB.entries.slice(0, 2);
+    expect(sliceA).toEqual(sliceB);
+  });
+
+  it('returns done:true without touching the DB when the import is already done', async () => {
+    const { persistImportChunk } = await import('./finance-statements.service');
+    const { db, resolveSequence } = createMockDb();
+    resolveSequence([[{ id: 'imp-1', orgId: 'org-1', status: 'done', nextChunk: 4 }]]);
+
+    const result = await persistImportChunk(ctx(db), 'imp-1');
+
+    expect(result).toEqual({ done: true });
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('counts insertedCount from the actual DB insert result, not the parsed-ok slice length (a replay that conflict-skips an already-persisted row must not inflate the count)', async () => {
+    const { persistImportChunk } = await import('./finance-statements.service');
+    const { getFileUrl } = await import('./file.service');
+    (getFileUrl as ReturnType<typeof vi.fn>).mockResolvedValue({
+      url: 'https://storage.example/file-1',
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(CSV)),
+    );
+
+    const importRow = {
+      id: 'imp-1',
+      orgId: 'org-1',
+      fileId: 'file-1',
+      status: 'queued',
+      nextChunk: 0,
+      insertedCount: 0,
+      rejectedCount: 0,
+    };
+    let capturedSet: Record<string, unknown> | undefined;
+    const { db, resolveSequence } = createMockDb();
+    resolveSequence([[importRow]]); // select import row
+    // 2 ok rows in CSV (Grocery, Salary) — simulate only 1 actually landing
+    // (the other already exists from a prior chunk run, so onConflictDoNothing
+    // skipped it).
+    db.insert = vi.fn(() => ({
+      values: () => ({
+        onConflictDoNothing: () => ({
+          returning: async () => [{ id: 'txn-1' }],
+        }),
+      }),
+    })) as never;
+    db.update = vi.fn(() => ({
+      set: (payload: Record<string, unknown>) => {
+        capturedSet = payload;
+        return { where: async () => [] };
+      },
+    })) as never;
+
+    await persistImportChunk(ctx(db), 'imp-1');
+
+    expect(capturedSet?.insertedCount).toBe(1); // actual inserted rows, not okSlice.length (2)
+    vi.unstubAllGlobals();
+  });
+
+  it('advances the cursor with a conditional WHERE on the next_chunk it read, so a stale/concurrent replay no-ops instead of double-advancing', async () => {
+    const { persistImportChunk } = await import('./finance-statements.service');
+    const { getFileUrl } = await import('./file.service');
+    (getFileUrl as ReturnType<typeof vi.fn>).mockResolvedValue({
+      url: 'https://storage.example/file-1',
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(CSV)),
+    );
+
+    const importRow = {
+      id: 'imp-1',
+      orgId: 'org-1',
+      fileId: 'file-1',
+      status: 'queued',
+      nextChunk: 0,
+      insertedCount: 0,
+      rejectedCount: 0,
+    };
+    let capturedWhere: unknown;
+    const { db, resolveSequence } = createMockDb();
+    resolveSequence([[importRow]]); // select import row
+    db.insert = vi.fn(() => ({
+      values: () => ({ onConflictDoNothing: () => ({ returning: async () => [] }) }),
+    })) as never;
+    db.update = vi.fn(() => ({
+      set: () => ({
+        where: (arg: unknown) => {
+          capturedWhere = arg;
+          return Promise.resolve([]);
+        },
+      }),
+    })) as never;
+
+    await persistImportChunk(ctx(db), 'imp-1');
+
+    expect(capturedWhere).toEqual(
+      and(eq(finStatementImports.id, 'imp-1'), eq(finStatementImports.nextChunk, importRow.nextChunk)),
+    );
+  });
+});
+
+describe('retryImport', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('is a no-op for a non-failed import (no update, no re-enqueue)', async () => {
+    const { retryImport } = await import('./finance-statements.service');
+    const { enqueueJob } = await import('./bg-runtime');
+    const { db, resolveSequence } = createMockDb();
+    const row = { id: 'imp-1', orgId: 'org-1', status: 'done' };
+    resolveSequence([[row]]);
+
+    const result = await retryImport(ctx(db), 'imp-1');
+
+    expect(result).toBe(row);
+    expect(db.update).not.toHaveBeenCalled();
+    expect(enqueueJob).not.toHaveBeenCalled();
+  });
+
+  it('resets a failed import to queued and re-enqueues', async () => {
+    const { retryImport } = await import('./finance-statements.service');
+    const { enqueueJob } = await import('./bg-runtime');
+    const { db, resolveSequence } = createMockDb();
+    resolveSequence([
+      [{ id: 'imp-1', orgId: 'org-1', status: 'failed' }], // select
+      [{ id: 'imp-1', orgId: 'org-1', status: 'queued' }], // update().returning()
+    ]);
+
+    const result = await retryImport(ctx(db), 'imp-1');
+
+    expect(result?.status).toBe('queued');
+    expect(enqueueJob).toHaveBeenCalledWith(
+      expect.objectContaining({ refId: 'imp-1', type: 'statement_ingest' }),
+    );
+  });
+
+  it('resets an undone import to queued and re-enqueues (so undo never permanently strands an import)', async () => {
+    const { retryImport } = await import('./finance-statements.service');
+    const { enqueueJob } = await import('./bg-runtime');
+    const { db, resolveSequence } = createMockDb();
+    resolveSequence([
+      [{ id: 'imp-1', orgId: 'org-1', status: 'undone', nextChunk: 0 }], // select
+      [{ id: 'imp-1', orgId: 'org-1', status: 'queued', nextChunk: 0 }], // update().returning()
+    ]);
+
+    const result = await retryImport(ctx(db), 'imp-1');
+
+    expect(result?.status).toBe('queued');
+    expect(enqueueJob).toHaveBeenCalledWith(
+      expect.objectContaining({ refId: 'imp-1', type: 'statement_ingest' }),
+    );
+  });
+});
+
+describe('undoImport', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('deletes transactions and marks the import undone (not queued — nothing re-enqueues it until retry/re-submit)', async () => {
+    const { undoImport } = await import('./finance-statements.service');
+    const { db, resolveSequence } = createMockDb();
+    resolveSequence([
+      [{ id: 'imp-1', orgId: 'org-1', status: 'done' }], // select
+      [], // delete fin_transactions
+      [
+        {
+          id: 'imp-1',
+          orgId: 'org-1',
+          status: 'undone',
+          nextChunk: 0,
+          insertedCount: 0,
+          rejectedCount: 0,
+        },
+      ], // update().returning()
+    ]);
+
+    const result = await undoImport(ctx(db), 'imp-1');
+
+    expect(result?.status).toBe('undone');
+    expect(db.delete).toHaveBeenCalled();
+  });
+
+  it('rejects with 409 while the import is actively parsing, and never touches transactions or the row', async () => {
+    const { undoImport } = await import('./finance-statements.service');
+    const { db, resolveSequence } = createMockDb();
+    resolveSequence([[{ id: 'imp-1', orgId: 'org-1', status: 'parsing' }]]); // select
+
+    await expect(undoImport(ctx(db), 'imp-1')).rejects.toMatchObject({ status: 409 });
+    expect(db.delete).not.toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/finance-statements.service.ts
+++ b/src/server/services/finance-statements.service.ts
@@ -1,0 +1,398 @@
+/**
+ * Personal-finance statement imports (WP4, R4/R5 — specs/2026-07-22-personal-
+ * org-differentiation-spec.md). Orchestrates: content-addressed dedupe, blob
+ * storage (reuses file.service), a resumable `statement_ingest` bg-runtime
+ * handler, and status/retry/undo.
+ *
+ * No LLM path in this wave — ambiguous rows are marked 'needs-llm' by the
+ * deterministic parser (finance-statement-parser.ts) and simply counted as
+ * rejected; the gateway drone fallback is R5/WP5 (later, cross-repo).
+ */
+import { createHash } from 'node:crypto';
+import { and, eq } from 'drizzle-orm';
+import { error } from '@sveltejs/kit';
+import { withOrgCore } from '$server/db/with-org-core';
+import { getCoreDb } from '$server/db/pg-client';
+import type { CoreCtx } from '$server/auth/core-ctx';
+import {
+  finStatementImports,
+  finTransactions,
+  type FinStatementImport,
+} from '$server/db/pg-finance-schema';
+import { uploadFile, getFileUrl } from './file.service';
+import {
+  registerJobHandler,
+  enqueueJob,
+  advanceJob,
+  type AdvanceResult,
+  type BgJob,
+} from './bg-runtime';
+import {
+  parseStatementCsv,
+  normalizeStatementText,
+  type StatementParseResult,
+  type StatementEntryOk,
+} from './finance-statement-parser';
+import { getTenant } from './tenant.service';
+
+/**
+ * The statement pipeline is personal-org-only (R5 — business orgs sync via the
+ * SUSII connector instead). 404, not 403: business callers must not learn the
+ * route exists. Same getTenant-by-tenantId pattern as the /pulse kind guard.
+ * Shared by all four /api/finances/statement-imports endpoints.
+ */
+export async function requirePersonalOrg(ctx: CoreCtx): Promise<void> {
+  const tenant = await getTenant({ tenantId: ctx.tenantId } as Parameters<typeof getTenant>[0]);
+  if (tenant?.kind !== 'personal') throw error(404, 'Not found');
+}
+
+export const STATEMENT_JOB_TYPE = 'statement_ingest';
+const PARSER_VERSION = 1;
+// ponytail: bounded rows-per-advance() step, not a hard system limit — raise
+// if real statements regularly need more than a couple of ticks to ingest.
+const CHUNK_SIZE = 500;
+// ponytail: rejections are recomputed by re-parsing on every status read
+// (deterministic + cheap for statement-sized files) rather than persisted in
+// a new table/column — cap what we return so a huge rejected set can't bloat
+// the response.
+const MAX_REJECTIONS_IN_STATUS = 200;
+
+function sha256Hex(bytes: Uint8Array | string): string {
+  return createHash('sha256')
+    .update(typeof bytes === 'string' ? Buffer.from(bytes, 'utf8') : bytes)
+    .digest('hex');
+}
+
+async function findBySha(ctx: CoreCtx, sha: string): Promise<FinStatementImport | null> {
+  return withOrgCore(ctx, async (tx) => {
+    const [row] = await tx
+      .select()
+      .from(finStatementImports)
+      .where(
+        and(
+          eq(finStatementImports.orgId, ctx.tenantId),
+          eq(finStatementImports.contentSha256, sha),
+        ),
+      )
+      .limit(1);
+    return row ?? null;
+  });
+}
+
+/** Enqueue the ingest job and kick it once so a persistent runtime (localhost
+ *  / adapter-node) can make immediate progress; the cron tick resumes it if
+ *  the process is frozen mid-flight (serverless). Mirrors finance-sync's POST. */
+async function enqueueAndKick(ctx: CoreCtx, importId: string): Promise<void> {
+  const jobId = await enqueueJob({
+    tenantId: ctx.tenantId,
+    userId: ctx.profileId ?? null,
+    type: STATEMENT_JOB_TYPE,
+    refId: importId,
+  });
+  void advanceJob(jobId, Number.POSITIVE_INFINITY).catch((e) =>
+    console.error('[finance-statements] advanceJob failed', e),
+  );
+}
+
+export interface CreateImportInput {
+  sourceKind: 'csv' | 'text';
+  fileName?: string;
+  contentType?: string;
+  /** Raw uploaded bytes — required for sourceKind 'csv'. */
+  bytes?: Uint8Array;
+  /** Pasted text — required for sourceKind 'text'; CRLF-normalized before hashing/storing. */
+  text?: string;
+  createdBy?: string | null;
+}
+
+/**
+ * Create (or return the existing) import for this content. Idempotency: the
+ * sha-256 of the exact uploaded bytes (CRLF-normalized for pasted text) is
+ * checked BEFORE any storage write, so re-submitting identical content never
+ * re-uploads or duplicates a row — UNIQUE(org_id, content_sha256) is the
+ * backstop against a concurrent-request race.
+ */
+export async function createImport(
+  ctx: CoreCtx,
+  input: CreateImportInput,
+): Promise<{ import: FinStatementImport; created: boolean }> {
+  const bytes =
+    input.sourceKind === 'text'
+      ? Buffer.from(normalizeStatementText(input.text ?? ''), 'utf8')
+      : (input.bytes ?? new Uint8Array());
+  const sha = sha256Hex(bytes);
+
+  const existing = await findBySha(ctx, sha);
+  if (existing) {
+    // An earlier undo left this content 'undone' (transactions deleted,
+    // cursor zeroed) — resubmitting the same content should resume ingest,
+    // not silently return a stranded row that nothing ever re-enqueues.
+    if (existing.status === 'undone') {
+      const requeued = await withOrgCore(ctx, async (tx) => {
+        const [r] = await tx
+          .update(finStatementImports)
+          .set({ status: 'queued', errorCode: null, errorMessage: null, finishedAt: null })
+          .where(eq(finStatementImports.id, existing.id))
+          .returning();
+        return r;
+      });
+      await enqueueAndKick(ctx, existing.id);
+      return { import: requeued, created: false };
+    }
+    return { import: existing, created: false };
+  }
+
+  const fileId = await uploadFile(ctx, {
+    fileName:
+      input.fileName ?? (input.sourceKind === 'text' ? 'pasted-statement.txt' : 'statement.csv'),
+    contentType: input.contentType ?? (input.sourceKind === 'text' ? 'text/plain' : 'text/csv'),
+    data: bytes,
+    category: 'finance-statements',
+    uploadedBy: input.createdBy ?? undefined,
+  });
+
+  let row: FinStatementImport;
+  try {
+    row = await withOrgCore(ctx, async (tx) => {
+      const [inserted] = await tx
+        .insert(finStatementImports)
+        .values({
+          orgId: ctx.tenantId,
+          fileId,
+          sourceKind: input.sourceKind,
+          contentSha256: sha,
+          parserVersion: PARSER_VERSION,
+          status: 'queued',
+          nextChunk: 0,
+          createdBy: input.createdBy ?? null,
+        })
+        .returning();
+      return inserted;
+    });
+  } catch (e) {
+    // Lost a race against UNIQUE(org_id, content_sha256) — another request
+    // created it first; return that row instead of duplicating.
+    if (e && typeof e === 'object' && 'code' in e && (e as { code?: string }).code === '23505') {
+      const raced = await findBySha(ctx, sha);
+      if (raced) return { import: raced, created: false };
+    }
+    throw e;
+  }
+
+  await enqueueAndKick(ctx, row.id);
+  return { import: row, created: true };
+}
+
+async function loadImportText(ctx: CoreCtx, row: FinStatementImport): Promise<string> {
+  if (!row.fileId) throw new Error('import has no stored content');
+  const file = await getFileUrl(ctx, row.fileId);
+  if (!file) throw new Error('stored statement content not found');
+  const res = await fetch(file.url);
+  if (!res.ok) throw new Error(`failed to fetch statement content (${res.status})`);
+  return res.text();
+}
+
+/** One bounded step: parse (deterministic, re-run every call — cheap for
+ *  statement-sized files) and persist the next CHUNK_SIZE rows starting at
+ *  `next_chunk`. Insert uses onConflictDoNothing on (import_id, source_row),
+ *  so re-running the same chunk (retry, or a resumed lease) never duplicates. */
+export async function persistImportChunk(ctx: CoreCtx, importId: string): Promise<AdvanceResult> {
+  return withOrgCore(ctx, async (tx) => {
+    const [row] = await tx
+      .select()
+      .from(finStatementImports)
+      .where(and(eq(finStatementImports.id, importId), eq(finStatementImports.orgId, ctx.tenantId)))
+      .limit(1);
+    if (!row) return { done: true, error: 'import not found' };
+    if (row.status === 'done') return { done: true };
+    if (row.status === 'failed') return { done: true, error: row.errorMessage ?? 'import failed' };
+
+    let parsed: StatementParseResult;
+    try {
+      const text = await loadImportText(ctx, row);
+      parsed = parseStatementCsv(text);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      await tx
+        .update(finStatementImports)
+        .set({
+          status: 'failed',
+          errorCode: 'parse_failed',
+          errorMessage: message,
+          finishedAt: new Date(),
+        })
+        .where(eq(finStatementImports.id, importId));
+      return { done: true, error: message };
+    }
+
+    const total = parsed.entries.length;
+    const slice = parsed.entries.slice(row.nextChunk, row.nextChunk + CHUNK_SIZE);
+    const okSlice = slice.filter((e): e is StatementEntryOk => e.ok);
+
+    // .returning() reports the rows the INSERT actually landed — a chunk
+    // replay (retry, resumed lease) hits onConflictDoNothing for rows already
+    // persisted, so this can be < okSlice.length. Counting the returned rows
+    // (not the slice length) keeps insertedCount accurate under replay.
+    let insertedRows = 0;
+    if (okSlice.length > 0) {
+      const inserted = await tx
+        .insert(finTransactions)
+        .values(
+          okSlice.map((e) => ({
+            orgId: ctx.tenantId,
+            importId,
+            sourceRow: e.sourceRow,
+            postedOn: e.postedOn,
+            description: e.description,
+            signedAmount: e.signedAmount,
+            currency: e.currency,
+            counterparty: e.counterparty,
+            category: e.category,
+            reference: e.reference,
+            confidence: e.confidence == null ? null : String(e.confidence), // numeric column — money-string convention
+            warnings: e.warnings,
+            raw: e.raw,
+          })),
+        )
+        .onConflictDoNothing({ target: [finTransactions.importId, finTransactions.sourceRow] })
+        .returning({ id: finTransactions.id });
+      insertedRows = inserted.length;
+    }
+
+    const nextChunk = row.nextChunk + slice.length;
+    const done = nextChunk >= total;
+    // Conditional on the next_chunk we read at the top of this call: if a
+    // stale/concurrent worker already advanced the cursor since then, this
+    // WHERE matches zero rows and the update no-ops instead of double-adding
+    // insertedCount/rejectedCount on top of the other worker's advance.
+    await tx
+      .update(finStatementImports)
+      .set({
+        nextChunk,
+        rowCount: total,
+        insertedCount: (row.insertedCount ?? 0) + insertedRows,
+        rejectedCount: (row.rejectedCount ?? 0) + (slice.length - okSlice.length),
+        status: done ? 'done' : 'parsing',
+        finishedAt: done ? new Date() : null,
+      })
+      .where(
+        and(eq(finStatementImports.id, importId), eq(finStatementImports.nextChunk, row.nextChunk)),
+      );
+
+    return { done };
+  });
+}
+
+async function advanceStatementIngest(job: BgJob): Promise<AdvanceResult> {
+  if (!job.refId) return { done: true, error: 'missing refId' };
+  const ctx: CoreCtx = { db: getCoreDb(), tenantId: job.tenantId };
+  return persistImportChunk(ctx, job.refId);
+}
+
+registerJobHandler({ type: STATEMENT_JOB_TYPE, advance: advanceStatementIngest });
+
+export interface ImportStatus {
+  import: FinStatementImport;
+  rejections: Array<{ sourceRow: number; reason: string; raw: Record<string, string> }>;
+}
+
+/** Status incl. counts + a bounded sample of rejections (recomputed by
+ *  re-parsing the stored content — cheap, deterministic, no extra table). */
+export async function getImportStatus(
+  ctx: CoreCtx,
+  importId: string,
+): Promise<ImportStatus | null> {
+  const row = await withOrgCore(ctx, async (tx) => {
+    const [r] = await tx
+      .select()
+      .from(finStatementImports)
+      .where(and(eq(finStatementImports.id, importId), eq(finStatementImports.orgId, ctx.tenantId)))
+      .limit(1);
+    return r ?? null;
+  });
+  if (!row) return null;
+
+  let rejections: ImportStatus['rejections'] = [];
+  if (row.status === 'done' || row.status === 'parsing') {
+    try {
+      const text = await loadImportText(ctx, row);
+      rejections = parseStatementCsv(text)
+        .rejected.slice(0, MAX_REJECTIONS_IN_STATUS)
+        .map((r) => ({ sourceRow: r.sourceRow, reason: r.reason, raw: r.raw }));
+    } catch {
+      // Best-effort — status/counts are already accurate; don't fail the read.
+    }
+  }
+  return { import: row, rejections };
+}
+
+/** Reuse the same import: reset a failed OR undone job back to 'queued' and
+ *  re-enqueue. Resumes from the existing `next_chunk` (0 for 'undone', since
+ *  undo already zeroed it — no re-work of already-persisted rows for
+ *  'failed'). No-op (returns the row as-is) for any other status. */
+export async function retryImport(
+  ctx: CoreCtx,
+  importId: string,
+): Promise<FinStatementImport | null> {
+  const row = await withOrgCore(ctx, async (tx) => {
+    const [r] = await tx
+      .select()
+      .from(finStatementImports)
+      .where(and(eq(finStatementImports.id, importId), eq(finStatementImports.orgId, ctx.tenantId)))
+      .limit(1);
+    return r ?? null;
+  });
+  if (!row) return null;
+  if (row.status !== 'failed' && row.status !== 'undone') return row;
+
+  const updated = await withOrgCore(ctx, async (tx) => {
+    const [r] = await tx
+      .update(finStatementImports)
+      .set({ status: 'queued', errorCode: null, errorMessage: null, finishedAt: null })
+      .where(eq(finStatementImports.id, importId))
+      .returning();
+    return r;
+  });
+  await enqueueAndKick(ctx, importId);
+  return updated;
+}
+
+/** Delete every persisted transaction for this import and mark it 'undone'
+ *  (next_chunk/counts back to zero) — atomically, in one transaction. Does
+ *  NOT re-enqueue; call retry (or re-submit the same content) to re-ingest
+ *  — both reset 'undone' back to 'queued' + enqueue. Rejects with 409 while
+ *  the import is actively 'parsing' (simplest serialization: don't undo out
+ *  from under an in-flight chunk write). */
+export async function undoImport(
+  ctx: CoreCtx,
+  importId: string,
+): Promise<FinStatementImport | null> {
+  return withOrgCore(ctx, async (tx) => {
+    const [row] = await tx
+      .select()
+      .from(finStatementImports)
+      .where(and(eq(finStatementImports.id, importId), eq(finStatementImports.orgId, ctx.tenantId)))
+      .limit(1);
+    if (!row) return null;
+    if (row.status === 'parsing') {
+      throw error(409, 'cannot undo an import while it is actively parsing');
+    }
+
+    await tx.delete(finTransactions).where(eq(finTransactions.importId, importId));
+    const [updated] = await tx
+      .update(finStatementImports)
+      .set({
+        status: 'undone',
+        nextChunk: 0,
+        rowCount: null,
+        insertedCount: 0,
+        rejectedCount: 0,
+        errorCode: null,
+        errorMessage: null,
+        finishedAt: null,
+      })
+      .where(eq(finStatementImports.id, importId))
+      .returning();
+    return updated;
+  });
+}

--- a/supabase/migrations/20260722234500_fin_statement_imports.sql
+++ b/supabase/migrations/20260722234500_fin_statement_imports.sql
@@ -1,0 +1,91 @@
+-- Personal-finance statement imports (WP4, R4/R5 — specs/2026-07-22-personal-
+-- org-differentiation-spec.md). NEW tables, deliberately separate from
+-- fin_invoices (a sales document, not a bank-statement transaction).
+-- Tenancy: org_id text + app_ledger role + app.current_org_id GUC
+-- (withOrgCore), matching every other fin_*/pos_* table. Idempotent.
+
+create table if not exists public.fin_statement_imports (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null,
+  file_id text,                        -- bridges to files.id (cuid2 text)
+  source_kind text not null,           -- 'csv' | 'text'
+  content_sha256 text not null,
+  parser_version integer not null,
+  status text not null default 'queued', -- queued|parsing|done|failed|undone
+  next_chunk integer not null default 0, -- resumable cursor for statement_ingest
+  row_count integer,
+  inserted_count integer,
+  rejected_count integer,
+  error_code text,
+  error_message text,
+  created_by uuid,
+  created_at timestamptz not null default now(),
+  finished_at timestamptz
+);
+--> statement-breakpoint
+create unique index if not exists fin_statement_imports_org_sha_uniq
+  on public.fin_statement_imports (org_id, content_sha256);
+--> statement-breakpoint
+create index if not exists fin_statement_imports_org_idx
+  on public.fin_statement_imports (org_id, created_at);
+--> statement-breakpoint
+-- Composite FK target so fin_transactions can enforce same-org parentage
+-- (RLS alone checks the transaction's org_id, not the referenced import's).
+create unique index if not exists fin_statement_imports_org_id_uniq
+  on public.fin_statement_imports (org_id, id);
+--> statement-breakpoint
+
+create table if not exists public.fin_transactions (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null,
+  import_id uuid not null,
+  source_row integer not null,
+  posted_on date not null,
+  description text not null,
+  signed_amount numeric(18,2) not null, -- sign = direction; no separate direction column
+  currency text,
+  counterparty text,
+  category text,
+  reference text,
+  party_id uuid,                        -- soft bridge to parties.id (no FK, matches fin_clients.party_id)
+  confidence numeric,
+  warnings jsonb not null default '[]',
+  raw jsonb not null default '{}',
+  created_at timestamptz not null default now(),
+  constraint fin_transactions_org_import_fk
+    foreign key (org_id, import_id)
+    references public.fin_statement_imports (org_id, id)
+    on delete cascade
+);
+--> statement-breakpoint
+create unique index if not exists fin_transactions_import_row_uniq
+  on public.fin_transactions (import_id, source_row);
+--> statement-breakpoint
+create index if not exists fin_transactions_org_posted_idx
+  on public.fin_transactions (org_id, posted_on desc);
+--> statement-breakpoint
+create index if not exists fin_transactions_party_idx
+  on public.fin_transactions (party_id);
+--> statement-breakpoint
+
+-- ── RLS: org isolation via the app_ledger role + GUC (mirrors pos.sql) ──
+grant select, insert, update, delete on public.fin_statement_imports to app_ledger;
+--> statement-breakpoint
+alter table public.fin_statement_imports enable row level security;
+--> statement-breakpoint
+alter table public.fin_statement_imports force  row level security;
+--> statement-breakpoint
+create policy fin_statement_imports_org_guc on public.fin_statement_imports
+  for all using (org_id = current_setting('app.current_org_id', true))
+          with check (org_id = current_setting('app.current_org_id', true));
+--> statement-breakpoint
+
+grant select, insert, update, delete on public.fin_transactions to app_ledger;
+--> statement-breakpoint
+alter table public.fin_transactions enable row level security;
+--> statement-breakpoint
+alter table public.fin_transactions force  row level security;
+--> statement-breakpoint
+create policy fin_transactions_org_guc on public.fin_transactions
+  for all using (org_id = current_setting('app.current_org_id', true))
+          with check (org_id = current_setting('app.current_org_id', true));


### PR DESCRIPTION
Second scoped slice off `feat/level-2026-07-30`. Ported from `4c76e1e4`, but **not verbatim** — see the split below.

## What it does

CSV / pasted bank-statement ingestion for personal orgs: an upload endpoint with its own MIME/size/hash checks (deliberately not raw `/api/files`, which has no finance capability gate), a resumable chunked parser driven by the bg-runtime `statement_ingest` handler, and retry/undo endpoints.

Idempotent on `UNIQUE(org_id, content_sha256)` — re-submitting identical bytes returns the existing import rather than duplicating, and CRLF normalization means the same statement pasted twice dedupes to one row.

## No DDL runs on this deploy

Migration `20260722234500` was **already applied to production on 2026-07-25** (`hub_migrations` records it; `public.fin_statement_imports` exists). The runner will skip it as already-recorded. The schema shipped manually a week before its code — this PR closes that gap.

Schema drift checked against production rather than assumed:

| Table | Prod columns | Drizzle def |
|---|---|---|
| `fin_statement_imports` | 16 | 16, exact match |
| `fin_transactions` | 16 | 16, exact match |

## What was left behind, and why

Three files in the original commit are **module-availability-refactor work** that rode along, not part of this feature. They do not compile against master:

| File | Why it can't ship here |
|---|---|
| `finance.service.test.ts` | asserts `financeSummary(ctx, p, 'personal')` and `(ctx, p, 'business', {stock:false})`; master's signature is `(ctx, p)` |
| `api/gateway/query/finance/+server.ts` | threads `locals.orgKind` / `locals.moduleStates`; neither exists on master's `Locals` |

Both belong with the 67-file refactor, which is a later slice. Evidence this split is exactly right: with the schema added and those two still present, `check` reported **6 errors, all in that one route file**; removing it took the tree to **0 errors, 0 warnings**.

Conversely the **Drizzle table definitions had to be added** (+80 lines, purely additive, from `0f1de0d2`). Master deliberately excluded them, and without them the service does not compile — 13 tests failed with `Cannot read properties of undefined (reading 'orgId')`. They describe tables that already exist in production.

## RBAC

`/api/finances` is already in `API_WRITE_PREFIXES` → `finance`, so all four new endpoints are centrally write-gated. No route-contract change: these are `+server.ts`, and the manifest counts only `+page.*`.

## Gates

`bun run check` **0 errors / 0 warnings** · **48/48** tests pass (parser 35 + service 13) · `lint:tokens` 0 violations · no `.svelte` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)