### PR TITLE
refactor(routing): centralize module availability in hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ package-lock.json
 
 # SDD process artifacts (subagent-driven-development reports)
 sdd/
+
+# generated review/test artifacts
+/.lavish/
+/.playwright-cli/

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,4 +1,6 @@
 import type { TenantContext } from '$server/services/base';
+import type { OrgKind } from '$lib/org-kind';
+import type { ModuleStates } from '$lib/modules/availability';
 
 declare global {
   interface ImportMetaEnv {
@@ -31,6 +33,25 @@ declare global {
       tenantCtx?: TenantContext;
       // serverId is set for metrics Bearer-token auth
       serverId?: string;
+      /**
+       * Org kind resolved once during identity resolution (the same
+       * organization_members query that already resolves orgId — no extra
+       * getTenant round trip, routing-simplification spec S2/R2).
+       * Undefined/null = unresolved. The `(app)` route hook guard
+       * ($lib/modules/route-guard.ts) FAILS CLOSED on this for
+       * kind-restricted modules — do NOT treat it as "business" the way
+       * org-kind.ts's UI-only default does.
+       */
+      orgKind?: OrgKind | null;
+      /**
+       * Per-org module-toggle snapshot (modules.service.ts's
+       * listModuleStates, cached 5-min TTL + SWR), loaded once per request in
+       * hooks.server.ts's finishApp for authenticated `(app)` page requests.
+       * Consumed by the route hook guard and by data-bearing route loads
+       * that used to call isModuleEnabled directly (routing-simplification
+       * spec S2/R3/R5).
+       */
+      moduleStates?: ModuleStates;
       // workforceIdentity is minted per-request by workforceIdentityHandle in hooks.server.ts
       workforceIdentity?: {
         token: string;

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,7 +5,7 @@ import '$server/env-hoist';
 
 import { sequence } from '@sveltejs/kit/hooks';
 import * as Sentry from '@sentry/sveltekit';
-import type { Handle } from '@sveltejs/kit';
+import { error, type Handle } from '@sveltejs/kit';
 import { i18n } from '$lib/i18n';
 import { canonicalPath } from '$lib/canonical-path';
 import { getPostHogClient } from '$lib/server/posthog';
@@ -14,7 +14,6 @@ import { getDb } from '$server/db/client';
 import { supabaseAdmin } from '$server/supabase';
 import { resolveIdentity } from '$server/auth/resolve-identity';
 import { env } from '$env/dynamic/private';
-import { startBackupScheduler } from '$server/services/backup-scheduler';
 import { mintWorkforceIdentity } from '$lib/server/workforce-identity';
 import { trustedWorkforceViewerRoleKeys } from '$lib/server/workforce-viewer';
 import { canonicalizeWorkforceRoleKeys } from '$lib/server/workforce-role-keys';
@@ -24,6 +23,8 @@ import { getCoreDb } from '$server/db/pg-client';
 import { getUserPreferences } from '$server/services/user-preferences.service';
 import { getCachedLanding, setCachedLanding } from '$server/landing-cache';
 import { apiWriteCapability, hasOrgCapability } from '$server/services/rbac.service';
+import { listModuleStates } from '$server/services/modules.service';
+import { isAppPageRequest, isAppRouteBlocked } from '$lib/modules/route-guard';
 import {
   proxyRequestHeaders,
   proxyResponseHeaders,
@@ -170,10 +171,38 @@ const appHandle: Handle = async ({ event, resolve }) => {
     if (canonicalPath(event.url.pathname) === '/') {
       return new Response(null, { status: 307, headers: { location: '/home' } });
     }
+    // Bypass covers AUTHENTICATION only — module/kind availability still
+    // applies, or auth-disabled dev reaches routes prod 404s (the per-route
+    // guards this hook replaced are gone). isAppPageRequest keeps the
+    // /api/metrics bearer bypass (no user / no (app) route id) out of it.
+    await applyModuleAvailabilityGuard(event);
     return resolve(event);
   }
   return finishApp({ event, resolve });
 };
+
+/**
+ * Module-availability guard for authenticated `(app)` page requests
+ * (routing-simplification spec S2). Populates locals.moduleStates as a
+ * per-request snapshot (one cached listModuleStates read — R3) that
+ * data-bearing route loads also consume, then 404s if the resolved module is
+ * kind-restricted or toggled off for this org.
+ */
+async function applyModuleAvailabilityGuard(event: Parameters<Handle>[0]['event']): Promise<void> {
+  if (!isAppPageRequest(Boolean(event.locals.user), event.route.id)) return;
+  const tenantId = event.locals.tenantCtx?.tenantId;
+  const moduleStates = tenantId
+    ? await listModuleStates({
+        db: getCoreDb(),
+        tenantId,
+        profileId: event.locals.user?.supabaseId,
+      })
+    : {};
+  event.locals.moduleStates = moduleStates;
+  if (isAppRouteBlocked(canonicalPath(event.url.pathname), { kind: event.locals.orgKind, moduleStates })) {
+    throw error(404, 'Not found');
+  }
+}
 
 /**
  * Shared tail for appHandle — runs after locals.user/tenantCtx have been set
@@ -246,6 +275,7 @@ const finishApp: Handle = async ({ event, resolve }) => {
       path === '/api/crm/dni-validation/tick' ||
       path === '/api/crm/conversations/vectorize/tick' ||
       path === '/api/crm/conversations/analyze/tick' ||
+      path === '/api/crm/relationship/tick' ||
       path === '/api/reliability/retention/tick'
     ) {
       return resolve(event);
@@ -292,6 +322,14 @@ const finishApp: Handle = async ({ event, resolve }) => {
     const location = await resolveLandingPage(event.locals.user.supabaseId);
     return new Response(null, { status: 307, headers: { location } });
   }
+
+  // Module-availability guard (routing-simplification spec S2). Server-token/
+  // cron requests never reach here (resolve-identity.ts's server-token
+  // provider sets bypassGate:true — the AUTH_DISABLED bypass branch runs this
+  // same guard itself); isAppPageRequest is defense in depth on top of that.
+  // Existing per-route pulse guards stay in place until this hook has soaked
+  // (belt-and-suspenders).
+  await applyModuleAvailabilityGuard(event);
 
   // Central RBAC write guard: business-data + org-config mutating API calls
   // (/api/crm|finances|sales|scheduling|support|memberships|projects|work|
@@ -465,8 +503,6 @@ const serverErrorHandler: HandleServerError = ({ error, event, status, message }
 // Wrap so exceptions also reach Sentry (no-op without a DSN); the PostHog
 // capture inside stays as the product-analytics record.
 export const handleError = Sentry.handleErrorWithSentry(serverErrorHandler);
-
-startBackupScheduler();
 
 // One-time cache initialization.
 void initCache().catch((err) => console.error('[cache] init failed', err));

--- a/src/lib/access/can.svelte.test.ts
+++ b/src/lib/access/can.svelte.test.ts
@@ -1,20 +1,31 @@
-import { describe, test, expect, vi } from 'vitest';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('$app/state', () => ({
+// Mutable so kind-gating tests below can flip `activeOrgKind` per test without
+// re-mocking the module — `page.data` is read fresh at each canViewPath() call.
+const pageData: {
+  user: { role: 'user' | 'admin' };
+  permissions: { permissions: string[] };
+  activeOrgKind?: 'business' | 'personal' | null;
+} = {
   // Platform admins receive the full PERMISSIONS set (loadPermissionsForUser
   // short-circuit); users.manage + reliability.monitor are now permission-driven
   // (RBAC-migrated off minRole/super-view), so the perm set must carry them.
   // For canViewPath we include finance:view but NOT finance.products:view so the
   // products subpage link hides while the section view stays.
-  page: {
-    data: {
-      user: { role: 'admin' },
-      permissions: {
-        permissions: ['marketplace:publish', 'users:manage', 'reliability:view', 'finance:view'],
-      },
-    },
+  user: { role: 'admin' },
+  permissions: {
+    permissions: ['marketplace:publish', 'users:manage', 'reliability:view', 'finance:view'],
   },
+  activeOrgKind: 'business',
+};
+
+vi.mock('$app/state', () => ({
+  page: { data: pageData },
 }));
+
+beforeEach(() => {
+  pageData.activeOrgKind = 'business';
+});
 
 describe('canClient', () => {
   test('reads role + permissions from page.data', async () => {
@@ -32,5 +43,45 @@ describe('canViewPath — section subpage gating', () => {
     expect(canViewPath('/finances')).toBe(true); // finance:view present
     expect(canViewPath('/finances/invoices')).toBe(true); // no sub-resource → inherits finance:view
     expect(canViewPath('/finances/products')).toBe(false); // finance.products:view absent
+  });
+});
+
+// S3/WP1 (specs/2026-07-22-personal-org-differentiation-spec.md R2/R6):
+// canViewPath additionally consults org-kind visibility so the command
+// palette/hotkeys/SettingsNav stop offering kind-hidden modules.
+describe('canViewPath — org-kind gating', () => {
+  test('personal org: Team/Stock/POS/Workforce hidden even though RBAC would allow them', async () => {
+    pageData.activeOrgKind = 'personal';
+    pageData.permissions.permissions = [...pageData.permissions.permissions, 'stock:view', 'pos:view'];
+    const { canViewPath } = await import('./can.svelte');
+    expect(canViewPath('/team')).toBe(false);
+    expect(canViewPath('/settings/team')).toBe(false);
+    expect(canViewPath('/stock')).toBe(false);
+    expect(canViewPath('/pos')).toBe(false);
+    expect(canViewPath('/workforce')).toBe(false);
+    expect(canViewPath('/support')).toBe(false);
+    expect(canViewPath('/sales')).toBe(false);
+  });
+
+  test('personal org: kind-neutral paths stay gated by RBAC only', async () => {
+    pageData.activeOrgKind = 'personal';
+    const { canViewPath } = await import('./can.svelte');
+    expect(canViewPath('/overview')).toBe(true);
+    expect(canViewPath('/finances')).toBe(true);
+  });
+
+  test('business org: Team/Stock/POS/Workforce are visible (RBAC-gated only)', async () => {
+    pageData.activeOrgKind = 'business';
+    const { canViewPath } = await import('./can.svelte');
+    expect(canViewPath('/team')).toBe(true); // users:manage present
+  });
+
+  test('query-string hrefs (archetype filters) resolve to no manifest module (kind-neutral)', async () => {
+    pageData.activeOrgKind = 'personal';
+    const { canViewPath } = await import('./can.svelte');
+    // /agents isn't in MODULE_MANIFEST, so kind never enters the decision —
+    // canViewPath falls straight through to the existing RBAC result, same
+    // as calling it with the plain path.
+    expect(canViewPath('/agents?archetype=copilot')).toBe(canViewPath('/agents'));
   });
 });

--- a/src/lib/access/can.svelte.ts
+++ b/src/lib/access/can.svelte.ts
@@ -1,10 +1,13 @@
 import { page } from '$app/state';
 import { can } from './policy';
 import { canAccessRoute, type RouteAccessContext } from '$lib/routes/route-access-policies';
+import { resolveModuleForPath } from '$lib/modules/availability';
+import { isModuleVisibleForKind, type OrgKind } from '$lib/org-kind';
 
 interface ClientAccessData {
   user?: { role?: 'user' | 'admin' } | null;
   permissions?: { permissions?: string[] } | null;
+  activeOrgKind?: OrgKind | null;
 }
 
 function accessData(): ClientAccessData {
@@ -43,7 +46,18 @@ export function canAct(module: string, action: string): boolean {
 /**
  * Evaluate a live href through the same route policy registry the server layout,
  * design manifest, global navigation, and command palette consult.
+ *
+ * Also applies org-kind visibility (S3/WP1 R2/R6): the command palette, nav
+ * hotkey chords (GNav.svelte), and SettingsNav all route through this one
+ * function, so kind-hidden modules (Team/Stock/POS/Workforce/… for personal
+ * orgs) stop being offered client-side without duplicating the check at each
+ * call site. Kind-only (no moduleStates) — the toggle-state gate stays
+ * server-side via `locals.moduleStates`/the hook guard; this is a UI-offer
+ * check, not the enforcement boundary.
  */
 export function canViewPath(path: string): boolean {
+  const kind = accessData().activeOrgKind;
+  const match = resolveModuleForPath(path.split(/[?#]/, 1)[0] || '/');
+  if (match && !isModuleVisibleForKind(match.moduleId, kind)) return false;
   return canAccessRoute(path, routeAccessContext());
 }

--- a/src/lib/components/layout/NotificationsPopup.svelte
+++ b/src/lib/components/layout/NotificationsPopup.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import * as m from '$lib/paraglide/messages';
-  import { Bell, ArrowRight, Download } from 'lucide-svelte';
+  import { Bell, ArrowRight, Download, Check, X } from 'lucide-svelte';
   import { scale } from 'svelte/transition';
   import { updateState } from '$lib/state/gateway/update-state.svelte';
-  import { Button } from '$lib/components/ui';
+  import { Button, iconSizes } from '$lib/components/ui';
+  import { pulse } from '$lib/state/features/pulse.svelte';
+  import type { PulseProposalRow } from '$server/db/pg-schema/pulse';
 
   interface PendingRequest {
     id: string;
@@ -16,6 +18,9 @@
 
   let requests = $state<PendingRequest[]>([]);
   let loading = $state(false);
+  let pulseBusyId = $state<string | null>(null);
+
+  const pulseItems = $derived(pulse.items as unknown as PulseProposalRow[]);
 
   async function fetchRequests() {
     loading = true;
@@ -32,8 +37,23 @@
     }
   }
 
+  async function pulseAct(id: string, action: 'approve' | 'dismiss') {
+    pulseBusyId = id;
+    try {
+      // pulse.act() already re-fetches items + count internally, and
+      // notifications.badgeCount reads pulse.pendingCount reactively — the
+      // bell badge updates on its own, no extra refresh call needed.
+      await (action === 'approve' ? pulse.approve(id) : pulse.dismiss(id));
+    } finally {
+      pulseBusyId = null;
+    }
+  }
+
   $effect(() => {
-    if (open) fetchRequests();
+    if (open) {
+      fetchRequests();
+      pulse.refresh();
+    }
   });
 
   function close() {
@@ -67,9 +87,9 @@
     <!-- Header -->
     <div class="flex items-center justify-between px-4 py-3 border-b border-[var(--hairline)]">
       <h3 class="text-sm font-semibold text-foreground">{m.notificationsPopup_title()}</h3>
-      {#if requests.length > 0}
+      {#if requests.length + pulseItems.length > 0}
         <span class="text-[length:var(--font-size-telemetry)] font-medium px-1.5 py-0.5 rounded-full bg-accent/15 text-accent">
-          {requests.length}
+          {requests.length + pulseItems.length}
         </span>
       {/if}
     </div>
@@ -92,12 +112,49 @@
         <div class="flex items-center justify-center py-8">
           <div class="w-5 h-5 border-2 border-muted-foreground/30 border-t-accent rounded-full animate-spin"></div>
         </div>
-      {:else if requests.length === 0}
+      {:else if requests.length === 0 && pulseItems.length === 0}
         <div class="flex flex-col items-center justify-center py-8 gap-2 text-muted-foreground">
           <Bell size={24} class="opacity-40" />
           <p class="text-xs">{m.notificationsPopup_noPending()}</p>
         </div>
       {:else}
+        {#if pulseItems.length > 0}
+          <a
+            href="/pulse"
+            onclick={close}
+            class="flex items-center justify-between px-4 py-1.5 border-b border-[var(--hairline)] text-[length:var(--font-size-telemetry)] font-semibold text-muted-foreground uppercase tracking-wide hover:text-foreground no-underline"
+          >
+            {m.nav_pulse()}
+          </a>
+          {#each pulseItems as p (p.id)}
+            <div class="flex flex-col px-4 py-3 border-b border-[var(--hairline)] hover:bg-bg3/50 transition-colors duration-[var(--duration-fast)]">
+              <span class="text-sm font-medium text-foreground truncate">{p.title}</span>
+              {#if p.summary}
+                <p class="text-xs text-muted mt-0.5 line-clamp-2">{p.summary}</p>
+              {/if}
+              <div class="flex items-center gap-2 mt-1.5">
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  disabled={pulseBusyId === p.id}
+                  onclick={() => pulseAct(p.id, 'approve')}
+                >
+                  <Check size={iconSizes.xs} />
+                  {m.notif_approve()}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  disabled={pulseBusyId === p.id}
+                  onclick={() => pulseAct(p.id, 'dismiss')}
+                >
+                  <X size={iconSizes.xs} />
+                  {m.common_dismiss()}
+                </Button>
+              </div>
+            </div>
+          {/each}
+        {/if}
         {#each requests as req (req.id)}
           <div class="flex flex-col px-4 py-3 border-b border-[var(--hairline)] last:border-b-0 hover:bg-bg3/50 transition-colors duration-[var(--duration-fast)]">
             <div class="flex items-start justify-between gap-2">

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -18,12 +18,7 @@
   } from 'lucide-svelte';
   import NavIcon from './NavIcon.svelte';
   import { Button, Tooltip } from '$lib/components/ui';
-  import {
-    getSections,
-    getDynamicPluginsSections,
-    type Section,
-    type SectionItem,
-  } from './sections';
+  import { getNavSections, type Section, type SectionItem } from './sections';
   import { readNavOrder, bySavedOrder, type NavOrder } from './nav-order';
   import MinionLogo from './MinionLogo.svelte';
   import OrgPicker from './OrgPicker.svelte';
@@ -39,17 +34,13 @@
   // brand. Relocated from the agents-sidebar footer.
   const serverVersion = $derived(gw.hello?.server?.version ?? null);
 
-  const staticSections = $derived(getSections());
   // Pass per-org enabled map so the derive re-runs when a plugin is toggled —
   // disabled-for-org plugin items render dimmed, reactively, with no reload.
-  const pluginsSections = $derived(
-    getDynamicPluginsSections(
-      pluginNavState.controlCenters,
-      pluginNavState.enabledByPluginId,
-      page.data.activeOrgKind,
-    ),
+  // getNavSections composes static + dynamic sections kind-aware (personal
+  // orgs get the R2 regrouping); Topbar's mobile hamburger uses the same call.
+  const navSections = $derived<Section[]>(
+    getNavSections(page.data.activeOrgKind, pluginNavState.controlCenters, pluginNavState.enabledByPluginId),
   );
-  const navSections = $derived<Section[]>([...staticSections, ...pluginsSections]);
 
   const showReliability = $derived(canViewPath('/reliability'));
   const showCloud = $derived(canViewPath('/cloud'));

--- a/src/lib/components/layout/Topbar.svelte
+++ b/src/lib/components/layout/Topbar.svelte
@@ -7,7 +7,7 @@
     import NotificationsPopup from "./NotificationsPopup.svelte";
     import MinionLogo from "./MinionLogo.svelte";
     import CompanySwitcher from "./CompanySwitcher.svelte";
-    import { getSections, getDynamicPluginsSections, type Section, type SectionItem } from "./sections";
+    import { getNavSections, type Section, type SectionItem } from "./sections";
     import { readNavOrder, orderSections, orderItems } from "./nav-order";
     import { pluginNavState } from "$lib/state/plugin-nav.svelte";
     import { canViewPath } from "$lib/access/can.svelte";
@@ -21,14 +21,12 @@
     import { userState, logout } from "$lib/state/features/user.svelte";
     import { Button } from '$lib/components/ui';
 
-    const allSections = $derived<Section[]>([
-        ...getSections(),
-        ...getDynamicPluginsSections(
-            pluginNavState.controlCenters,
-            pluginNavState.enabledByPluginId,
-            page.data.activeOrgKind,
-        ),
-    ]);
+    // Same call as Sidebar's desktop nav (mobile-parity: R2) — getNavSections
+    // composes static + dynamic sections kind-aware, merging Pulse/My Work
+    // into the "My Space" group for personal orgs.
+    const allSections = $derived<Section[]>(
+        getNavSections(page.data.activeOrgKind, pluginNavState.controlCenters, pluginNavState.enabledByPluginId),
+    );
     // Honor the user's drag-reordered sidebar order here too (same prefs source),
     // so desktop nav and the mobile hamburger stay consistent.
     const navOrder = $derived(readNavOrder(page.data));

--- a/src/lib/components/layout/sections.test.ts
+++ b/src/lib/components/layout/sections.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { getSections, getDynamicPluginsSections } from './sections';
+import { getSections, getDynamicPluginsSections, getNavSections } from './sections';
+import type { PluginUiManifestOccupant } from '$lib/plugins/plugin-types';
 
 describe('getSections — core nav taxonomy', () => {
   it('exposes Organization (Home/Overview/Team) and Agents groups', () => {
@@ -60,5 +61,102 @@ describe('personal-org nav gating', () => {
     const secs = getDynamicPluginsSections([]);
     const hrefs = secs.flatMap((s) => s.items.map((i) => i.href));
     expect(hrefs).toContain('/pos');
+  });
+
+  // S3/WP1: deliberate expansion — support/memberships/sales/ads/team also
+  // drop for personal orgs (org-kind.ts ORG_KIND_POLICY).
+  it('hides support/memberships/sales/ads/team for personal orgs', () => {
+    const secs = getDynamicPluginsSections([], {}, 'personal');
+    const hrefs = secs.flatMap((s) => s.items.map((i) => i.href));
+    expect(hrefs).not.toContain('/support');
+    expect(hrefs).not.toContain('/memberships');
+    expect(hrefs).not.toContain('/sales');
+    expect(hrefs).not.toContain('/socials');
+    const orgHrefs = getSections('personal').find((s) => s.id === 'organization')?.items.map((i) => i.href);
+    expect(orgHrefs).not.toContain('/team');
+  });
+});
+
+describe('getSections — personal org (R2)', () => {
+  it('drops /team but keeps Home/Overview, relabels the group "My Space"', () => {
+    const org = getSections('personal').find((s) => s.id === 'organization');
+    expect(org?.items.map((i) => i.href)).toEqual(['/home', '/overview']);
+    expect(org?.label).toBe('My Space');
+  });
+
+  it('business orgs are unaffected (Home/Overview/Team, "Organization" label)', () => {
+    const org = getSections('business').find((s) => s.id === 'organization');
+    expect(org?.items.map((i) => i.href)).toEqual(['/home', '/overview', '/team']);
+    expect(org?.label).toBe('Organization');
+  });
+});
+
+describe('getNavSections — personal org regrouping (R2)', () => {
+  const voiceCallPlugin: PluginUiManifestOccupant = {
+    pluginId: 'voice-call',
+    slot: 'plugins.controlCenter' as const,
+    title: 'Voice Calls',
+    description: '',
+    entrypoint: 'c.html',
+    category: 'tool' as const,
+  };
+  const whatsapp: PluginUiManifestOccupant = {
+    pluginId: 'whatsapp',
+    slot: 'plugins.controlCenter' as const,
+    title: 'WhatsApp',
+    description: '',
+    entrypoint: 'c.html',
+    category: 'channel' as const,
+  };
+  const studio: PluginUiManifestOccupant = {
+    pluginId: 'studio',
+    slot: 'plugins.controlCenter' as const,
+    title: 'Studio',
+    description: '',
+    entrypoint: 'c.html',
+    category: 'creative' as const,
+  };
+
+  it('merges Pulse + My Work into a single "My Space" group with Home/Overview', () => {
+    const secs = getNavSections('personal', [], {});
+    const mySpace = secs.find((s) => s.id === 'organization');
+    expect(mySpace?.label).toBe('My Space');
+    expect(mySpace?.items.map((i) => i.href)).toEqual(
+      expect.arrayContaining(['/home', '/overview', '/pulse', '/work']),
+    );
+    expect(mySpace?.items).toHaveLength(4);
+    // no separate "plugins:my-space" section leaks through
+    expect(secs.find((s) => s.id === 'plugins:my-space')).toBeUndefined();
+  });
+
+  it('groups People (relabeled CRM), Scheduling, Channels, Voice Calls under "Relationships"', () => {
+    const secs = getNavSections('personal', [voiceCallPlugin, whatsapp], {});
+    const relationships = secs.find((s) => s.id === 'plugins:relationships');
+    const hrefs = relationships?.items.map((i) => i.href);
+    expect(hrefs).toEqual(expect.arrayContaining(['/crm', '/scheduling', '/channels', '/plugins/voice-call']));
+    const crmItem = relationships?.items.find((i) => i.href === '/crm');
+    expect(crmItem?.label).toBe('People');
+  });
+
+  it('Finances lands in a "Money"-labeled group (no Sales/Memberships alongside it)', () => {
+    const secs = getNavSections('personal', [], {});
+    const money = secs.find((s) => s.id === 'plugins:finance');
+    expect(money?.label).toBe('Money');
+    expect(money?.items.map((i) => i.href)).toEqual(['/finances']);
+  });
+
+  it('remaining permitted plugins fall into "Tools"', () => {
+    const secs = getNavSections('personal', [studio], {});
+    const tools = secs.find((s) => s.id === 'plugins:tool');
+    expect(tools?.items.map((i) => i.href)).toContain('/plugins/studio');
+  });
+
+  it('business orgs: unchanged concat, no My Space/Relationships/Money groups', () => {
+    const secs = getNavSections('business', [voiceCallPlugin], {});
+    expect(secs.find((s) => s.id === 'plugins:relationships')).toBeUndefined();
+    expect(secs.find((s) => s.id === 'plugins:my-space')).toBeUndefined();
+    const org = secs.find((s) => s.id === 'organization');
+    expect(org?.label).toBe('Organization');
+    expect(org?.items.map((i) => i.href)).toEqual(['/home', '/overview', '/team']);
   });
 });

--- a/src/lib/components/layout/sections.ts
+++ b/src/lib/components/layout/sections.ts
@@ -92,10 +92,13 @@ function archetypeItem(archetype: AgentArchetype, label: string, icon: LucideIco
 
 /**
  * Build the static core nav sections (always present): Organization (Home,
- * Overview, Team) and Agents (Copilots / AI Brains / Autonomous archetype
- * filters, then Capabilities / Agent Builder / Prompt authoring tools).
+ * Overview, Team — Team drops for personal orgs, R1/kind matrix) and Agents
+ * (Copilots / AI Brains / Autonomous archetype filters, then Capabilities /
+ * Agent Builder / Prompt authoring tools). `orgKind` defaults to business
+ * (matches `isModuleVisibleForKind`'s unknown-kind fallback), so existing
+ * no-arg callers are unaffected.
  */
-export function getSections(): Section[] {
+export function getSections(orgKind?: "business" | "personal"): Section[] {
     const agentItems: SectionItem[] = [
         archetypeItem("copilot", m.nav_copilots(), UserRound),
         {
@@ -112,12 +115,19 @@ export function getSections(): Section[] {
         },
         ...routeItems("agents"),
     ];
+    const isPersonal = orgKind === "personal";
+    // Same moduleId-derivation + isModuleVisibleForKind gate the dynamic
+    // plugin items use below (R2: one seam for nav kind-filtering) — drops
+    // /team for personal via ORG_KIND_POLICY, no separate branch needed.
+    const organizationItems = routeItems("organization").filter((it) =>
+        isModuleVisibleForKind(it.href.replace(/^\//, "").split("/")[0], orgKind),
+    );
     return [
         {
             id: "organization",
-            label: SECTION_META.organization.label(),
+            label: isPersonal ? m.nav_mySpace() : SECTION_META.organization.label(),
             tone: SECTION_META.organization.tone,
-            items: routeItems("organization"),
+            items: organizationItems,
         },
         {
             id: "agents",
@@ -132,8 +142,22 @@ export function findActiveSection(sections: Section[], pathname: string): Sectio
     return sections.find((s) => s.items.some((it) => it.matcher(pathname))) ?? null;
 }
 
-/** Plugin manifest taxonomy → business-domain nav buckets. */
-type PluginNavCategory = "marketing" | "operations" | "finance" | "creative" | "customer-support" | "channel" | "tool";
+/**
+ * Plugin manifest taxonomy → business-domain nav buckets. `my-space` and
+ * `relationships` are PERSONAL-ONLY display buckets (R2) — they never appear
+ * for business orgs and are resolved purely by category overrides in
+ * `getDynamicPluginsSections`, not by any gateway plugin manifest category.
+ */
+type PluginNavCategory =
+    | "marketing"
+    | "operations"
+    | "finance"
+    | "creative"
+    | "customer-support"
+    | "channel"
+    | "tool"
+    | "my-space"
+    | "relationships";
 
 /**
  * Built-in plugin entries surfaced regardless of which gateway plugins are
@@ -269,6 +293,36 @@ const PLUGIN_NAV_GROUPS: ReadonlyArray<{ category: PluginNavCategory; label: () 
 ];
 
 /**
+ * Personal-org nav groups (R2). `my-space` merges into the static
+ * "organization" section (Home/Overview) by `getNavSections` below — it is
+ * NOT rendered as its own section here (excluded from this list on purpose).
+ * `relationships` replaces marketing/customer-support; `finance` is relabeled
+ * "Money"; `tool` stays the catch-all for whatever plugins remain permitted.
+ */
+const PLUGIN_NAV_GROUPS_PERSONAL: ReadonlyArray<{ category: PluginNavCategory; label: () => string }> = [
+    { category: "relationships", label: () => m.nav_relationships() },
+    { category: "finance", label: () => m.nav_money() },
+    { category: "tool", label: () => m.nav_tools_group() },
+];
+
+/**
+ * Personal-only display placement overrides (R2). Business plugin/manifest
+ * categories are untouched — this is purely a hub-side nav-grouping map,
+ * keyed by the same moduleId/pluginId the business-category resolution
+ * already uses. `pulse`/`work` land in `my-space` (merged into the
+ * "organization"/My Space section by `getNavSections`); `crm`/`scheduling`
+ * and the voice-call plugin land in `relationships` alongside Channels.
+ */
+const PERSONAL_CATEGORY_OVERRIDES: Record<string, PluginNavCategory> = {
+    pulse: "my-space",
+    work: "my-space",
+    crm: "relationships",
+    scheduling: "relationships",
+    "voice-call": "relationships",
+    voicecall: "relationships",
+};
+
+/**
  * First-party plugin → category overrides. The running gateway may predate the
  * business-domain manifest categories (it would then report "tool"/"automation"/
  * "channel"), so we pin known first-party plugins to their intended group here.
@@ -340,13 +394,29 @@ export function getDynamicPluginsSections(
         byCategory.set(category, list);
     };
 
+    const isPersonal = orgKind === "personal";
+    // Personal has no Marketing/Operations/Branding/Customer-Support groups
+    // (PLUGIN_NAV_GROUPS_PERSONAL) — anything not explicitly placed in
+    // my-space/relationships/finance collapses into the Tools catch-all.
+    // "channel" is exempt — `place()` special-cases it into channelItems
+    // before any category bucketing happens, for both kinds.
+    const PERSONAL_KEPT_CATEGORIES = new Set<PluginNavCategory>(["my-space", "relationships", "finance", "channel"]);
+    const personalize = (id: string, category: PluginNavCategory): PluginNavCategory => {
+        if (!isPersonal) return category;
+        if (PERSONAL_CATEGORY_OVERRIDES[id]) return PERSONAL_CATEGORY_OVERRIDES[id];
+        return PERSONAL_KEPT_CATEGORIES.has(category) ? category : "tool";
+    };
+
     for (const { category, item } of BUILTIN_PLUGIN_ITEMS) {
         // 'crm' | 'finances' | 'workforce' | ... — falls back to the href's
         // first segment unless the item overrides it (e.g. /socials -> 'ads').
         const moduleId = item.moduleId ?? item.href.replace(/^\//, "").split("/")[0];
         if (enabledByPluginId[moduleId] === false) continue; // per-org module gate
         if (!isModuleVisibleForKind(moduleId, orgKind)) continue;
-        place(category, item);
+        // Personal-only relabel: the CRM item reads "People" (R2) — data-only,
+        // the underlying route/module is unchanged.
+        const effectiveItem = isPersonal && moduleId === "crm" ? { ...item, label: m.nav_people() } : item;
+        place(personalize(moduleId, category), effectiveItem);
     }
     for (const e of entries) {
         // Per-org gate: a plugin disabled for the acting org is removed from the
@@ -354,8 +424,13 @@ export function getDynamicPluginsSections(
         // updates pluginNavState.enabledByPluginId, so the link appears/vanishes
         // with no reload.
         if (enabledByPluginId[e.pluginId] === false) continue;
+        // Kind gate (R2/R6: sections.ts:351 gap) — installed plugins go through
+        // the same isModuleVisibleForKind predicate as builtins. No installed
+        // plugin id is in ORG_KIND_POLICY today, so this is a no-op unless a
+        // future plugin id collides with a hidden module id — safety net.
+        if (!isModuleVisibleForKind(e.pluginId, orgKind)) continue;
         const category = PLUGIN_CATEGORY_OVERRIDES[e.pluginId] ?? normalizePluginCategory(e.category);
-        place(category, {
+        place(personalize(e.pluginId, category), {
             href: `/plugins/${e.pluginId}`,
             label: e.title,
             icon: resolvePluginIcon(e.icon),
@@ -363,21 +438,23 @@ export function getDynamicPluginsSections(
         });
     }
 
-    // Channels collapse into a single "Channels" link under Customer Support;
-    // the enabled channels themselves live on the /channels secondary side-menu.
+    // Channels collapse into a single "Channels" link — under Customer Support
+    // for business, folded into Relationships for personal (R2); the enabled
+    // channels themselves live on the /channels secondary side-menu.
     if (channelItems.length) {
-        const cs = byCategory.get("customer-support") ?? [];
-        cs.push({
+        const target = isPersonal ? "relationships" : "customer-support";
+        const list = byCategory.get(target) ?? [];
+        list.push({
             href: "/channels",
             label: m.nav_channels(),
             icon: MessagesSquare,
             matcher: (p: string) => p.startsWith("/channels"),
         });
-        byCategory.set("customer-support", cs);
+        byCategory.set(target, list);
     }
 
     const sections: Section[] = [];
-    for (const group of PLUGIN_NAV_GROUPS) {
+    for (const group of isPersonal ? PLUGIN_NAV_GROUPS_PERSONAL : PLUGIN_NAV_GROUPS) {
         const items = byCategory.get(group.category) ?? [];
         if (items.length === 0) continue;
         sections.push({
@@ -387,5 +464,42 @@ export function getDynamicPluginsSections(
             items,
         });
     }
+    // "my-space" is personal-only and merges into the static organization
+    // section (getNavSections) — never surfaced as its own section here.
+    if (isPersonal) {
+        const myItems = byCategory.get("my-space") ?? [];
+        if (myItems.length) {
+            sections.unshift({ id: "plugins:my-space", label: m.nav_mySpace(), tone: "accent", items: myItems });
+        }
+    }
     return sections;
+}
+
+/**
+ * Compose the static core sections and the dynamic plugin sections into the
+ * final nav list, kind-aware. For personal orgs the "my-space" plugin bucket
+ * (Pulse, My Work) is folded into the static "organization"/My Space section
+ * so Home/Overview/Pulse/My Work render as ONE group — same "insert after
+ * assembly" pattern the Channels→Customer Support fold already uses inside
+ * `getDynamicPluginsSections`. Business orgs are a plain concat, unchanged.
+ * Single call site for Sidebar/Topbar so both stay in lockstep (R2 mobile
+ * parity: they share this + `nav-order.ts`).
+ */
+export function getNavSections(
+    orgKind: "business" | "personal" | undefined,
+    entries: PluginUiManifestOccupant[],
+    enabledByPluginId: Record<string, boolean> = {},
+): Section[] {
+    const staticSections = getSections(orgKind);
+    const pluginSections = getDynamicPluginsSections(entries, enabledByPluginId, orgKind);
+    if (orgKind !== "personal") return [...staticSections, ...pluginSections];
+
+    const myPlugins = pluginSections.find((s) => s.id === "plugins:my-space");
+    const rest = pluginSections.filter((s) => s.id !== "plugins:my-space");
+    if (!myPlugins) return [...staticSections, ...rest];
+
+    const merged = staticSections.map((s) =>
+        s.id === "organization" ? { ...s, items: [...s.items, ...myPlugins.items] } : s,
+    );
+    return [...merged, ...rest];
 }

--- a/src/lib/components/settings/SettingsNav.svelte
+++ b/src/lib/components/settings/SettingsNav.svelte
@@ -3,6 +3,7 @@
   import { Brain, Bot, Radio, Shield, Server, Palette, DatabaseBackup, Puzzle, Users, KeyRound, Phone, Blocks, Bell, Workflow, Building2, Activity } from "lucide-svelte";
   import { page } from "$app/state";
   import { isAdmin } from "$lib/state/features/user.svelte";
+  import { canViewPath } from "$lib/access/can.svelte";
   import { TABS } from "$lib/utils/config-schema";
   import * as m from "$lib/paraglide/messages";
   import {
@@ -62,9 +63,16 @@
     return id === 'ai';
   }
 
+  // Gateway config tabs have no /settings/<id> route (they live on ?s=<id>,
+  // outside MODULE_MANIFEST) so canViewPath's kind check is a no-op for them —
+  // the Hub/Team tabs below DO have real routes, so filter through the same
+  // predicate GNav's hotkey chords use (R2/R6: one seam, stop offering
+  // kind-hidden settings tabs — e.g. /settings/team for personal orgs).
   const visibleGatewayTabs = $derived(isAdmin.value ? gatewayTabs : []);
-  const visibleHubTabs = $derived(isAdmin.value ? HUB_TABS : HUB_TABS.filter((t) => !t.adminOnly));
-  const visibleTeamTabs = $derived(isAdmin.value ? TEAM_TABS : []);
+  const visibleHubTabs = $derived(
+    (isAdmin.value ? HUB_TABS : HUB_TABS.filter((t) => !t.adminOnly)).filter((t) => canViewPath(t.href)),
+  );
+  const visibleTeamTabs = $derived((isAdmin.value ? TEAM_TABS : []).filter((t) => canViewPath(t.href)));
 
   function hubItem(t: HubTab): SectionNavItem {
     return { id: t.id, label: t.label, icon: ICON_MAP[t.icon], href: t.href };
@@ -73,7 +81,11 @@
   // Build grouped sections; SideNav handles search filtering + empty-group culling.
   const groups = $derived.by<SectionNavGroup[]>(() => {
     const out: SectionNavGroup[] = [];
-    out.push({ id: 'general', label: m.settings_nav_group_general(), items: GENERAL_TABS.map(hubItem) });
+    out.push({
+      id: 'general',
+      label: m.settings_nav_group_general(),
+      items: GENERAL_TABS.filter((t) => canViewPath(t.href)).map(hubItem),
+    });
     if (visibleGatewayTabs.length) {
       out.push({
         id: 'server',

--- a/src/lib/modules/availability.test.ts
+++ b/src/lib/modules/availability.test.ts
@@ -1,0 +1,252 @@
+import { describe, test, expect } from 'vitest';
+import { readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  MODULE_MANIFEST,
+  resolveModuleForPath,
+  isModuleAvailable,
+  effectiveModuleEnabled,
+} from './availability';
+
+// NOTE (S3/WP1, specs/2026-07-22-personal-org-differentiation-spec.md R1):
+// this file originally characterized the kind matrix as it existed BEFORE
+// the personal-org-differentiation policy expansion. support/memberships/
+// sales/ads/team are now DELIBERATELY kind-gated (personal hides them) —
+// the tests below reflect the new intended matrix, not a behavior-preserving
+// snapshot. `team` also went from CORE_UNMANAGED to a manifest entry.
+
+describe('resolveModuleForPath', () => {
+  test('longest-prefix wins: /settings/pulse resolves to pulse, not a bare /settings entry', () => {
+    expect(resolveModuleForPath('/settings/pulse')?.moduleId).toBe('pulse');
+    expect(resolveModuleForPath('/settings/pulse/anything')?.moduleId).toBe('pulse');
+  });
+
+  test('/pulse resolves to pulse directly', () => {
+    expect(resolveModuleForPath('/pulse')?.moduleId).toBe('pulse');
+    expect(resolveModuleForPath('/pulse/history')?.moduleId).toBe('pulse');
+  });
+
+  test('alias: /socials resolves to the ads module id', () => {
+    expect(resolveModuleForPath('/socials')?.moduleId).toBe('ads');
+    expect(resolveModuleForPath('/socials/campaigns/x')?.moduleId).toBe('ads');
+  });
+
+  test('composite: /pos/appointments resolves to posAppointments, not pos', () => {
+    expect(resolveModuleForPath('/pos/appointments')?.moduleId).toBe('posAppointments');
+    expect(resolveModuleForPath('/pos/appointments/today')?.moduleId).toBe('posAppointments');
+  });
+
+  test('other /pos subpaths still resolve to pos', () => {
+    expect(resolveModuleForPath('/pos/sell')?.moduleId).toBe('pos');
+    expect(resolveModuleForPath('/pos')?.moduleId).toBe('pos');
+  });
+
+  test('a path that is a prefix of a manifest prefix does not match (no false positive)', () => {
+    expect(resolveModuleForPath('/po')).toBeNull();
+    expect(resolveModuleForPath('/socialsx')).toBeNull();
+  });
+
+  test('/team resolves to the team module', () => {
+    expect(resolveModuleForPath('/team')?.moduleId).toBe('team');
+    expect(resolveModuleForPath('/team/roster')?.moduleId).toBe('team');
+  });
+
+  test('/settings/team resolves to team via longest-prefix, not a bare /settings entry', () => {
+    expect(resolveModuleForPath('/settings/team')?.moduleId).toBe('team');
+  });
+
+  test('unknown path resolves to null', () => {
+    expect(resolveModuleForPath('/home')).toBeNull();
+    expect(resolveModuleForPath('/nonexistent')).toBeNull();
+  });
+});
+
+describe('isModuleAvailable — kind matrix (org-kind.ts ORG_KIND_POLICY, S3/WP1 DELIBERATE expansion)', () => {
+  test('pulse: hidden for business, visible for personal', () => {
+    expect(isModuleAvailable('pulse', { kind: 'business', moduleStates: {} })).toBe(false);
+    expect(isModuleAvailable('pulse', { kind: 'personal', moduleStates: {} })).toBe(true);
+  });
+
+  test('pos/stock/workforce: hidden for personal, visible for business', () => {
+    for (const moduleId of ['pos', 'stock', 'workforce']) {
+      expect(isModuleAvailable(moduleId, { kind: 'personal', moduleStates: {} })).toBe(false);
+      expect(isModuleAvailable(moduleId, { kind: 'business', moduleStates: {} })).toBe(true);
+    }
+  });
+
+  test('support/memberships/sales/ads/team: hidden for personal, visible for business (S3/WP1 addition)', () => {
+    for (const moduleId of ['support', 'memberships', 'sales', 'ads', 'team']) {
+      expect(isModuleAvailable(moduleId, { kind: 'personal', moduleStates: {} })).toBe(false);
+      expect(isModuleAvailable(moduleId, { kind: 'business', moduleStates: {} })).toBe(true);
+    }
+  });
+
+  test('crm/finances/scheduling remain available for both kinds', () => {
+    for (const moduleId of ['crm', 'finances', 'scheduling']) {
+      expect(isModuleAvailable(moduleId, { kind: 'personal', moduleStates: {} })).toBe(true);
+      expect(isModuleAvailable(moduleId, { kind: 'business', moduleStates: {} })).toBe(true);
+    }
+  });
+
+  test('unknown/undefined kind degrades to business (matches org-kind.ts)', () => {
+    expect(isModuleAvailable('pulse', { kind: undefined, moduleStates: {} })).toBe(false);
+    expect(isModuleAvailable('pulse', { kind: null, moduleStates: {} })).toBe(false);
+    expect(isModuleAvailable('pos', { kind: undefined, moduleStates: {} })).toBe(true);
+    expect(isModuleAvailable('team', { kind: undefined, moduleStates: {} })).toBe(true);
+  });
+});
+
+describe('isModuleAvailable — module-toggle states', () => {
+  test('missing row in moduleStates = enabled (modules.service.ts:26 semantics)', () => {
+    expect(isModuleAvailable('crm', { kind: 'business', moduleStates: {} })).toBe(true);
+    expect(isModuleAvailable('finances', { kind: 'business', moduleStates: {} })).toBe(true);
+  });
+
+  test('explicit false in moduleStates disables a toggleable module', () => {
+    expect(isModuleAvailable('finances', { kind: 'business', moduleStates: { finances: false } })).toBe(false);
+    expect(isModuleAvailable('crm', { kind: 'business', moduleStates: { crm: false } })).toBe(false);
+  });
+
+  test('explicit true is a no-op (same as absent)', () => {
+    expect(isModuleAvailable('sales', { kind: 'business', moduleStates: { sales: true } })).toBe(true);
+  });
+
+  test('a module without a toggleId is never disabled by moduleStates (memberships, workforce)', () => {
+    expect(
+      isModuleAvailable('memberships', { kind: 'business', moduleStates: { memberships: false } }),
+    ).toBe(true);
+    expect(
+      isModuleAvailable('workforce', { kind: 'business', moduleStates: { workforce: false } }),
+    ).toBe(true);
+  });
+});
+
+describe('isModuleAvailable — composite deps (/pos/appointments)', () => {
+  test('available when both pos and scheduling are available', () => {
+    expect(isModuleAvailable('posAppointments', { kind: 'business', moduleStates: {} })).toBe(true);
+  });
+
+  test('unavailable when scheduling is toggled off, even though pos is enabled', () => {
+    expect(
+      isModuleAvailable('posAppointments', {
+        kind: 'business',
+        moduleStates: { pos: true, scheduling: false },
+      }),
+    ).toBe(false);
+  });
+
+  test('unavailable when pos is toggled off, even though scheduling is enabled', () => {
+    expect(
+      isModuleAvailable('posAppointments', {
+        kind: 'business',
+        moduleStates: { pos: false, scheduling: true },
+      }),
+    ).toBe(false);
+  });
+
+  test('unavailable for personal orgs (inherits pos\'s business-only kind gate transitively)', () => {
+    expect(isModuleAvailable('posAppointments', { kind: 'personal', moduleStates: {} })).toBe(false);
+  });
+});
+
+describe('isModuleAvailable — unmanaged module ids', () => {
+  test('an id with no manifest entry is always available (unmanaged, not gated by this predicate)', () => {
+    expect(isModuleAvailable('home', { kind: 'business', moduleStates: {} })).toBe(true);
+    expect(isModuleAvailable('settings', { kind: 'personal', moduleStates: { settings: false } })).toBe(true);
+  });
+});
+
+describe('effectiveModuleEnabled (S3/WP1 R6)', () => {
+  test('kind-hidden feature is disabled regardless of moduleStates', () => {
+    expect(effectiveModuleEnabled('personal', {}, 'stock')).toBe(false);
+    expect(effectiveModuleEnabled('personal', { stock: true }, 'stock')).toBe(false);
+  });
+
+  test('kind-visible + toggle-off is disabled', () => {
+    expect(effectiveModuleEnabled('business', { finances: false }, 'finances')).toBe(false);
+  });
+
+  test('kind-visible + toggle-absent/true is enabled', () => {
+    expect(effectiveModuleEnabled('business', {}, 'finances')).toBe(true);
+    expect(effectiveModuleEnabled('personal', {}, 'crm')).toBe(true);
+  });
+
+  test('works for feature ids with no MODULE_MANIFEST entry (e.g. a Connections panel group key)', () => {
+    expect(effectiveModuleEnabled('business', {}, 'sales')).toBe(true);
+    expect(effectiveModuleEnabled('personal', {}, 'sales')).toBe(false);
+    expect(effectiveModuleEnabled('personal', { sales: true }, 'sales')).toBe(false);
+  });
+
+  test('undefined/null kind degrades to business (matches org-kind.ts)', () => {
+    expect(effectiveModuleEnabled(undefined, {}, 'stock')).toBe(true);
+    expect(effectiveModuleEnabled(null, {}, 'pulse')).toBe(false);
+  });
+});
+
+/**
+ * Filesystem sweep: every top-level (app) route directory must be either
+ * mapped by MODULE_MANIFEST (its first path segment resolves to a manifest
+ * entry) or explicitly listed in CORE_UNMANAGED with a reason. This is
+ * coverage documentation only — it does not gate anything (S1 is
+ * characterization; wiring is a later step) — and mirrors the intent of the
+ * routing-simplification spec's W1 "must map to a manifest entry" test
+ * without replacing the route-design-contract suites (R7: those stay
+ * independent).
+ */
+const CORE_UNMANAGED: Record<string, string> = {
+  account: 'core account settings, no module toggle',
+  ads: 'legacy 301 redirect to /socials (ads/+page.server.ts) — R6 keeps redirects out of the availability manifest',
+  agents: 'core agent-stack roster, no module toggle',
+  brains: 'core agent-stack (AI Brains), no module toggle',
+  builder: 'legacy 308 redirect to /agents/builder',
+  capabilities: 'core agent-stack (aliased with /tools), no module toggle',
+  channels: 'core channel management, no module toggle',
+  cloud: 'core cloud workstation, no module toggle',
+  config: 'core gateway config editor, no module toggle',
+  'flow-editor': 'core agent-stack (agent builder), no module toggle',
+  home: 'core landing page, no module toggle',
+  killswitches: 'core admin surface, no module toggle',
+  marketplace: 'core plugin browsing, no module toggle',
+  notifications: 'core, no module toggle',
+  orgs: 'core org switching, no module toggle',
+  overview: 'core org graph, no module toggle',
+  plugins: 'core installed-plugin management, no module toggle',
+  prompt: 'core agent-stack (prompt tools), no module toggle',
+  reliability: 'core platform health, no module toggle',
+  sessions: 'core, no module toggle',
+  settings:
+    'core settings shell; /settings/pulse and /settings/team specifically are mapped via the pulse/team entries',
+  shells: 'core terminal shells, no module toggle',
+  terminal: 'core terminal access, no module toggle',
+  tools: 'core agent-stack (aliased with /capabilities), no module toggle',
+  users: 'core user management, no module toggle',
+  work: 'core "My Work" inbox, no module toggle',
+  workshop: 'legacy 308 redirect to /agents/workshop',
+};
+
+describe('filesystem coverage sweep', () => {
+  test('every top-level (app) route dir is manifest-mapped or explicitly CORE_UNMANAGED', () => {
+    const appDir = fileURLToPath(new URL('../../routes/(app)/', import.meta.url));
+    const topLevelDirs = readdirSync(appDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+
+    const mappedFirstSegments = new Set(
+      Object.values(MODULE_MANIFEST).flatMap((entry) =>
+        entry.appPrefixes.map((p) => p.replace(/^\//, '').split('/')[0]),
+      ),
+    );
+
+    const unaccounted = topLevelDirs.filter(
+      (dir) => !mappedFirstSegments.has(dir) && !(dir in CORE_UNMANAGED),
+    );
+    expect(unaccounted).toEqual([]);
+
+    // Guard the allowlist itself: no stale entries for dirs that no longer exist.
+    const staleAllowlistEntries = Object.keys(CORE_UNMANAGED).filter(
+      (dir) => !topLevelDirs.includes(dir),
+    );
+    expect(staleAllowlistEntries).toEqual([]);
+  });
+});

--- a/src/lib/modules/availability.ts
+++ b/src/lib/modules/availability.ts
@@ -1,0 +1,201 @@
+import { isModuleVisibleForKind, type OrgKind } from '$lib/org-kind';
+
+/**
+ * Module availability manifest — characterization of CURRENT hub behavior
+ * only (no-behavior-change step, see
+ * specs/2026-07-22-hub-routing-simplification-spec.md S1). Availability-only
+ * per the v2 spec's R1: no `permission` field (RBAC stays in
+ * `$lib/routes/route-access-registry`), no nav metadata (labels/icons/order
+ * stay in `sections.ts`). This file is NOT wired into any route/hook yet —
+ * that's a later step (S2).
+ *
+ * `kinds` mirrors `$lib/org-kind.ts` ORG_KIND_POLICY (business hides pulse;
+ * personal hides pos/stock/workforce/support/memberships/sales/ads/team) — it
+ * is NOT a new policy, just the same facts in per-module shape so a single
+ * resolver can eventually replace both the nav-side `isModuleVisibleForKind`
+ * calls and the route-side kind checks.
+ *
+ * S3/WP1 (specs/2026-07-22-personal-org-differentiation-spec.md R1): the
+ * five additions (support/memberships/sales/ads/team) are a DELIBERATE
+ * behavior change, not a characterization of pre-existing hiding — they were
+ * previously visible to personal orgs at the route level (nav-hidden at
+ * most). The route-guard hook (route-guard.ts, wired in hooks.server.ts)
+ * enforces this as a 404, same mechanism as pos/stock/workforce.
+ * `toggleId` is set only where a current route load actually calls
+ * `isModuleEnabled`/`bothEnabled` for that id — see the per-entry notes below
+ * for the (known, pre-existing) gaps where that's inconsistent with the
+ * `settings/modules` toggle UI or with nav-hiding.
+ */
+export type ModuleAvailability = {
+  /** Canonical (locale-stripped) app path prefixes that belong to this module. */
+  appPrefixes: readonly string[];
+  /** `app_modules` toggle id this module reads via modules.service. Absent = never gated by a toggle today. */
+  toggleId?: string;
+  /** Org kinds this module is available for. Absent = both kinds. */
+  kinds?: readonly OrgKind[];
+  /** Other module ids that must ALSO be available (composite gates, e.g. /pos/appointments). */
+  requires?: readonly string[];
+};
+
+export const MODULE_MANIFEST = {
+  crm: {
+    appPrefixes: ['/crm'],
+    // settings/modules exposes a toggle for 'crm', but NO current (app)/crm
+    // route calls isModuleEnabled('crm') — pre-existing nav-hidden-but-
+    // route-open gap (same class the routing-simplification spec calls out
+    // for pos/stock/workforce). toggleId reflects intent/DB row identity,
+    // not current route enforcement.
+    toggleId: 'crm',
+  },
+  finances: {
+    appPrefixes: ['/finances'],
+    toggleId: 'finances',
+  },
+  // /socials is the route; the toggle/module id is 'ads' (sections.ts:161
+  // moduleId override, socials/+page.server.ts:38 isModuleEnabled('ads')).
+  // Legacy /ads/* 301-redirects to /socials/* (ads/+page.server.ts) and is
+  // deliberately NOT an appPrefix here — R6 keeps redirect handling separate
+  // from module-availability resolution.
+  ads: {
+    appPrefixes: ['/socials'],
+    toggleId: 'ads',
+    kinds: ['business'],
+  },
+  sales: {
+    appPrefixes: ['/sales'],
+    toggleId: 'sales',
+    kinds: ['business'],
+  },
+  support: {
+    appPrefixes: ['/support'],
+    toggleId: 'support',
+    kinds: ['business'],
+  },
+  scheduling: {
+    appPrefixes: ['/scheduling'],
+    toggleId: 'scheduling',
+  },
+  // No settings/modules toggle UI and no route-level isModuleEnabled call
+  // found for 'memberships' today — always available (toggleId absent).
+  memberships: {
+    appPrefixes: ['/memberships'],
+    kinds: ['business'],
+  },
+  // Core organization nav (route-access-registry gated, not module-toggle
+  // gated) — was CORE_UNMANAGED until the S3/WP1 kind-matrix expansion added
+  // team to personal.hiddenModules (org-kind.ts). /settings/team included so
+  // the settings-side tab 404s too (longest-prefix, mirrors pulse's pattern).
+  team: {
+    appPrefixes: ['/team', '/settings/team'],
+    kinds: ['business'],
+  },
+  // /settings/pulse must win over any (currently nonexistent) /settings
+  // manifest entry via longest-prefix match. No toggleId: pulse has no
+  // isModuleEnabled call, only the per-route `tenant.kind === 'business'`
+  // 404 (pulse/+page.server.ts:18, settings/pulse/+page.server.ts:18).
+  pulse: {
+    appPrefixes: ['/pulse', '/settings/pulse'],
+    kinds: ['personal'],
+  },
+  // pos/stock/workforce: org-kind.ts hides these for personal orgs, but
+  // (per the routing-simplification spec's problem statement) that's
+  // ENFORCED ONLY VIA NAV for pos/stock/workforce today — no route-level
+  // kind check exists yet (unlike pulse). `kinds` here characterizes the
+  // POLICY as it exists in org-kind.ts, not today's route enforcement gap.
+  pos: {
+    appPrefixes: ['/pos'],
+    toggleId: 'pos',
+    kinds: ['business'],
+  },
+  stock: {
+    appPrefixes: ['/stock'],
+    toggleId: 'stock',
+    kinds: ['business'],
+  },
+  // No isModuleEnabled('workforce') call anywhere — /workforce/+layout.server.ts
+  // only gates on org provisioning (ensureWorkforceCompany), not a toggle.
+  // The nested /workforce/projects subpage gates on a DIFFERENT id,
+  // 'projects' (workforce/projects/+page.server.ts:37) — that's a distinct
+  // module identity from the top-level 'workforce' nav item and is left
+  // unmapped here (ambiguity noted in the S1 report, not resolved by this
+  // characterization step).
+  workforce: {
+    appPrefixes: ['/workforce'],
+    kinds: ['business'],
+  },
+  // Composite: /pos/appointments needs BOTH pos and scheduling enabled
+  // (pos/appointments/+page.server.ts:17, bothEnabled(ctx,'pos','scheduling')).
+  // No own toggleId/kinds — isModuleAvailable composes them from `requires`.
+  posAppointments: {
+    appPrefixes: ['/pos/appointments'],
+    requires: ['pos', 'scheduling'],
+  },
+} as const satisfies Record<string, ModuleAvailability>;
+
+export type ModuleId = keyof typeof MODULE_MANIFEST;
+
+/** Longest-prefix match of a canonical path against every manifest entry's `appPrefixes`. */
+export function resolveModuleForPath(
+  canonicalPath: string,
+): { moduleId: ModuleId; entry: ModuleAvailability } | null {
+  let best: { moduleId: ModuleId; entry: ModuleAvailability; prefix: string } | null = null;
+  for (const [moduleId, entry] of Object.entries(MODULE_MANIFEST) as [ModuleId, ModuleAvailability][]) {
+    for (const prefix of entry.appPrefixes) {
+      const matches = canonicalPath === prefix || canonicalPath.startsWith(`${prefix}/`);
+      if (matches && (!best || prefix.length > best.prefix.length)) {
+        best = { moduleId, entry, prefix };
+      }
+    }
+  }
+  return best ? { moduleId: best.moduleId, entry: best.entry } : null;
+}
+
+/** Per-org module toggle map, matching listModuleStates()'s shape (modules.service.ts:26) — absent id = enabled. */
+export type ModuleStates = Record<string, boolean>;
+
+export type ModuleAvailabilityContext = {
+  kind: OrgKind | undefined | null;
+  moduleStates: ModuleStates;
+};
+
+// Local normalizer for MODULE_MANIFEST's `entry.kinds` membership check below
+// (distinct from `isModuleVisibleForKind`, now imported for
+// `effectiveModuleEnabled` — that one resolves against ORG_KIND_POLICY
+// directly and doesn't need a manifest entry at all).
+function resolvedKind(kind: OrgKind | undefined | null): OrgKind {
+  return kind === 'personal' ? 'personal' : 'business';
+}
+
+/** Pure predicate: is `moduleId` available given the org's kind and module-toggle snapshot? Unknown ids are unmanaged → always available. */
+export function isModuleAvailable(moduleId: string, ctx: ModuleAvailabilityContext): boolean {
+  const entry = MODULE_MANIFEST[moduleId as ModuleId] as ModuleAvailability | undefined;
+  if (!entry) return true;
+  if (entry.kinds && !(entry.kinds as readonly OrgKind[]).includes(resolvedKind(ctx.kind))) return false;
+  if (entry.toggleId && ctx.moduleStates[entry.toggleId] === false) return false;
+  if (entry.requires) {
+    for (const dep of entry.requires) {
+      if (!isModuleAvailable(dep, ctx)) return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * S3/WP1 R6 (specs/2026-07-22-personal-org-differentiation-spec.md): the one
+ * helper cross-module services/UI should call to decide "is this feature
+ * usable right now", composing BOTH gates the individual pieces already knew
+ * about separately (kind-hidden ≠ module-disabled today —
+ * `isModuleEnabled`/`modules.service.ts:26` treats an absent row as enabled
+ * and never consulted kind at all). Unlike `isModuleAvailable`, this does NOT
+ * require a `MODULE_MANIFEST` entry — `featureId` is looked up directly
+ * against `ORG_KIND_POLICY` (via `isModuleVisibleForKind`) and `moduleStates`,
+ * so it works for feature ids that aren't top-level routed modules too (e.g.
+ * a Connections panel group key).
+ */
+export function effectiveModuleEnabled(
+  kind: OrgKind | undefined | null,
+  moduleStates: ModuleStates,
+  featureId: string,
+): boolean {
+  return isModuleVisibleForKind(featureId, kind) && moduleStates[featureId] !== false;
+}

--- a/src/lib/modules/deguarded-routes.test.ts
+++ b/src/lib/modules/deguarded-routes.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { resolveModuleForPath, MODULE_MANIFEST, type ModuleId } from './availability';
+
+/**
+ * Coverage pin for the routing-simplification refactor (S2/R2).
+ *
+ * This refactor DELETED an inline `isModuleEnabled(...)` 404 from every route
+ * below and moved the decision into the `(app)` hook guard. That guard is
+ * fail-OPEN for unmapped paths (`isAppRouteBlocked` returns false when
+ * `resolveModuleForPath` finds nothing), so a manifest prefix that is dropped
+ * or renamed does not fail loudly — it silently un-gates the route.
+ *
+ * Each entry is the route whose inline gate was removed, paired with the
+ * module that gate required. The route must resolve to a manifest entry that
+ * requires it, directly or through the `requires` chain.
+ */
+const DEGUARDED_ROUTES: ReadonlyArray<readonly [path: string, requiredModule: string]> = [
+  ['/finances', 'finances'],
+  ['/finances/invoices', 'finances'],
+  ['/finances/invoices/abc', 'finances'],
+  ['/finances/products', 'finances'],
+  ['/finances/settings', 'finances'],
+  ['/pos', 'pos'],
+  ['/pos/sell', 'pos'],
+  // Composite gate: the inline check was bothEnabled('pos', 'scheduling').
+  ['/pos/appointments', 'pos'],
+  ['/pos/appointments', 'scheduling'],
+  ['/sales', 'sales'],
+  ['/sales/abc', 'sales'],
+  ['/scheduling', 'scheduling'],
+  ['/scheduling/bookings', 'scheduling'],
+  ['/scheduling/calendar', 'scheduling'],
+  ['/scheduling/event-types', 'scheduling'],
+  ['/scheduling/links', 'scheduling'],
+  ['/scheduling/reminders', 'scheduling'],
+  ['/scheduling/resources', 'scheduling'],
+  ['/socials', 'ads'],
+  ['/socials/campaigns', 'ads'],
+  ['/socials/campaigns/abc', 'ads'],
+  ['/socials/posts', 'ads'],
+  ['/socials/posts/abc', 'ads'],
+  ['/socials/settings', 'ads'],
+  ['/stock', 'stock'],
+  ['/stock/commitments', 'stock'],
+  ['/stock/consume', 'stock'],
+  ['/stock/consumption', 'stock'],
+  ['/stock/entries', 'stock'],
+  ['/stock/entries/abc', 'stock'],
+  ['/stock/entries/new', 'stock'],
+  ['/stock/items', 'stock'],
+  ['/stock/items/abc', 'stock'],
+  ['/stock/warehouses', 'stock'],
+  ['/support', 'support'],
+  ['/support/abc', 'support'],
+];
+
+/** `moduleId` itself, plus everything it transitively `requires`. */
+function requirementChain(moduleId: string, seen = new Set<string>()): Set<string> {
+  if (seen.has(moduleId)) return seen;
+  seen.add(moduleId);
+  const entry = MODULE_MANIFEST[moduleId as ModuleId];
+  for (const dep of entry?.requires ?? []) requirementChain(dep, seen);
+  return seen;
+}
+
+describe('routes that lost their inline module guard', () => {
+  it.each(DEGUARDED_ROUTES)('%s is still gated on %s by the central map', (path, required) => {
+    const match = resolveModuleForPath(path);
+    // A null match means the hook guard lets this route through for every org.
+    expect(match, `${path} resolves to no module — the central guard fails open`).not.toBeNull();
+    expect(
+      requirementChain(match!.moduleId),
+      `${path} → ${match!.moduleId}, which does not require ${required}`,
+    ).toContain(required);
+  });
+});

--- a/src/lib/modules/route-guard.test.ts
+++ b/src/lib/modules/route-guard.test.ts
@@ -1,0 +1,147 @@
+import { describe, test, expect } from 'vitest';
+import { canonicalPath } from '$lib/canonical-path';
+import { isAppPageRequest, isAppRouteBlocked } from './route-guard';
+
+describe('isAppPageRequest — request-class classification', () => {
+  test('authenticated (app) page request is in-class', () => {
+    expect(isAppPageRequest(true, '/(app)/pos/sell')).toBe(true);
+  });
+
+  test('server-token request (no locals.user) is skipped even on an (app)-shaped route id', () => {
+    // Mirrors resolve-identity.ts: the server-token provider sets
+    // bypassGate:true and never reaches finishApp at all, but this
+    // classification is defense in depth for anything that does.
+    expect(isAppPageRequest(false, '/(app)/pos/sell')).toBe(false);
+  });
+
+  test('API routes (no (app) route id) are skipped', () => {
+    expect(isAppPageRequest(true, '/api/pos/sellables')).toBe(false);
+  });
+
+  test('a null/undefined route id (unmatched route) is skipped', () => {
+    expect(isAppPageRequest(true, null)).toBe(false);
+    expect(isAppPageRequest(true, undefined)).toBe(false);
+  });
+});
+
+describe('isAppRouteBlocked — locale + longest-prefix composition (R6: canonicalization stays separate)', () => {
+  test('locale-prefixed path resolves the same as its canonical form', () => {
+    const ctx = { kind: 'business' as const, moduleStates: {} };
+    expect(isAppRouteBlocked(canonicalPath('/es/pulse'), ctx)).toBe(true);
+    expect(isAppRouteBlocked(canonicalPath('/en/pos/sell'), ctx)).toBe(false);
+  });
+
+  test('/settings/pulse (localized) still resolves to pulse via longest-prefix, not a bare /settings', () => {
+    const business = { kind: 'business' as const, moduleStates: {} };
+    const personal = { kind: 'personal' as const, moduleStates: {} };
+    expect(isAppRouteBlocked(canonicalPath('/es/settings/pulse'), business)).toBe(true);
+    expect(isAppRouteBlocked(canonicalPath('/settings/pulse'), personal)).toBe(false);
+  });
+});
+
+describe('isAppRouteBlocked — org-kind restrictions', () => {
+  test('personal org: /pos, /stock, /workforce all 404', () => {
+    const ctx = { kind: 'personal' as const, moduleStates: {} };
+    expect(isAppRouteBlocked('/pos/sell', ctx)).toBe(true);
+    expect(isAppRouteBlocked('/stock/items', ctx)).toBe(true);
+    expect(isAppRouteBlocked('/workforce/projects', ctx)).toBe(true);
+  });
+
+  test('business org: /pos, /stock, /workforce pass', () => {
+    const ctx = { kind: 'business' as const, moduleStates: {} };
+    expect(isAppRouteBlocked('/pos/sell', ctx)).toBe(false);
+    expect(isAppRouteBlocked('/stock/items', ctx)).toBe(false);
+    expect(isAppRouteBlocked('/workforce/projects', ctx)).toBe(false);
+  });
+
+  test('business org: /pulse and /settings/pulse 404', () => {
+    const ctx = { kind: 'business' as const, moduleStates: {} };
+    expect(isAppRouteBlocked('/pulse', ctx)).toBe(true);
+    expect(isAppRouteBlocked('/settings/pulse', ctx)).toBe(true);
+  });
+
+  test('personal org: /pulse passes', () => {
+    const ctx = { kind: 'personal' as const, moduleStates: {} };
+    expect(isAppRouteBlocked('/pulse', ctx)).toBe(false);
+  });
+
+  // S3/WP1 (specs/2026-07-22-personal-org-differentiation-spec.md R1): DELIBERATE
+  // expansion — personal orgs additionally lose support/memberships/sales/ads/team.
+  test('personal org: /support, /sales, /memberships, /team, /socials all 404', () => {
+    const ctx = { kind: 'personal' as const, moduleStates: {} };
+    expect(isAppRouteBlocked('/support', ctx)).toBe(true);
+    expect(isAppRouteBlocked('/sales', ctx)).toBe(true);
+    expect(isAppRouteBlocked('/memberships', ctx)).toBe(true);
+    expect(isAppRouteBlocked('/team', ctx)).toBe(true);
+    expect(isAppRouteBlocked('/socials', ctx)).toBe(true);
+    expect(isAppRouteBlocked('/settings/team', ctx)).toBe(true);
+  });
+
+  test('business org: /support, /sales, /memberships, /team, /socials all pass', () => {
+    const ctx = { kind: 'business' as const, moduleStates: {} };
+    expect(isAppRouteBlocked('/support', ctx)).toBe(false);
+    expect(isAppRouteBlocked('/sales', ctx)).toBe(false);
+    expect(isAppRouteBlocked('/memberships', ctx)).toBe(false);
+    expect(isAppRouteBlocked('/team', ctx)).toBe(false);
+    expect(isAppRouteBlocked('/socials', ctx)).toBe(false);
+    expect(isAppRouteBlocked('/settings/team', ctx)).toBe(false);
+  });
+});
+
+describe('isAppRouteBlocked — module-toggle state', () => {
+  test('toggled-off mapped module 404s', () => {
+    expect(
+      isAppRouteBlocked('/finances', { kind: 'business', moduleStates: { finances: false } }),
+    ).toBe(true);
+  });
+
+  test('missing toggle row (absent = enabled) passes', () => {
+    expect(isAppRouteBlocked('/finances', { kind: 'business', moduleStates: {} })).toBe(false);
+  });
+
+  test('composite /pos/appointments 404s when either dependency is toggled off', () => {
+    expect(
+      isAppRouteBlocked('/pos/appointments', {
+        kind: 'business',
+        moduleStates: { scheduling: false },
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('isAppRouteBlocked — unmapped paths', () => {
+  test('a path with no manifest entry always passes', () => {
+    const ctx = { kind: undefined, moduleStates: {} };
+    expect(isAppRouteBlocked('/home', ctx)).toBe(false);
+    expect(isAppRouteBlocked('/crm', ctx)).toBe(false);
+    // /settings/team is no longer unmapped as of S3/WP1 — see the
+    // "unknown kind fails CLOSED" describe block below for its coverage.
+  });
+});
+
+describe('isAppRouteBlocked — unknown kind fails CLOSED (overrides isModuleAvailable UI business-fallback)', () => {
+  test('unresolved kind 404s a business-only module (pos), NOT defaults to allowed', () => {
+    expect(isAppRouteBlocked('/pos/sell', { kind: undefined, moduleStates: {} })).toBe(true);
+    expect(isAppRouteBlocked('/stock/items', { kind: null, moduleStates: {} })).toBe(true);
+  });
+
+  test('unresolved kind 404s a personal-only module (pulse) too', () => {
+    expect(isAppRouteBlocked('/pulse', { kind: undefined, moduleStates: {} })).toBe(true);
+  });
+
+  test('unresolved kind 404s the new business-only /team and /settings/team (S3/WP1)', () => {
+    expect(isAppRouteBlocked('/team', { kind: undefined, moduleStates: {} })).toBe(true);
+    expect(isAppRouteBlocked('/settings/team', { kind: undefined, moduleStates: {} })).toBe(true);
+  });
+
+  test('unresolved kind 404s a composite whose dependency is kind-restricted (posAppointments -> pos)', () => {
+    expect(isAppRouteBlocked('/pos/appointments', { kind: undefined, moduleStates: {} })).toBe(
+      true,
+    );
+  });
+
+  test('unresolved kind still passes a module with no kind restriction at all', () => {
+    expect(isAppRouteBlocked('/finances', { kind: undefined, moduleStates: {} })).toBe(false);
+    expect(isAppRouteBlocked('/crm', { kind: null, moduleStates: {} })).toBe(false);
+  });
+});

--- a/src/lib/modules/route-guard.ts
+++ b/src/lib/modules/route-guard.ts
@@ -1,0 +1,62 @@
+import type { OrgKind } from '$lib/org-kind';
+import {
+  MODULE_MANIFEST,
+  resolveModuleForPath,
+  isModuleAvailable,
+  type ModuleAvailability,
+  type ModuleId,
+  type ModuleStates,
+} from './availability';
+
+/**
+ * Pure decision helpers for the `(app)` route hook guard
+ * (specs/2026-07-22-hub-routing-simplification-spec.md S2/R2). Extracted out
+ * of hooks.server.ts's `finishApp` so the guard logic is unit-testable
+ * without mocking a full SvelteKit `RequestEvent`.
+ */
+
+/**
+ * Is this the request class the `(app)` guard applies to — an authenticated
+ * browser-session page load under the `(app)` route group? Server-token/cron
+ * requests never set `locals.user` (resolve-identity.ts's server-token
+ * provider sets `bypassGate: true`, which skips `finishApp` entirely — this
+ * check is belt-and-suspenders for anything that reaches it anyway), and
+ * API/public routes have no `(app)` route id.
+ */
+export function isAppPageRequest(hasUser: boolean, routeId: string | null | undefined): boolean {
+  return hasUser && Boolean(routeId?.startsWith('/(app)'));
+}
+
+/** Does `moduleId` (or anything it `requires`) carry a `kinds` restriction? */
+function isKindRestricted(moduleId: string, seen: Set<string> = new Set()): boolean {
+  if (seen.has(moduleId)) return false;
+  seen.add(moduleId);
+  const entry = MODULE_MANIFEST[moduleId as ModuleId] as ModuleAvailability | undefined;
+  if (!entry) return false;
+  if (entry.kinds) return true;
+  return (entry.requires ?? []).some((dep) => isKindRestricted(dep, seen));
+}
+
+export type RouteGuardContext = {
+  /**
+   * Org kind resolved during identity resolution. Undefined/null means the
+   * hook could not resolve it — this FAILS CLOSED below for kind-restricted
+   * modules, unlike `isModuleAvailable`'s UI-only business-fallback
+   * (org-kind.ts:13, characterized in availability.test.ts).
+   */
+  kind: OrgKind | undefined | null;
+  moduleStates: ModuleStates;
+};
+
+/**
+ * True when `canonicalPath` must 404 for this org (kind-restricted or
+ * toggled-off module). Caller canonicalizes the path first (locale-strip
+ * only, `$lib/canonical-path` — kept as a separate operation per R6).
+ * Unmapped paths and unmanaged module ids always pass.
+ */
+export function isAppRouteBlocked(canonicalPath: string, ctx: RouteGuardContext): boolean {
+  const match = resolveModuleForPath(canonicalPath);
+  if (!match) return false;
+  if (ctx.kind == null && isKindRestricted(match.moduleId)) return true;
+  return !isModuleAvailable(match.moduleId, ctx);
+}

--- a/src/lib/org-kind.test.ts
+++ b/src/lib/org-kind.test.ts
@@ -24,4 +24,13 @@ describe('isModuleVisibleForKind', () => {
     expect(isModuleVisibleForKind('crm', 'business')).toBe(true);
     expect(isModuleVisibleForKind('crm', 'personal')).toBe(true);
   });
+
+  // S3/WP1 (specs/2026-07-22-personal-org-differentiation-spec.md R1): DELIBERATE
+  // expansion — personal orgs additionally lose support/memberships/sales/ads/team.
+  test('support/memberships/sales/ads/team hidden for personal, visible for business', () => {
+    for (const moduleId of ['support', 'memberships', 'sales', 'ads', 'team']) {
+      expect(isModuleVisibleForKind(moduleId, 'personal')).toBe(false);
+      expect(isModuleVisibleForKind(moduleId, 'business')).toBe(true);
+    }
+  });
 });

--- a/src/lib/org-kind.ts
+++ b/src/lib/org-kind.ts
@@ -7,7 +7,19 @@ export type OrgKind = 'business' | 'personal';
 
 export const ORG_KIND_POLICY = {
   business: { hiddenModules: new Set<string>(['pulse']), label: 'Business' },
-  personal: { hiddenModules: new Set<string>(['pos', 'stock', 'workforce']), label: 'Personal' },
+  personal: {
+    hiddenModules: new Set<string>([
+      'pos',
+      'stock',
+      'workforce',
+      'support',
+      'memberships',
+      'sales',
+      'ads',
+      'team',
+    ]),
+    label: 'Personal',
+  },
 } as const;
 
 /** Unknown/undefined kind degrades to 'business' — matches the DB default. */

--- a/src/lib/state/features/pulse.svelte.ts
+++ b/src/lib/state/features/pulse.svelte.ts
@@ -20,20 +20,31 @@ async function fetchItems() {
   }
 }
 
+// Every consumer of `refresh` (popover open, external callers) needs the list
+// and the bell badge count to agree — fetching items alone left pendingCount
+// stale relative to what the popover just rendered.
+async function refreshAll() {
+  await Promise.all([fetchItems(), fetchCount()]);
+}
+
 async function act(id: string, action: 'approve' | 'dismiss') {
-  await fetch(`/api/pulse/proposals/${id}`, {
+  const r = await fetch(`/api/pulse/proposals/${id}`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ action }),
   });
-  await Promise.all([fetchItems(), fetchCount()]);
+  if (!r.ok) {
+    console.error(`pulse ${action} failed: ${r.status}`);
+    return; // leave items/pendingCount as-is — the action did not take effect
+  }
+  await refreshAll();
 }
 
 export const pulse = {
   get pendingCount() { return s.pendingCount; },
   get items() { return s.items; },
   refreshCount: fetchCount,
-  refresh: fetchItems,
+  refresh: refreshAll,
   approve: (id: string) => act(id, 'approve'),
   dismiss: (id: string) => act(id, 'dismiss'),
 };

--- a/src/routes/(app)/finances/+page.server.ts
+++ b/src/routes/(app)/finances/+page.server.ts
@@ -1,7 +1,6 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { requireCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import {
   financeSummary,
   maskFinanceSummary,
@@ -16,7 +15,6 @@ import { parsePeriod, resolvePeriodWindow } from '$lib/finance/period';
 
 export const load: PageServerLoad = async ({ locals, url, depends }) => {
   const ctx = await requireCoreCtx(locals);
-  if (!(await isModuleEnabled(ctx, 'finances'))) throw error(404, 'Finances module disabled');
   depends('finances:data');
   // A calendar day is LOCAL. Resolve the picked days to instants in the org's
   // business timezone so an evening sale isn't reported on the next day.
@@ -34,8 +32,8 @@ export const load: PageServerLoad = async ({ locals, url, depends }) => {
   // instantly with skeletons instead of blocking on this.
   async function computeData() {
     const [rawSummary, series, products, clients] = await Promise.all([
-      financeSummary(ctx, period),
-      revenueSeries(ctx, period),
+      financeSummary(ctx, period, locals.orgKind, locals.moduleStates),
+      revenueSeries(ctx, period, locals.orgKind, locals.moduleStates),
       topProducts(ctx, period, { limit: 15 }),
       topClients(ctx, period, { limit: 10 }),
     ]);

--- a/src/routes/(app)/finances/invoices/+page.server.ts
+++ b/src/routes/(app)/finances/invoices/+page.server.ts
@@ -1,14 +1,12 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listInvoices } from '$server/services/finance.service';
 import { getContact } from '$server/services/crm-contacts.service';
 
 export const load: PageServerLoad = async ({ locals, depends, url }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'finances'))) throw error(404, 'Finances module disabled');
   depends('finances:data');
   // Load the full set (capped) so the page can sort/filter client-side like the
   // CRM customers view; rendering is windowed on the client for paint cost.

--- a/src/routes/(app)/finances/invoices/[id]/+page.server.ts
+++ b/src/routes/(app)/finances/invoices/[id]/+page.server.ts
@@ -1,7 +1,6 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { getInvoice } from '$server/services/finance.service';
 import { findEntryByInvoice, listWarehouses, listItems } from '$server/services/stock.service';
 import { uuidParamOr404 } from '$server/utils/uuid-param';
@@ -10,12 +9,14 @@ export const load: PageServerLoad = async ({ locals, params, depends }) => {
   uuidParamOr404(params.id);
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'finances'))) throw error(404, 'Finances module disabled');
   depends('finances:data');
   const data = await getInvoice(ctx, params.id);
   if (!data) throw error(404, 'Invoice not found');
 
-  const stockEnabled = await isModuleEnabled(ctx, 'stock');
+  // Data-bearing, not a route gate: shapes the returned stock payload below.
+  // Reads the hook's per-request module-state snapshot instead of
+  // re-querying (routing-simplification spec R5).
+  const stockEnabled = locals.moduleStates?.stock ?? true;
   const [stockEntry, stockWarehouses, stockItems] = stockEnabled
     ? await Promise.all([findEntryByInvoice(ctx, params.id), listWarehouses(ctx), listItems(ctx)])
     : [null, [], []];

--- a/src/routes/(app)/finances/products/+page.server.ts
+++ b/src/routes/(app)/finances/products/+page.server.ts
@@ -1,15 +1,12 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listProducts, catalogCoverage } from '$server/services/finance-products.service';
 import { costForProducts, productCompositionTrees } from '$server/services/item-cost.service';
 import { shouldMaskSensitive } from '$server/services/rbac.service';
 
 export const load: PageServerLoad = async ({ locals, depends }) => {
-  const ctx = await getCoreCtx(locals);
-  if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'finances'))) throw error(404, 'Finances module disabled');
+  const ctx = await getCoreCtx(locals); if (!ctx) throw error(401, 'Authentication required');
   depends('finances:data');
   const [products, coverage, mask] = await Promise.all([
     listProducts(ctx),
@@ -19,10 +16,7 @@ export const load: PageServerLoad = async ({ locals, depends }) => {
   const ids = products.map((p) => p.id);
   // Read-only view: stats + the recursive item relationships. Product/item
   // MANAGEMENT lives in POS (/pos/catalog) and stock (/stock/items).
-  const [costs, trees] = await Promise.all([
-    costForProducts(ctx, ids),
-    productCompositionTrees(ctx, ids),
-  ]);
+  const [costs, trees] = await Promise.all([costForProducts(ctx, ids), productCompositionTrees(ctx, ids)]);
   const enriched = products.map((p) => {
     const c = costs.get(p.id);
     const costable = c?.costable ?? false;
@@ -30,22 +24,10 @@ export const load: PageServerLoad = async ({ locals, depends }) => {
     // Field-level RBAC: cost & margin are sensitive — omit the values entirely
     // when masked (never ship the number and hide it client-side).
     const composition = trees.get(p.id) ?? [];
-    if (mask)
-      return {
-        ...p,
-        cost: null,
-        margin: null,
-        marginPct: null,
-        costable,
-        partial,
-        costMasked: true,
-        composition,
-      };
+    if (mask) return { ...p, cost: null, margin: null, marginPct: null, costable, partial, costMasked: true, composition };
     const cost = costable && c ? c.cost : null;
-    const margin =
-      cost != null && p.unitPrice != null ? Math.round((p.unitPrice - cost) * 100) / 100 : null;
-    const marginPct =
-      margin != null && p.unitPrice ? Math.round((margin / p.unitPrice) * 1000) / 10 : null;
+    const margin = cost != null && p.unitPrice != null ? Math.round((p.unitPrice - cost) * 100) / 100 : null;
+    const marginPct = margin != null && p.unitPrice ? Math.round((margin / p.unitPrice) * 1000) / 10 : null;
     return { ...p, cost, margin, marginPct, costable, partial, costMasked: false, composition };
   });
   return { products: enriched, coverage };

--- a/src/routes/(app)/finances/settings/+page.server.ts
+++ b/src/routes/(app)/finances/settings/+page.server.ts
@@ -1,13 +1,11 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { getSource, sourceHasCredentials, getFinSettings } from '$server/services/finance.service';
 
 export const load: PageServerLoad = async ({ locals }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'finances'))) throw error(404, 'Finances module disabled');
   const [src, settings] = await Promise.all([getSource(ctx, 'susii'), getFinSettings(ctx)]);
   return {
     source: src ? { ...src, secretRefs: undefined, hasCredentials: sourceHasCredentials(src) } : null,

--- a/src/routes/(app)/notifications/+page.server.ts
+++ b/src/routes/(app)/notifications/+page.server.ts
@@ -3,9 +3,14 @@ import { requireAdmin } from '$server/auth/authorize';
 import { error } from '@sveltejs/kit';
 import { listPendingRequests } from '$server/services/join/requests.service';
 import type { JoinRequestRow } from '$server/services/join/requests.service';
+import { isModuleVisibleForKind } from '$lib/org-kind';
+import { requireCoreCtx } from '$server/auth/core-ctx';
+import { listPending } from '$server/services/pulse.service';
+import type { PulseProposalRow } from '$server/db/pg-schema/pulse';
 
-export const load: PageServerLoad = async ({ locals }) => {
+export const load: PageServerLoad = async ({ locals, parent, depends }) => {
   requireAdmin(locals);
+  depends('app:notifications');
   if (!locals.tenantCtx) throw error(401, 'tenant context required');
 
   // Supabase `join_request` is the system-of-record (Turso is telemetry only).
@@ -18,5 +23,14 @@ export const load: PageServerLoad = async ({ locals }) => {
     createdAt: new Date(r.created_at).getTime(),
   }));
 
-  return { requests };
+  // Pulse is hidden for business orgs (see ORG_KIND_POLICY) — same rule the
+  // /pulse page itself 404s on. Business orgs just get no pulse section here.
+  const { activeOrgKind } = await parent();
+  let pulseProposals: PulseProposalRow[] = [];
+  if (isModuleVisibleForKind('pulse', activeOrgKind)) {
+    const ctx = await requireCoreCtx(locals);
+    pulseProposals = await listPending(ctx);
+  }
+
+  return { requests, pulseProposals };
 };

--- a/src/routes/(app)/notifications/+page.svelte
+++ b/src/routes/(app)/notifications/+page.svelte
@@ -3,14 +3,26 @@
   import type { PageData } from './$types';
   import { invalidate } from '$app/navigation';
   import { refreshNotifications } from '$lib/state/features/notifications.svelte';
+  import { pulse } from '$lib/state/features/pulse.svelte';
   import { toastPromise } from '$lib/state/ui/toast.svelte';
   import { Bell, Check, X } from 'lucide-svelte';
-  import { Badge, Button, PageHeader } from '$lib/components/ui';
+  import { Badge, Button, PageHeader, iconSizes } from '$lib/components/ui';
   import { AsyncBoundary, PageBody, PageShell } from '$lib/components/ui/foundations';
 
   let { data }: { data: PageData } = $props();
 
   let reviewing = $state<string | null>(null);
+  let pulseBusyId = $state<string | null>(null);
+
+  async function decidePulse(id: string, action: 'approve' | 'dismiss') {
+    pulseBusyId = id;
+    try {
+      await (action === 'approve' ? pulse.approve(id) : pulse.dismiss(id));
+      await invalidate('app:notifications');
+    } finally {
+      pulseBusyId = null;
+    }
+  }
 
   async function review(id: string, status: 'approved' | 'denied') {
     reviewing = id;
@@ -59,7 +71,7 @@
 
   <PageBody width="content">
     <AsyncBoundary
-      state={data.requests.length === 0
+      state={data.requests.length === 0 && data.pulseProposals.length === 0
         ? {
             kind: 'empty',
             title: m.notif_noNotifications(),
@@ -68,6 +80,39 @@
         : { kind: 'ready' }}
     >
       <div class="notification-list" aria-live="polite">
+        {#each data.pulseProposals as p (p.id)}
+          <article class="notification-card">
+            <div class="notification-copy">
+              <div class="notification-title-row">
+                <strong>{p.title}</strong>
+              </div>
+              {#if p.summary}
+                <p>{p.summary}</p>
+              {/if}
+              <Badge variant="neutral" size="sm">{m.nav_pulse()}</Badge>
+            </div>
+            <div class="notification-actions">
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={pulseBusyId === p.id}
+                onclick={() => decidePulse(p.id, 'approve')}
+              >
+                <Check size={iconSizes.sm} />
+                {m.notif_approve()}
+              </Button>
+              <Button
+                variant="danger"
+                size="sm"
+                loading={pulseBusyId === p.id}
+                onclick={() => decidePulse(p.id, 'dismiss')}
+              >
+                <X size={iconSizes.sm} />
+                {m.common_dismiss()}
+              </Button>
+            </div>
+          </article>
+        {/each}
         {#each data.requests as req (req.id)}
           <article class="notification-card">
             <div class="notification-copy">

--- a/src/routes/(app)/pos/+layout.server.ts
+++ b/src/routes/(app)/pos/+layout.server.ts
@@ -1,22 +1,25 @@
 import { error } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { getPosSettings, getOpenShift } from '$server/services/pos.service';
 import { getUser } from '$server/services/user.service';
 import type { TenantContext } from '$server/services/base';
 
-/** Gate the whole /pos subtree on the per-org module toggle; feed shift + settings state to PosNav/ShiftBanner. */
+/** Auth guard for the whole /pos subtree; feed shift + settings state to
+ *  PosNav/ShiftBanner. The module-toggle/kind 404 is enforced centrally by
+ *  the (app) route hook guard now (routing-simplification spec S2); the
+ *  stock/scheduling flags below are data-bearing (shape the returned UI
+ *  state, not a gate) so they stay here, reading the hook's per-request
+ *  module-state snapshot instead of re-querying (R5). */
 export const load: LayoutServerLoad = async ({ locals, depends }) => {
   depends('pos:shift');
 
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'pos'))) throw error(404, 'POS module disabled');
 
-  const [stockEnabled, schedulingEnabled, posSettings, openShift] = await Promise.all([
-    isModuleEnabled(ctx, 'stock'),
-    isModuleEnabled(ctx, 'scheduling'),
+  const stockEnabled = locals.moduleStates?.stock ?? true;
+  const schedulingEnabled = locals.moduleStates?.scheduling ?? true;
+  const [posSettings, openShift] = await Promise.all([
     getPosSettings(ctx),
     getOpenShift(ctx).catch(() => null),
   ]);

--- a/src/routes/(app)/pos/appointments/+page.server.ts
+++ b/src/routes/(app)/pos/appointments/+page.server.ts
@@ -2,7 +2,6 @@ import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getCoreCtx } from '$server/auth/core-ctx';
 import { shouldMaskSensitive } from '$server/services/rbac.service';
-import { bothEnabled, isModuleEnabled } from '$server/services/modules.service';
 import { listBookings } from '$server/services/scheduling-bookings.service';
 import { listResources, listEventTypes } from '$server/services/scheduling.service';
 import { accrualSummaryForSources } from '$server/services/stock-accruals.service';
@@ -10,11 +9,13 @@ import { accrualSummaryForSources } from '$server/services/stock-accruals.servic
 const DAY = 86_400_000;
 
 /** View perm (`pos.appointments:view`) is enforced centrally by the root layout
- *  guard (MODULE_SUBRESOURCES) — this load only fetches the tab's data. */
+ *  guard (MODULE_SUBRESOURCES). The pos+scheduling composite module-toggle 404
+ *  is enforced centrally by the (app) route hook guard now (routing-
+ *  simplification spec S2 — `/pos/appointments` maps to the `posAppointments`
+ *  composite manifest entry) — this load only fetches the tab's data. */
 export const load: PageServerLoad = async ({ locals, depends }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await bothEnabled(ctx, 'pos', 'scheduling'))) throw error(404, 'POS or scheduling module disabled');
   depends('pos:appointments');
 
   // ponytail: server-local midnight, not per-org timezone — fine for a
@@ -44,7 +45,7 @@ export const load: PageServerLoad = async ({ locals, depends }) => {
     bookings,
     resources: resources.filter((r) => r.active).map((r) => ({ id: r.id, name: r.name })),
     eventTypes: eventTypes.map((e) => ({ id: e.id, title: e.title, productId: e.productId ?? null })),
-    stockEnabled: await isModuleEnabled(ctx, 'stock'),
+    stockEnabled: locals.moduleStates?.stock ?? true,
     accrualSummaries,
   };
 };

--- a/src/routes/(app)/pos/catalog/+page.server.ts
+++ b/src/routes/(app)/pos/catalog/+page.server.ts
@@ -1,19 +1,21 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listSellables } from '$server/services/pos.service';
 import { listItems, listConsumption, listAllComponentEdges } from '$server/services/stock.service';
 
-/** The /pos module gate + 401 already live in (app)/pos/+layout.server.ts —
- *  this load only adds the merged catalog + (when stock is on) the item
- *  picker + existing consumption mappings the wizard needs for edit prefill. */
+/** The /pos module gate + 401 live in the (app) route hook guard + this
+ *  layout's auth check — this load only adds the merged catalog + (when
+ *  stock is on) the item picker + existing consumption mappings the wizard
+ *  needs for edit prefill. stockEnabled is data-bearing (controls stock
+ *  ENRICHMENT below, not a route gate), so it reads the hook's per-request
+ *  module-state snapshot instead of re-querying (R5). */
 export const load: PageServerLoad = async ({ locals, depends }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
   depends('pos:catalog');
 
-  const stockEnabled = await isModuleEnabled(ctx, 'stock');
+  const stockEnabled = locals.moduleStates?.stock ?? true;
   const [sellables, stockItems, consumption, componentEdges] = await Promise.all([
     listSellables(ctx),
     stockEnabled ? listItems(ctx) : Promise.resolve([]),

--- a/src/routes/(app)/pos/sell/+page.server.ts
+++ b/src/routes/(app)/pos/sell/+page.server.ts
@@ -1,7 +1,6 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listSellables, listTickets, listShifts } from '$server/services/pos.service';
 
 /** View perm (`pos.sell:view`) is enforced centrally by the root layout guard
@@ -9,7 +8,6 @@ import { listSellables, listTickets, listShifts } from '$server/services/pos.ser
 export const load: PageServerLoad = async ({ locals, depends }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'pos'))) throw error(404, 'POS module disabled');
   depends('pos:sell');
 
   const [sellables, recentTickets, shifts] = await Promise.all([

--- a/src/routes/(app)/sales/+page.server.ts
+++ b/src/routes/(app)/sales/+page.server.ts
@@ -2,14 +2,12 @@ import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getCoreCtx } from '$server/auth/core-ctx';
 import { ownerFilter } from '$server/services/rbac.service';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listOrders } from '$server/services/sales.service';
 import { getContact } from '$server/services/crm-contacts.service';
 
 export const load: PageServerLoad = async ({ locals, url, depends }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'sales'))) throw error(404, 'Sales module disabled');
   depends('sales:list');
 
   // Cross-module nav: ?contact= scopes the list to one contact (Connections panel).

--- a/src/routes/(app)/sales/[id]/+page.server.ts
+++ b/src/routes/(app)/sales/[id]/+page.server.ts
@@ -2,7 +2,6 @@ import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getCoreCtx } from '$server/auth/core-ctx';
 import { ownerFilter } from '$server/services/rbac.service';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { getOrder } from '$server/services/sales.service';
 import { listEntityTimeline } from '$server/services/activity.service';
 import { transitionsFor } from '$server/services/workflow.service';
@@ -12,7 +11,6 @@ export const load: PageServerLoad = async ({ locals, params, depends }) => {
   uuidParamOr404(params.id);
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'sales'))) throw error(404, 'Sales module disabled');
   depends('sales:order');
 
   // if-owner scope: a scoped caller only opens orders they own (else 404).

--- a/src/routes/(app)/scheduling/+layout.server.ts
+++ b/src/routes/(app)/scheduling/+layout.server.ts
@@ -1,12 +1,13 @@
 import { error } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 
-/** Gate the whole /scheduling subtree on the per-org module toggle. */
+/** Auth guard for the whole /scheduling subtree. The module-toggle/kind 404
+ *  is enforced centrally by the (app) route hook guard now (routing-
+ *  simplification spec S2, hooks.server.ts's finishApp) — kept as an empty
+ *  layout load only for the shared 401. */
 export const load: LayoutServerLoad = async ({ locals }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'scheduling'))) throw error(404, 'Scheduling module disabled');
   return {};
 };

--- a/src/routes/(app)/scheduling/+page.server.ts
+++ b/src/routes/(app)/scheduling/+page.server.ts
@@ -1,7 +1,6 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { schedulingSummary, utilizationHeatmap, revenueByResource } from '$server/services/scheduling-analytics.service';
 
 const DAY = 86_400_000;
@@ -9,7 +8,6 @@ const DAY = 86_400_000;
 export const load: PageServerLoad = async ({ locals, depends }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'scheduling'))) throw error(404, 'Scheduling module disabled');
   depends('scheduling:data');
 
   // A 4-week window centred near "now": last 7 days + next 21 days, INCLUSIVE of

--- a/src/routes/(app)/scheduling/bookings/+page.server.ts
+++ b/src/routes/(app)/scheduling/bookings/+page.server.ts
@@ -2,18 +2,17 @@ import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getCoreCtx } from '$server/auth/core-ctx';
 import { shouldMaskSensitive } from '$server/services/rbac.service';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listBookings } from '$server/services/scheduling-bookings.service';
 import { listResources, listEventTypes } from '$server/services/scheduling.service';
 import { getContact } from '$server/services/crm-contacts.service';
 import { accrualSummaryForSources } from '$server/services/stock-accruals.service';
+import { effectiveModuleEnabled } from '$lib/modules/availability';
 
 const DAY = 86_400_000;
 
 export const load: PageServerLoad = async ({ locals, depends, url }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'scheduling'))) throw error(404, 'Scheduling module disabled');
   depends('scheduling:data');
 
   // Cross-module nav: ?contact= shows ALL of one contact's bookings (no window),
@@ -33,22 +32,28 @@ export const load: PageServerLoad = async ({ locals, depends, url }) => {
     contact ? getContact(ctx, contact) : Promise.resolve(null),
   ]);
 
+  // S3/WP1 R6: stock is now kind-hidden for personal orgs (not just
+  // toggle-gated) — skip the accrual read entirely instead of relying on the
+  // try/catch to swallow a query that shouldn't run.
+  const stockEnabled = effectiveModuleEnabled(locals.orgKind, locals.moduleStates ?? {}, 'stock');
   let accrualSummaries: Awaited<ReturnType<typeof accrualSummaryForSources>> = [];
-  try {
-    accrualSummaries = await accrualSummaryForSources(
-      ctx,
-      'booking',
-      bookings.map((b) => b.id),
-    );
-  } catch {
-    // stock module absent/off — bookings render without chips
+  if (stockEnabled) {
+    try {
+      accrualSummaries = await accrualSummaryForSources(
+        ctx,
+        'booking',
+        bookings.map((b) => b.id),
+      );
+    } catch {
+      // stock module absent/off — bookings render without chips
+    }
   }
 
   return {
     bookings,
     resources: resources.map((r) => ({ id: r.id, name: r.name })),
     eventTypes: eventTypes.map((e) => ({ id: e.id, title: e.title, productId: e.productId ?? null })),
-    stockEnabled: await isModuleEnabled(ctx, 'stock'),
+    stockEnabled,
     contactId: contact ?? null,
     contactName: contactRec?.contact?.displayName ?? null,
     openNew,

--- a/src/routes/(app)/scheduling/bookings/+page.svelte
+++ b/src/routes/(app)/scheduling/bookings/+page.svelte
@@ -10,8 +10,13 @@
   import ConsumptionGauge from '$lib/components/stock/ConsumptionGauge.svelte';
   import { gaugeMax } from '$lib/components/stock/stock-ui';
   import { canAct } from '$lib/access/can.svelte';
+  import { page } from '$app/state';
 
   let { data }: { data: PageData } = $props();
+
+  // Sales orders are business-only kind-gated (S3/WP1 R6) — hide the
+  // per-booking "Create sales order" action for personal orgs.
+  const isPersonal = $derived(page.data.activeOrgKind === 'personal');
 
   const resourceName = (id: string) => data.resources.find((r) => r.id === id)?.name ?? '—';
   const eventTitle = (id: string) => data.eventTypes.find((e) => e.id === id)?.title ?? '—';
@@ -408,7 +413,7 @@
                     <X size={15} />
                   </Button>
                 {/if}
-                {#if b.status !== 'cancelled' && b.status !== 'rejected'}
+                {#if !isPersonal && b.status !== 'cancelled' && b.status !== 'rejected'}
                   <Button
                     variant="ghost"
                     size="sm"

--- a/src/routes/(app)/scheduling/calendar/+page.server.ts
+++ b/src/routes/(app)/scheduling/calendar/+page.server.ts
@@ -2,14 +2,12 @@ import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getCoreCtx } from '$server/auth/core-ctx';
 import { shouldMaskSensitive } from '$server/services/rbac.service';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listBookings } from '$server/services/scheduling-bookings.service';
 import { listResources, listEventTypes } from '$server/services/scheduling.service';
 
 export const load: PageServerLoad = async ({ locals, depends, url }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'scheduling'))) throw error(404, 'Scheduling module disabled');
   depends('scheduling:data');
 
   // Default "today" in the ORG's timezone (resources carry it; the server runs

--- a/src/routes/(app)/scheduling/event-types/+page.server.ts
+++ b/src/routes/(app)/scheduling/event-types/+page.server.ts
@@ -1,22 +1,24 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled, bothEnabled } from '$server/services/modules.service';
 import { listEventTypes, listResources } from '$server/services/scheduling.service';
 import { listProducts } from '$server/services/finance-products.service';
 
 export const load: PageServerLoad = async ({ locals, depends }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'scheduling'))) throw error(404, 'Scheduling module disabled');
   depends('scheduling:data');
 
   const [eventTypes, resources] = await Promise.all([listEventTypes(ctx), listResources(ctx)]);
 
   // Procedure list (finance bridge) — only when finances is also enabled.
+  // Data-bearing, not a route gate (not a manifest composite): reads the
+  // hook's per-request module-state snapshot instead of re-querying (R5).
   let products: Array<{ id: string; name: string }> = [];
   try {
-    if (await bothEnabled(ctx, 'scheduling', 'finances')) {
+    const financeBridgeEnabled =
+      (locals.moduleStates?.scheduling ?? true) && (locals.moduleStates?.finances ?? true);
+    if (financeBridgeEnabled) {
       products = (await listProducts(ctx)).map((p) => ({ id: p.id, name: p.name }));
     }
   } catch {

--- a/src/routes/(app)/scheduling/links/+page.server.ts
+++ b/src/routes/(app)/scheduling/links/+page.server.ts
@@ -1,13 +1,11 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listLinks, listEventTypes, listResources } from '$server/services/scheduling.service';
 
 export const load: PageServerLoad = async ({ locals, depends, url }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'scheduling'))) throw error(404, 'Scheduling module disabled');
   depends('scheduling:data');
   const [links, eventTypes, resources] = await Promise.all([listLinks(ctx), listEventTypes(ctx), listResources(ctx)]);
   return {

--- a/src/routes/(app)/scheduling/reminders/+page.server.ts
+++ b/src/routes/(app)/scheduling/reminders/+page.server.ts
@@ -1,7 +1,6 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { getReminderConfig } from '$server/services/reminder-config.service';
 import { getReminderActivity } from '$server/services/reminders.service';
 import { getChannelCatalog } from '$server/services/crm-channels.service';
@@ -9,7 +8,6 @@ import { getChannelCatalog } from '$server/services/crm-channels.service';
 export const load: PageServerLoad = async ({ locals, depends }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'scheduling'))) throw error(404, 'Scheduling module disabled');
   depends('scheduling:data');
   const [config, activity, catalog] = await Promise.all([
     getReminderConfig(ctx).catch(() => null),

--- a/src/routes/(app)/scheduling/resources/+page.server.ts
+++ b/src/routes/(app)/scheduling/resources/+page.server.ts
@@ -2,7 +2,6 @@ import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getCoreCtx } from '$server/auth/core-ctx';
 import { shouldMaskSensitive } from '$server/services/rbac.service';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listResources, getResourceSchedule, listEventTypes } from '$server/services/scheduling.service';
 import { listBookings } from '$server/services/scheduling-bookings.service';
 import { listUsers } from '$server/services/user.service';
@@ -18,7 +17,6 @@ function dayOffset(n: number): Date {
 export const load: PageServerLoad = async ({ locals, depends }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'scheduling'))) throw error(404, 'Scheduling module disabled');
   depends('scheduling:data');
 
   // 7-day window centred on today: 3 days behind + today + 3 ahead.

--- a/src/routes/(app)/socials/+page.server.ts
+++ b/src/routes/(app)/socials/+page.server.ts
@@ -1,7 +1,6 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import {
   adDataExtent,
   adKpis,
@@ -35,7 +34,6 @@ function resolveRange(url: URL, extent: DataExtent): DateRange {
 export const load: PageServerLoad = async ({ locals, url, depends }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'ads'))) throw error(404, 'Ads module disabled');
   depends('ads:data');
 
   const connections = await listConnections(ctx);

--- a/src/routes/(app)/socials/campaigns/+page.server.ts
+++ b/src/routes/(app)/socials/campaigns/+page.server.ts
@@ -1,7 +1,6 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import {
   adDataExtent,
   campaignBreakdown,
@@ -14,7 +13,6 @@ import {
 export const load: PageServerLoad = async ({ locals, url, depends }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'ads'))) throw error(404, 'Ads module disabled');
   depends('ads:data');
 
   const connections = await listConnections(ctx);

--- a/src/routes/(app)/socials/campaigns/[campaignId]/+page.server.ts
+++ b/src/routes/(app)/socials/campaigns/[campaignId]/+page.server.ts
@@ -1,7 +1,6 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { uuidParamOr404 } from '$server/utils/uuid-param';
 import {
   adDataExtent,
@@ -16,7 +15,6 @@ export const load: PageServerLoad = async ({ locals, params, url, depends }) => 
   uuidParamOr404(params.campaignId);
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'ads'))) throw error(404, 'Ads module disabled');
   depends('ads:data');
 
   // Same range semantics as the campaigns list page: explicit ?from=&to= wins,

--- a/src/routes/(app)/socials/posts/+page.server.ts
+++ b/src/routes/(app)/socials/posts/+page.server.ts
@@ -1,13 +1,11 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { postPerformance, listConnections } from '$server/services/meta/meta-insights.service';
 
 export const load: PageServerLoad = async ({ locals, depends }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'ads'))) throw error(404, 'Ads module disabled');
   depends('ads:data');
 
   const connections = await listConnections(ctx);

--- a/src/routes/(app)/socials/posts/[postId]/+page.server.ts
+++ b/src/routes/(app)/socials/posts/[postId]/+page.server.ts
@@ -1,14 +1,11 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { getPostDetail } from '$server/services/meta/meta-insights.service';
 
 export const load: PageServerLoad = async ({ locals, params }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'ads'))) throw error(404, 'Ads module disabled');
-
   const postId = decodeURIComponent(params.postId);
   const post = await getPostDetail(ctx, postId);
   if (!post) throw error(404, 'Post not found');

--- a/src/routes/(app)/socials/settings/+page.server.ts
+++ b/src/routes/(app)/socials/settings/+page.server.ts
@@ -1,13 +1,11 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listConnections, listAssetsWithStatus, syncJobHistory } from '$server/services/meta/meta-insights.service';
 
 export const load: PageServerLoad = async ({ locals, depends }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'ads'))) throw error(404, 'Ads module disabled');
   depends('ads:settings');
 
   const [connections, assets, jobs] = await Promise.all([

--- a/src/routes/(app)/stock/+page.server.ts
+++ b/src/routes/(app)/stock/+page.server.ts
@@ -1,13 +1,11 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listItems, listWarehouses, getBins, getRecentLedger } from '$server/services/stock.service';
 
 export const load: PageServerLoad = async ({ locals, depends }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'stock'))) throw error(404, 'Stock module disabled');
   depends('stock:overview');
 
   const [items, warehouses, bins, recentLedger] = await Promise.all([

--- a/src/routes/(app)/stock/commitments/+page.server.ts
+++ b/src/routes/(app)/stock/commitments/+page.server.ts
@@ -1,13 +1,11 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listAccruals, committedSpend } from '$server/services/stock-accruals.service';
 
 export const load: PageServerLoad = async ({ locals }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'stock'))) throw error(404, 'Stock module disabled');
   const [open, realized, committed] = await Promise.all([
     listAccruals(ctx, { status: 'open' }),
     listAccruals(ctx, { status: 'realized' }),

--- a/src/routes/(app)/stock/consume/+page.server.ts
+++ b/src/routes/(app)/stock/consume/+page.server.ts
@@ -1,15 +1,12 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listConsumption, listWarehouses } from '$server/services/stock.service';
 import { listProducts } from '$server/services/finance-products.service';
 
 export const load: PageServerLoad = async ({ locals }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'stock'))) throw error(404, 'Stock module disabled');
-
   const [consumption, warehouses, products] = await Promise.all([
     listConsumption(ctx),
     listWarehouses(ctx),

--- a/src/routes/(app)/stock/consumption/+page.server.ts
+++ b/src/routes/(app)/stock/consumption/+page.server.ts
@@ -1,14 +1,12 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listConsumption, listItems } from '$server/services/stock.service';
 import { listProducts } from '$server/services/finance-products.service';
 
 export const load: PageServerLoad = async ({ locals, depends }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'stock'))) throw error(404, 'Stock module disabled');
   depends('stock:consumption');
 
   const [consumption, items, products] = await Promise.all([

--- a/src/routes/(app)/stock/entries/+page.server.ts
+++ b/src/routes/(app)/stock/entries/+page.server.ts
@@ -1,14 +1,12 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listEntries, listItems } from '$server/services/stock.service';
 import { getParty } from '$server/services/party.service';
 
 export const load: PageServerLoad = async ({ locals, url, depends }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'stock'))) throw error(404, 'Stock module disabled');
   depends('stock:entries');
 
   const partyId = url.searchParams.get('party') ?? undefined;

--- a/src/routes/(app)/stock/entries/[id]/+page.server.ts
+++ b/src/routes/(app)/stock/entries/[id]/+page.server.ts
@@ -1,7 +1,6 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { getEntry, listItems, listWarehouses } from '$server/services/stock.service';
 import { getParty } from '$server/services/party.service';
 import { uuidParamOr404 } from '$server/utils/uuid-param';
@@ -10,7 +9,6 @@ export const load: PageServerLoad = async ({ locals, params, depends }) => {
   uuidParamOr404(params.id);
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'stock'))) throw error(404, 'Stock module disabled');
   depends('stock:entry-detail');
 
   const [result, items, warehouses] = await Promise.all([getEntry(ctx, params.id), listItems(ctx), listWarehouses(ctx)]);

--- a/src/routes/(app)/stock/entries/new/+page.server.ts
+++ b/src/routes/(app)/stock/entries/new/+page.server.ts
@@ -1,13 +1,11 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listItems, listWarehouses } from '$server/services/stock.service';
 
 export const load: PageServerLoad = async ({ locals }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'stock'))) throw error(404, 'Stock module disabled');
   const [items, warehouses] = await Promise.all([listItems(ctx), listWarehouses(ctx)]);
   return { items, warehouses };
 };

--- a/src/routes/(app)/stock/items/+page.server.ts
+++ b/src/routes/(app)/stock/items/+page.server.ts
@@ -1,13 +1,11 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listItems, itemSupplyInfo } from '$server/services/stock.service';
 
 export const load: PageServerLoad = async ({ locals, depends }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'stock'))) throw error(404, 'Stock module disabled');
   depends('stock:items');
   const [items, supply] = await Promise.all([listItems(ctx), itemSupplyInfo(ctx)]);
   // Last restock cost/supplier are derived from the ledger, not columns.

--- a/src/routes/(app)/stock/items/[id]/+page.server.ts
+++ b/src/routes/(app)/stock/items/[id]/+page.server.ts
@@ -1,15 +1,7 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
-import {
-  listItems,
-  listWarehouses,
-  getBins,
-  getLedger,
-  listConsumption,
-  itemSupplyInfo,
-} from '$server/services/stock.service';
+import { listItems, listWarehouses, getBins, getLedger, listConsumption, itemSupplyInfo } from '$server/services/stock.service';
 import { getParty } from '$server/services/party.service';
 import { uuidParamOr404 } from '$server/utils/uuid-param';
 
@@ -17,7 +9,6 @@ export const load: PageServerLoad = async ({ locals, params, depends }) => {
   uuidParamOr404(params.id);
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'stock'))) throw error(404, 'Stock module disabled');
   depends('stock:item-detail');
 
   const [items, warehouses, bins, ledger, consumedBy, supply] = await Promise.all([
@@ -33,9 +24,7 @@ export const load: PageServerLoad = async ({ locals, params, depends }) => {
   const warehouseById = new Map(warehouses.map((w) => [w.id, w]));
   // Standing supplier name for the picker's initial label (the picker itself
   // only round-trips an id).
-  const supplier = item.defaultSupplierPartyId
-    ? await getParty(ctx, item.defaultSupplierPartyId)
-    : null;
+  const supplier = item.defaultSupplierPartyId ? await getParty(ctx, item.defaultSupplierPartyId) : null;
   const supplyInfo = supply.get(item.id) ?? null;
 
   return {
@@ -47,14 +36,8 @@ export const load: PageServerLoad = async ({ locals, params, depends }) => {
       lastSupplierName: supplyInfo?.supplierName ?? null,
     },
     itemIds: items.map((i) => i.id), // ordered ids only (keep payload small) — [ / ] prev/next nav
-    bins: bins.map((b) => ({
-      ...b,
-      warehouseName: warehouseById.get(b.warehouseId)?.name ?? b.warehouseId,
-    })),
-    ledger: ledger.map((l) => ({
-      ...l,
-      warehouseName: warehouseById.get(l.warehouseId)?.name ?? l.warehouseId,
-    })),
+    bins: bins.map((b) => ({ ...b, warehouseName: warehouseById.get(b.warehouseId)?.name ?? b.warehouseId })),
+    ledger: ledger.map((l) => ({ ...l, warehouseName: warehouseById.get(l.warehouseId)?.name ?? l.warehouseId })),
     consumedBy,
   };
 };

--- a/src/routes/(app)/stock/warehouses/+page.server.ts
+++ b/src/routes/(app)/stock/warehouses/+page.server.ts
@@ -1,13 +1,11 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getCoreCtx } from '$server/auth/core-ctx';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listWarehouses } from '$server/services/stock.service';
 
 export const load: PageServerLoad = async ({ locals, depends }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'stock'))) throw error(404, 'Stock module disabled');
   depends('stock:warehouses');
   return { warehouses: await listWarehouses(ctx) };
 };

