### PR TITLE
ci: run the vitest suite on every PR and push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      PUBLIC_DEFAULT_ORG_SLUG: ci
+      # No PUBLIC_DEFAULT_ORG_SLUG override here: agent-org.ts derives its org
+      # regex from it, and tests expect the .env.example default (faces-sculptors).
       PUBLIC_POSTHOG_HOST: https://posthog.invalid
       PUBLIC_POSTHOG_KEY: ci
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history: ui-audit-inventory resolves its pinned baseline commit.
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           cp .env.example .env
           bun run i18n:compile
+          bunx svelte-kit sync
 
       - name: Unit tests
         # --retry=2 absorbs known parallel-load flakes (timeouts that pass in isolation)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,35 @@ on:
     branches: [dev, master]
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      PUBLIC_DEFAULT_ORG_SLUG: ci
+      PUBLIC_POSTHOG_HOST: https://posthog.invalid
+      PUBLIC_POSTHOG_KEY: ci
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate Svelte environment and translations
+        run: |
+          cp .env.example .env
+          bun run i18n:compile
+
+      - name: Unit tests
+        # --retry=2 absorbs known parallel-load flakes (timeouts that pass in isolation)
+        run: bunx vitest run --retry=2
+
+      - name: Architecture recon index
+        run: bun run test:architecture-recon
+
   check-and-build:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Why

The 2026-08-10 test-suite recon found that hub CI runs **zero tests**: `ci.yml` does check/lint/prettier/build only. All 2,568 vitest tests were advisory — and 36 parallel-load flaky failures (5s timeouts that pass in isolation) had accumulated silently because no pipeline ever went red.

## What

Adds a `test` job (parallel to `check-and-build`) that mirrors the existing setup steps and runs:

- `bunx vitest run --retry=2` — retry absorbs the known load flakes; genuine failures still fail after 3 attempts
- `bun run test:architecture-recon` — the other half of `bun run test`

No changes to the existing job. This PR's own checks exercise the new job end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017W3RPTvwJTr4wJDUpPfzzc