### PR TITLE
perf(brains): bump work_mem for channel-discovery aggregate

### DIFF
--- a/src/server/services/brain-corpus.service.ts
+++ b/src/server/services/brain-corpus.service.ts
@@ -587,6 +587,11 @@ export async function ensureMasterBrain(ctx: CoreCtx, createdBy?: string | null)
  * channel/account pair in the org-scoped ledger. */
 export async function discoverConversationSources(ctx: CoreCtx): Promise<KnowledgeSource[]> {
   return withOrgCore(ctx, async (tx) => {
+    // The composite count(distinct (chat_id, month)) below sorts the org's
+    // whole eligible ledger; at the server default work_mem (2MB) that sort
+    // spilled ~88GB of temp file I/O per reconcile tick (2026-07 IO alert).
+    // SET LOCAL keeps the bump scoped to this txn.
+    await tx.execute(sql`select set_config('work_mem', '128MB', true)`);
     const accounts = (await tx.execute(sql`
       select lower(trim(message.channel)) as channel,
         coalesce(nullif(trim(message.account_id), ''), 'default') as account_id,


### PR DESCRIPTION
## Why

The Supabase disk-IO alert root cause (2026-07-30 investigation) is still live in prod: `discoverConversationSources`' `count(distinct (chat_id, month))` sorts the org's whole eligible message ledger at the server default `work_mem` (2MB), spilling ~140MB of temp file I/O per reconcile tick — **174GB cumulative** in `pg_stat_statements` (was 88GB on Jul 30).

Side effect: during spill windows the brain-vector outbox worker's 15s-capped RPCs hit `statement timeout` and dead-letter jobs (2 chunks dead-lettered 2026-08-05; revived + drained separately).

## What

Transaction-local `set_config('work_mem','128MB', true)` before the aggregate — the exact fix already proven on `feat/level-2026-07-30` (`831da4b0`), ported alone so it ships without the rest of that slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqrF89e5i6JWFskbvPg4oL