--- a/src/routes/(app)/support/+page.server.ts
+++ b/src/routes/(app)/support/+page.server.ts
@@ -2,14 +2,12 @@ import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getCoreCtx } from '$server/auth/core-ctx';
 import { ownerFilter } from '$server/services/rbac.service';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { listIssues, issueStats, agreementStatus } from '$server/services/support.service';
 import { getContact } from '$server/services/crm-contacts.service';
 
 export const load: PageServerLoad = async ({ locals, depends, url }) => {
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'support'))) throw error(404, 'Support module disabled');
   depends('support:list');
 
   // Cross-module nav: ?contact= filters to one contact's tickets (Connections

--- a/src/routes/(app)/support/[id]/+page.server.ts
+++ b/src/routes/(app)/support/[id]/+page.server.ts
@@ -2,7 +2,6 @@ import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getCoreCtx } from '$server/auth/core-ctx';
 import { ownerFilter } from '$server/services/rbac.service';
-import { isModuleEnabled } from '$server/services/modules.service';
 import { getIssue, agreementStatus } from '$server/services/support.service';
 import { listEntityTimeline } from '$server/services/activity.service';
 import { transitionsFor } from '$server/services/workflow.service';
@@ -12,7 +11,6 @@ export const load: PageServerLoad = async ({ locals, params, depends }) => {
   uuidParamOr404(params.id);
   const ctx = await getCoreCtx(locals);
   if (!ctx) throw error(401, 'Authentication required');
-  if (!(await isModuleEnabled(ctx, 'support'))) throw error(404, 'Support module disabled');
   depends('support:issue');
 
   // if-owner scope: a scoped caller only opens tickets they own (else 404).

--- a/src/routes/api/jobs/tick/+server.ts
+++ b/src/routes/api/jobs/tick/+server.ts
@@ -7,6 +7,7 @@ import '$server/services/groupchat.service';
 import '$server/services/brains.service';
 import '$server/services/brain-corpus-jobs.service';
 import '$server/services/brain-business-corpus-jobs.service';
+import '$server/services/finance-statements.service';
 
 /**
  * GET /api/jobs/tick — cron entrypoint for the GLOBAL background-job runtime.

--- a/src/server/auth/resolve-identity.ts
+++ b/src/server/auth/resolve-identity.ts
@@ -27,7 +27,10 @@ import { env } from '$env/dynamic/private';
 export { resolveUserTenant } from '$server/auth/tenant';
 
 /** The subset of `App.Locals` that an identity provider populates. */
-type LocalsPatch = Pick<App.Locals, 'user' | 'session' | 'orgId' | 'tenantCtx' | 'serverId'>;
+type LocalsPatch = Pick<
+  App.Locals,
+  'user' | 'session' | 'orgId' | 'tenantCtx' | 'serverId' | 'orgKind'
+>;
 
 export interface IdentityResolution {
   /** Fields to assign onto `event.locals`. */
@@ -171,11 +174,19 @@ export async function resolveServerTokenAuth(
 
 /** AUTH_DISABLED dev mode: fabricate a local admin and grab the first org. */
 async function resolveAuthDisabled(): Promise<IdentityResolution> {
-  const { data } = await supabaseAdmin().from('organizations').select('id').limit(1).maybeSingle();
-  const tenantCtx = data ? { db: getDb(), tenantId: (data as { id: string }).id } : undefined;
+  const { data } = await supabaseAdmin()
+    .from('organizations')
+    .select('id, kind')
+    .limit(1)
+    .maybeSingle();
+  const row = data as { id: string; kind?: string | null } | null;
+  const tenantCtx = row ? { db: getDb(), tenantId: row.id } : undefined;
   return {
     locals: {
       tenantCtx,
+      // Real kind so the module-availability guard behaves like prod in dev
+      // (bypassGate only skips authentication, not availability).
+      orgKind: row?.kind === 'personal' ? 'personal' : row ? 'business' : undefined,
       user: { id: 'local', email: 'local@dev', displayName: 'Local Dev', role: 'admin' },
     },
     bypassGate: true,
@@ -218,13 +229,19 @@ async function resolveViaSupabase(event: RequestEvent): Promise<IdentityResoluti
   // user with no Supabase membership row still resolves exactly as before.
   // resolveSupabaseTenant only honors preferredOrgId if the user is actually a
   // member, else it falls back to the alphabetical-first org (its default).
-  const supaOrgId = bridged.supabaseId
-    ? (await resolveSupabaseTenant(bridged.supabaseId, preferredOrgId))?.orgId
-    : undefined;
+  const supaTenant = bridged.supabaseId
+    ? await resolveSupabaseTenant(bridged.supabaseId, preferredOrgId)
+    : null;
   const orgId =
-    supaOrgId ??
+    supaTenant?.orgId ??
     (await resolveUserTenant(db, { userId: bridged.id, fallbackToMembership: true }))?.orgId;
   const tenantCtx = orgId ? { db, tenantId: orgId } : undefined;
+  // kind is only known when Supabase resolved the org directly (same query,
+  // no extra round trip — routing-simplification spec S2/R2). The legacy
+  // Turso fallback path below doesn't carry a kind column, so this stays
+  // undefined for it — the (app) route hook guard fails closed on an unknown
+  // kind for kind-restricted modules rather than guessing.
+  const orgKind = supaTenant && supaTenant.orgId === orgId ? supaTenant.kind : undefined;
 
   const resolution: IdentityResolution = {
     locals: {
@@ -240,6 +257,7 @@ async function resolveViaSupabase(event: RequestEvent): Promise<IdentityResoluti
       },
       orgId,
       tenantCtx,
+      orgKind,
     },
     bypassGate: false,
   };

--- a/src/server/auth/supabase-bridge.runtime.ts
+++ b/src/server/auth/supabase-bridge.runtime.ts
@@ -4,6 +4,14 @@ import type { RequestEvent } from '@sveltejs/kit';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { supabaseServer, supabaseAdmin } from '$server/supabase';
 import { mapProfileToUser, type BridgedUser, type ProfileRow } from './supabase-bridge.js';
+import type { OrgKind } from '$lib/org-kind';
+
+/** DB `organizations.kind` is free-text; only the two known values normalize
+ *  — anything else (or null/unset) is "unresolvable", not a silent default
+ *  (routing-simplification spec S2: the caller fails closed on this). */
+function normalizeOrgKind(value: string | null | undefined): OrgKind | null {
+  return value === 'personal' || value === 'business' ? value : null;
+}
 
 export type { BridgedUser } from './supabase-bridge.js';
 
@@ -105,16 +113,16 @@ export async function resolveSupabaseUser(
 export async function resolveSupabaseTenant(
   supabaseId: string,
   preferredOrgId?: string | null,
-): Promise<{ orgId: string } | null> {
+): Promise<{ orgId: string; kind: OrgKind | null } | null> {
   try {
     const admin = supabaseAdmin();
     const { data, error } = await admin
       .from('organization_members')
-      .select('organizations(id, name)')
+      .select('organizations(id, name, kind)')
       .eq('profile_id', supabaseId);
     if (error || !data) return null;
 
-    type OrgRow = { id: string; name: string | null };
+    type OrgRow = { id: string; name: string | null; kind: string | null };
     type MemRow = { organizations: OrgRow | OrgRow[] | null };
     const orgs = (data as unknown as MemRow[])
       .map((row) => (Array.isArray(row.organizations) ? row.organizations[0] : row.organizations))
@@ -122,10 +130,11 @@ export async function resolveSupabaseTenant(
       .sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
 
     if (orgs.length === 0) return null;
-    if (preferredOrgId && orgs.some((o) => o.id === preferredOrgId)) {
-      return { orgId: preferredOrgId };
+    if (preferredOrgId) {
+      const preferred = orgs.find((o) => o.id === preferredOrgId);
+      if (preferred) return { orgId: preferred.id, kind: normalizeOrgKind(preferred.kind) };
     }
-    return { orgId: orgs[0].id };
+    return { orgId: orgs[0].id, kind: normalizeOrgKind(orgs[0].kind) };
   } catch {
     return null;
   }

--- a/src/server/services/backup-scheduler-lifecycle.test.ts
+++ b/src/server/services/backup-scheduler-lifecycle.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('backup scheduler lifecycle', () => {
+  it('does not start a process timer from the SvelteKit request module', () => {
+    const hooks = readFileSync('src/hooks.server.ts', 'utf8');
+    const scheduler = readFileSync('src/server/services/backup-scheduler.ts', 'utf8');
+
+    expect(hooks).not.toContain('startBackupScheduler');
+    expect(scheduler).toContain('export function startBackupScheduler()');
+  });
+});

--- a/src/server/services/finance.service.test.ts
+++ b/src/server/services/finance.service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { createMockDb } from '$server/test-utils/mock-db';
 
 vi.mock('@minion-stack/cache', () => ({
@@ -143,6 +144,62 @@ describe('financeSummary', () => {
     expect(result.netRevenue).toBe(0);
     expect(result.currency).toBe('PEN');
   });
+
+  // S3/WP1 R6: stock is kind-hidden for personal orgs — COGS must be 0
+  // WITHOUT even issuing the COGS query (not just zeroed after the fact).
+  it('kind=personal: COGS forced to 0, COGS query skipped entirely', async () => {
+    const { financeSummary } = await import('./finance.service');
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce([
+        { net: '100', gross: '100', discount: '0', invoices: '1', tax: '0', clients: '1', voids: '0', currency: 'PEN' },
+      ])
+      .mockResolvedValueOnce([{ n: '1' }]); // no COGS call in between
+    useExecMock(execute);
+
+    const result = await financeSummary(ctx(), { from: null, to: null, bucket: 'month' }, 'personal');
+    expect(result.totalCogs).toBe(0);
+    expect(result.netRevenue).toBe(100); // no COGS/tax deducted
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  // Same gate applies to a business org that toggled stock off explicitly —
+  // effectiveModuleEnabled composes BOTH kind and the app_modules toggle.
+  it('kind=business with stock toggled off: COGS forced to 0, query skipped', async () => {
+    const { financeSummary } = await import('./finance.service');
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce([
+        { net: '100', gross: '100', discount: '0', invoices: '1', tax: '0', clients: '1', voids: '0', currency: 'PEN' },
+      ])
+      .mockResolvedValueOnce([{ n: '1' }]);
+    useExecMock(execute);
+
+    const result = await financeSummary(
+      ctx(),
+      { from: null, to: null, bucket: 'month' },
+      'business',
+      { stock: false },
+    );
+    expect(result.totalCogs).toBe(0);
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('kind omitted (2-arg call): unchanged — COGS query still runs (business behavior identical)', async () => {
+    const { financeSummary } = await import('./finance.service');
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce([
+        { net: '100', gross: '100', discount: '0', invoices: '1', tax: '0', clients: '1', voids: '0', currency: 'PEN' },
+      ])
+      .mockResolvedValueOnce([{ cogs: '20' }])
+      .mockResolvedValueOnce([{ n: '1' }]);
+    useExecMock(execute);
+
+    const result = await financeSummary(ctx(), { from: null, to: null, bucket: 'month' });
+    expect(result.totalCogs).toBe(20);
+    expect(execute).toHaveBeenCalledTimes(3);
+  });
 });
 
 describe('revenueSeries', () => {
@@ -158,6 +215,30 @@ describe('revenueSeries', () => {
     expect(result).toHaveLength(2);
     expect(result[0]).toEqual({ bucket: '2026-01-01', invoices: 5, revenue: 590.0, discount: 10.0, gross: 600.0, voided: 20.0, tax: 90.0, opCost: 50.0 });
     expect(result[1].revenue).toBe(354.0);
+  });
+
+  // S3/WP1 R6: personal orgs never see stk_ledger rows in op_cost — asserted
+  // at the SQL level since the `cost` CTE is a single combined query (can't
+  // skip a whole tx.execute() call the way financeSummary's separate COGS
+  // query can).
+  it('kind=personal: the cost CTE is forced empty (no stock rows leak into op_cost)', async () => {
+    const { revenueSeries } = await import('./finance.service');
+    const execute = vi.fn().mockResolvedValueOnce([]);
+    useExecMock(execute);
+
+    await revenueSeries(ctx(), { from: null, to: null, bucket: 'month' }, 'personal');
+    const query = new PgDialect().sqlToQuery(execute.mock.calls[0][0]);
+    expect(query.sql).toContain('and false');
+  });
+
+  it('kind=business (or omitted): the cost CTE has no forced-false clause', async () => {
+    const { revenueSeries } = await import('./finance.service');
+    const execute = vi.fn().mockResolvedValueOnce([]);
+    useExecMock(execute);
+
+    await revenueSeries(ctx(), { from: null, to: null, bucket: 'month' }, 'business');
+    const query = new PgDialect().sqlToQuery(execute.mock.calls[0][0]);
+    expect(query.sql).not.toContain('and false');
   });
 
   it('respects period params without error', async () => {

--- a/src/server/services/finance.service.ts
+++ b/src/server/services/finance.service.ts
@@ -16,6 +16,8 @@ import type { CanonicalInvoice } from '$server/finance/connector';
 import { cached, keys, invalidateTags, tags } from '@minion-stack/cache';
 import type { Period } from '$lib/finance/period';
 import { emitHubEvent } from '$server/events/emit';
+import { effectiveModuleEnabled, type ModuleStates } from '$lib/modules/availability';
+import type { OrgKind } from '$lib/org-kind';
 
 const numStr = (n: number | null) => (n == null ? null : String(n));
 
@@ -663,7 +665,21 @@ export function financeDataSpan(ctx: CoreCtx, tz = 'UTC') {
   );
 }
 
-export function financeSummary(ctx: CoreCtx, p: Period) {
+/**
+ * `kind`/`moduleStates` are optional and default to "stock effectively
+ * enabled" (business-fallback kind + no toggle row) — existing 2-arg callers
+ * are unaffected (S3/WP1 R6: keep business behavior identical). Pass the
+ * caller's resolved org kind (`locals.orgKind`/`locals.moduleStates`) so
+ * personal orgs — where stock is kind-hidden — don't pay for or report a
+ * COGS figure sourced from a module they can't see.
+ */
+export function financeSummary(
+  ctx: CoreCtx,
+  p: Period,
+  kind?: OrgKind | null,
+  moduleStates: ModuleStates = {},
+) {
+  const stockEnabled = effectiveModuleEnabled(kind, moduleStates, 'stock');
   return cached(
     ck(ctx.tenantId, 'summary', p),
     { ttl: '2m', swr: '30s', tags: ctags(ctx.tenantId) },
@@ -679,14 +695,17 @@ export function financeSummary(ctx: CoreCtx, p: Period) {
         from fin_invoices where ${periodWhere(p)}
       `)) as unknown as Array<Record<string, unknown>>;
         // COGS = value of inventory consumed (issue-type ledger), same source as the
-        // revenue chart's op-cost band, scoped to the period by posted_at.
-        const [cg] = (await tx.execute(sql`
+        // revenue chart's op-cost band, scoped to the period by posted_at. Skipped
+        // entirely when stock isn't effectively enabled for this org.
+        const [cg] = stockEnabled
+          ? ((await tx.execute(sql`
         select coalesce(-sum(l.value_delta::numeric),0)::float8 cogs
         from stk_ledger l join stk_entries e on e.id = l.entry_id
         where e.type = 'issue' and l.org_id = current_setting('app.current_org_id', true)
           ${p.from ? sql`and l.posted_at >= ${p.from}` : sql``}
           ${p.to ? sql`and l.posted_at < ${p.to}` : sql``}
-      `)) as unknown as Array<{ cogs: number }>;
+      `)) as unknown as Array<{ cogs: number }>)
+          : [{ cogs: 0 }];
         const net = Number(r.net),
           gross = Number(r.gross),
           discount = Number(r.discount),
@@ -753,7 +772,18 @@ export function maskFinanceSummary(s: FinanceSummary): FinanceSummary {
   };
 }
 
-export function revenueSeries(ctx: CoreCtx, p: Period) {
+/**
+ * See `financeSummary` for the `kind`/`moduleStates` contract (S3/WP1 R6) —
+ * op_cost (COGS) is forced to zero, not just omitted, when stock isn't
+ * effectively enabled for this org.
+ */
+export function revenueSeries(
+  ctx: CoreCtx,
+  p: Period,
+  kind?: OrgKind | null,
+  moduleStates: ModuleStates = {},
+) {
+  const stockEnabled = effectiveModuleEnabled(kind, moduleStates, 'stock');
   return cached(
     ck(ctx.tenantId, 'series', p),
     { ttl: '2m', swr: '30s', tags: ctags(ctx.tenantId) },
@@ -763,6 +793,7 @@ export function revenueSeries(ctx: CoreCtx, p: Period) {
         // inventory consumption cost (issue-type ledger value, by posted_at). FULL
         // JOIN so a bucket with only one of the two still appears. op_cost: issue
         // value_delta is stored negative (stock leaving) → negate to a positive cost.
+        // `cost` yields no rows at all when stock isn't effectively enabled.
         const rows = (await tx.execute(sql`
         with inv as (
           select date_trunc(${p.bucket}, issued_at) b,
@@ -783,6 +814,7 @@ export function revenueSeries(ctx: CoreCtx, p: Period) {
             and l.org_id = current_setting('app.current_org_id', true)
             ${p.from ? sql`and l.posted_at >= ${p.from}` : sql``}
             ${p.to ? sql`and l.posted_at < ${p.to}` : sql``}
+            ${stockEnabled ? sql`` : sql`and false`}
           group by 1
         )
         select to_char(coalesce(inv.b, cost.b), 'YYYY-MM-DD') bucket,


### PR DESCRIPTION
Third slice off `feat/level-2026-07-30`, and the one that **unblocks the rest** — the remaining slices' tests and routes depend on the `Locals`/signature changes it introduces.

**Re-derived against master, not ported.** The original commit `a6a7fe38` cannot be cherry-picked (details below).

## What it does

Replaces **41 hand-written `isModuleEnabled(...)` 404s** scattered across `(app)` routes with one decision in the route hook, driven by a manifest mapping URL prefixes → modules.

- `$lib/modules/availability.ts` — the manifest (prefixes, kind restrictions, `requires` chains)
- `$lib/modules/route-guard.ts` — pure decision helpers, so the guard is unit-testable without mocking a full `RequestEvent`
- `Locals` gains `orgKind` / `moduleStates`, resolved once during identity resolution instead of re-queried per route

The guard **fails closed**: an unresolvable org kind blocks kind-restricted modules, unlike the UI-side business fallback.

`financeSummary`/`revenueSeries` gain optional `kind`/`moduleStates` so personal orgs — where stock is kind-hidden — skip the COGS query rather than reporting a figure from a module they cannot see. Both default to existing business behavior, so 2-arg callers are unaffected.

## Why re-derived rather than cherry-picked

| Problem | Resolution |
|---|---|
| The commit edits `socials/ad-performance/+page.server.ts`, which master **deleted** in #88 — a plain rebase *resurrects that page* | excluded from the patch |
| Its route-contract counts are branch state (151/141, B:69) | kept master's **149/139, B:67** |
| It registers `/crm/graph` in the manifest + access registry, but the actual route is added by the relationship-graph commit | dropped — registering it here declares a route that does not exist |
| `financeSummary`/`revenueSeries` signature change lives in a *different* commit (`0f1de0d2`) and is required for this one to compile | pulled in, with its test |

## New test this PR adds

`deguarded-routes.test.ts` — **did not exist before, and this refactor needs it.**

The hook guard is fail-**open** for unmapped paths (`isAppRouteBlocked` returns `false` when `resolveModuleForPath` finds nothing). So a dropped or renamed manifest prefix does not fail loudly — it **silently un-gates a route**. Deleting 41 inline gates without pinning that mapping would have left no test standing between a manifest typo and an ungated business module.

It asserts all 36 de-guarded routes still resolve to a manifest entry requiring the module their inline gate required, following `requires` chains — e.g. `/pos/appointments` must still require **both** `pos` and `scheduling`, as its `bothEnabled('pos','scheduling')` gate did.

One thing worth noting from the audit: on `/pos/appointments` the removed `isModuleEnabled(ctx,'stock')` was **not** a route gate — it was a display flag, now `locals.moduleStates?.stock ?? true`. The route gate was the `bothEnabled` call, which the `posAppointments` manifest entry reproduces via `requires`.

## Gates

`bun run check` **0 errors / 0 warnings** · **1058 tests pass across 139 files** · `lint:tokens` 0 violations · design ratchet **against `origin/master`** reports no changed file increased governed debt.

⚠️ Note for future PRs: `lint:design` defaults its base to `origin/dev`, which **no longer exists** — it prints `per-file debt skipped` and **exits 0**, reading as "no debt added" when nothing was checked. Ran it as `DESIGN_LINT_BASE_REF=origin/master`. The fallback fix exists on `feat/level` but has not landed on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)