### PR TITLE
feat(finances): sunat-sire connector — pull the RVIE registry straight from SUNAT

### DIFF
--- a/src/routes/api/finances/sources/+server.ts
+++ b/src/routes/api/finances/sources/+server.ts
@@ -23,6 +23,7 @@ const putSchema = z.object({
   provider: z.string().max(200).optional(),
   username: z.string().max(500).optional(),
   password: z.string().max(500).optional(),
+  clientSecret: z.string().max(500).optional(),
   config: z.record(z.string(), z.unknown()).optional(),
   enabled: z.boolean().optional(),
 });
@@ -35,10 +36,11 @@ export const PUT: RequestHandler = async ({ locals, request }) => {
   const provider = typeof body.provider === 'string' ? body.provider : 'susii';
   const username = typeof body.username === 'string' ? body.username.trim() : '';
   const password = typeof body.password === 'string' ? body.password.trim() : '';
+  const clientSecret = typeof body.clientSecret === 'string' ? body.clientSecret.trim() : '';
 
   let secretRefs: Record<string, unknown>;
   if (username && password) {
-    secretRefs = encryptCreds({ username, password });
+    secretRefs = encryptCreds({ username, password, ...(clientSecret ? { clientSecret } : {}) });
   } else {
     // Preserve existing credentials when the user left the fields blank.
     const existing = await getSource(ctx, provider);

--- a/src/server/finance/connectors/sunat-sire-client.ts
+++ b/src/server/finance/connectors/sunat-sire-client.ts
@@ -1,0 +1,151 @@
+const TOKEN_BASE = 'https://api-seguridad.sunat.gob.pe';
+const API_BASE = 'https://api-sire.sunat.gob.pe';
+const SCOPE = API_BASE;
+
+/** Per-request timeout — a hung SUNAT response aborts instead of parking the worker forever. */
+const REQUEST_TIMEOUT_MS = 30_000;
+/** Backoff schedule for retryable failures (timeout / 429 / 5xx). */
+const RETRY_BACKOFF_MS = [1_000, 4_000, 12_000];
+/** Gentle pacing between page fetches — SUNAT's API gateway rate-limits aggressively. */
+const PAGE_DELAY_MS = 300;
+/** Refresh the OAuth token this long before its stated expiry (tokens last ~3600s). */
+const TOKEN_SLACK_MS = 60_000;
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+export interface SirePage {
+  paginacion: { page: number; perPage: number; totalRegistros: number };
+  registros: Record<string, unknown>[];
+  totales?: Record<string, unknown>;
+}
+
+export interface SireCreds {
+  /** RUC of the taxpayer (11 digits). */
+  ruc: string;
+  /** SOL secondary user + clave (NOT the principal). */
+  username: string;
+  password: string;
+  /** App registered in SOL → "Gestión Credenciales de API SUNAT". */
+  clientId: string;
+  clientSecret: string;
+}
+
+export class SunatSireClient {
+  private token: string | null = null;
+  private tokenExpiresAt = 0;
+
+  constructor(private creds: SireCreds) {}
+
+  /** fetch + AbortController timeout. Throws on timeout (AbortError) or network error. */
+  private async fetchOnce(url: string, init?: RequestInit): Promise<Response> {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS);
+    try {
+      return await fetch(url, { ...init, signal: ctrl.signal });
+    } finally {
+      clearTimeout(t);
+    }
+  }
+
+  /**
+   * fetch with timeout + retry/backoff. Retries on a network/timeout error or a
+   * retryable status (429, 5xx); other 4xx are returned to the caller. After the
+   * backoff schedule is exhausted the last error/response surfaces so advanceJob
+   * fails the page with the cursor preserved (resume retries it).
+   */
+  private async fetchRetry(url: string, init?: RequestInit): Promise<Response> {
+    let lastErr: unknown;
+    for (let attempt = 0; attempt <= RETRY_BACKOFF_MS.length; attempt++) {
+      try {
+        const res = await this.fetchOnce(url, init);
+        if (res.status === 429 || res.status >= 500) {
+          lastErr = new Error(`sunat ${res.status}`);
+          if (attempt < RETRY_BACKOFF_MS.length) { await sleep(RETRY_BACKOFF_MS[attempt]); continue; }
+          return res; // exhausted — let the caller treat as a failure
+        }
+        return res;
+      } catch (e) {
+        lastErr = e; // timeout (AbortError) or network failure
+        if (attempt < RETRY_BACKOFF_MS.length) { await sleep(RETRY_BACKOFF_MS[attempt]); continue; }
+        throw lastErr instanceof Error ? lastErr : new Error('sunat request failed');
+      }
+    }
+    throw lastErr instanceof Error ? lastErr : new Error('sunat request failed');
+  }
+
+  /**
+   * OAuth password grant against api-seguridad. Username is RUC+SOL user
+   * concatenated (e.g. "20611172967NIKO1998") — SUNAT's convention, not ours.
+   */
+  async login(): Promise<void> {
+    const { ruc, username, password, clientId, clientSecret } = this.creds;
+    const body = new URLSearchParams({
+      grant_type: 'password',
+      scope: SCOPE,
+      client_id: clientId,
+      client_secret: clientSecret,
+      username: `${ruc}${username}`,
+      password,
+    });
+    const res = await this.fetchRetry(`${TOKEN_BASE}/v1/clientessol/${encodeURIComponent(clientId)}/oauth2/token/`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+    if (!res.ok) {
+      // Carry SUNAT's reason (error_description), not just the status — the body
+      // never echoes the submitted secret, so it is safe to surface.
+      const detail = await res.text().catch(() => '');
+      throw new Error(`sunat token failed: ${res.status}${detail ? ` — ${detail.slice(0, 200)}` : ''}`);
+    }
+    const tok = (await res.json()) as { access_token: string; expires_in?: number };
+    this.token = tok.access_token;
+    this.tokenExpiresAt = Date.now() + (tok.expires_in ?? 3600) * 1000 - TOKEN_SLACK_MS;
+  }
+
+  private async authedGet(url: string): Promise<Response> {
+    if (!this.token || Date.now() >= this.tokenExpiresAt) await this.login();
+    let res = await this.fetchRetry(url, { headers: { Authorization: `Bearer ${this.token}` } });
+    if (res.status === 401) {
+      await this.login();
+      res = await this.fetchRetry(url, { headers: { Authorization: `Bearer ${this.token}` } });
+    }
+    return res;
+  }
+
+  /**
+   * All periods SUNAT knows for this RUC, newest first, flattened across
+   * ejercicios. `codEstado`/`desEstado` distinguish presented ('Presentado')
+   * from still-open ('No Presentado') periods.
+   */
+  async periodos(): Promise<Array<{ perTributario: string; codEstado: string; desEstado: string }>> {
+    const res = await this.authedGet(`${API_BASE}/v1/contribuyente/migeigv/libros/rvierce/padron/web/omisos/140000/periodos`);
+    if (!res.ok) throw new Error(`sunat periodos fetch failed: ${res.status}`);
+    const body = (await res.json()) as Array<{ lisPeriodos?: Array<{ perTributario: string; codEstado: string; desEstado: string }> }>;
+    return (Array.isArray(body) ? body : []).flatMap((e) => e.lisPeriodos ?? []);
+  }
+
+  /**
+   * One page of the RVIE propuesta for a period (YYYYMM). Works for both the
+   * open period and already-presented ones (verified empirically 2026-08-14),
+   * which is what makes month-by-month backfill possible.
+   */
+  async propuestaPage(periodo: string, page: number, perPage = 100): Promise<SirePage> {
+    const u = new URL(`${API_BASE}/v1/contribuyente/migeigv/libros/rvie/propuesta/web/propuesta/${periodo}/comprobantes`);
+    u.searchParams.set('page', String(page));
+    u.searchParams.set('perPage', String(perPage));
+    u.searchParams.set('mostrarDetalle', '1');
+    if (page > 1) await sleep(PAGE_DELAY_MS); // pace requests to avoid rate-limiting
+    const res = await this.authedGet(u.toString());
+    if (!res.ok) throw new Error(`sunat propuesta fetch failed (${periodo} p${page}): ${res.status}`);
+    const body = (await res.json()) as SirePage;
+    return { paginacion: body.paginacion, registros: body.registros ?? [], totales: body.totales };
+  }
+
+  /** Document count for one period via a perPage=1 probe. Doubles as the credential check. */
+  async count(periodo: string): Promise<number | null> {
+    const body = await this.propuestaPage(periodo, 1, 1);
+    const n = body.paginacion?.totalRegistros;
+    return typeof n === 'number' ? n : null;
+  }
+}

--- a/src/server/finance/connectors/sunat-sire-connector.test.ts
+++ b/src/server/finance/connectors/sunat-sire-connector.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { sunatSireConnector, resolvePeriods } from './sunat-sire-connector';
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+afterEach(() => vi.restoreAllMocks());
+
+const PERIODS = [
+  { perTributario: '202608', codEstado: '03', desEstado: 'No Presentado' },
+  { perTributario: '202607', codEstado: '01', desEstado: 'Presentado' },
+  { perTributario: '202606', codEstado: '01', desEstado: 'Presentado' },
+];
+
+describe('resolvePeriods', () => {
+  it('defaults to the open (non-presented) periods', () => {
+    expect(resolvePeriods(PERIODS, {})).toEqual(['202608']);
+  });
+  it('a since inside presented history backfills from that period', () => {
+    expect(resolvePeriods(PERIODS, { since: '2026-06-15T00:00:00Z' })).toEqual(['202606', '202607', '202608']);
+  });
+  it('a fresh since never skips an open period — presented is the only lock', () => {
+    // watermark says "yesterday" but August is still open → August is re-pulled whole
+    expect(resolvePeriods(PERIODS, { since: '2026-08-13T00:00:00Z' })).toEqual(['202608']);
+  });
+  it('startPeriod is the first-run backfill knob', () => {
+    expect(resolvePeriods(PERIODS, { startPeriod: '202607' })).toEqual(['202607', '202608']);
+  });
+});
+
+const config = { ruc: '20611172967', clientId: 'CID' };
+const secrets = { username: 'NIKO1998', password: 'pw', clientSecret: 'cs' };
+const row = (n: number) => ({ codCar: `car-${n}`, numSerieCDP: 'BE01', numCDP: String(n), codTipoCDP: '03' });
+
+describe('sunatSireConnector.pullPages', () => {
+  it('logs in with RUC+user, pages a period, and chains cursors', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse({ access_token: 'TOK', expires_in: 3600 }))
+      .mockResolvedValueOnce(jsonResponse([{ lisPeriodos: PERIODS }]))
+      .mockResolvedValueOnce(jsonResponse({ paginacion: { page: 1, perPage: 100, totalRegistros: 150 }, registros: [row(1)] }))
+      .mockResolvedValueOnce(jsonResponse({ paginacion: { page: 2, perPage: 100, totalRegistros: 150 }, registros: [row(2)] }));
+    const pages = [];
+    for await (const p of sunatSireConnector.pullPages({ config, secrets })) pages.push(p);
+    // token request carries SUNAT's concatenated RUC+user
+    expect(String(fetchMock.mock.calls[0][1]?.body)).toContain('username=20611172967NIKO1998');
+    // API calls carry the Bearer token
+    expect(fetchMock.mock.calls[1][1]?.headers).toMatchObject({ Authorization: 'Bearer TOK' });
+    expect(pages).toHaveLength(2);
+    expect(pages[0].cursor).toBe('202608|2'); // more rows in the period
+    expect(pages[0].invoices[0].documentId).toBe('BE01-1');
+    expect(pages[1].cursor).toBeNull(); // drained
+  });
+
+  it('resumes from a "PERIODO|PAGE" cursor without refetching earlier pages', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse({ access_token: 'TOK', expires_in: 3600 }))
+      .mockResolvedValueOnce(jsonResponse([{ lisPeriodos: PERIODS }]))
+      .mockResolvedValueOnce(jsonResponse({ paginacion: { page: 2, perPage: 100, totalRegistros: 150 }, registros: [row(2)] }));
+    const pages = [];
+    for await (const p of sunatSireConnector.pullPages({ config, secrets, cursor: '202608|2' })) pages.push(p);
+    expect(pages).toHaveLength(1);
+    expect(pages[0].cursor).toBeNull();
+    expect(String(fetchMock.mock.calls[2][0])).toContain('page=2');
+  });
+
+  it('refuses to run with incomplete credentials', async () => {
+    const it_ = sunatSireConnector.pullPages({ config, secrets: { username: 'u', password: 'p' } });
+    await expect(it_[Symbol.asyncIterator]().next()).rejects.toThrow(/clientSecret/);
+  });
+});
+
+describe('sunatSireConnector.count', () => {
+  it('sums totalRegistros across the resolved periods', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse({ access_token: 'TOK', expires_in: 3600 }))
+      .mockResolvedValueOnce(jsonResponse([{ lisPeriodos: PERIODS }]))
+      .mockResolvedValueOnce(jsonResponse({ paginacion: { page: 1, perPage: 1, totalRegistros: 59 }, registros: [] }));
+    expect(await sunatSireConnector.count!({ config, secrets })).toBe(59);
+  });
+
+  it('surfaces a bad credential as a thrown error (sources PUT probe)', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse({ error: 'unauthorized_client', error_description: 'cliente no autorizado' }, 401));
+    await expect(sunatSireConnector.count!({ config, secrets })).rejects.toThrow(/401|no autorizado/);
+  });
+});

--- a/src/server/finance/connectors/sunat-sire-connector.ts
+++ b/src/server/finance/connectors/sunat-sire-connector.ts
@@ -1,0 +1,93 @@
+import { registerConnector, type FinanceConnector, type CanonicalInvoice, type PullPage } from '../connector';
+import { SunatSireClient } from './sunat-sire-client';
+import { mapSireRegistro } from './sunat-sire-mapper';
+
+const PER_PAGE = 100;
+/** count() probes one request per period — beyond this many, skip the baseline rather than hammer SUNAT. */
+const MAX_COUNT_PROBES = 25;
+
+function makeClient(config: Record<string, unknown>, secrets: Record<string, string>) {
+  const ruc = String(config.ruc ?? '');
+  const clientId = String(config.clientId ?? '');
+  const { username, password, clientSecret } = secrets;
+  if (!/^\d{11}$/.test(ruc) || !clientId || !username || !password || !clientSecret) {
+    throw new Error('sunat-sire connector requires config.ruc (11 digits), config.clientId, secrets.username, secrets.password, secrets.clientSecret');
+  }
+  return new SunatSireClient({ ruc, username, password, clientId, clientSecret });
+}
+
+const periodOf = (iso: string): string => iso.slice(0, 7).replace('-', '');
+
+/**
+ * Which periods to pull this run. SIRE data is period-scoped and a period keeps
+ * changing until the accountant presents it — so instead of trusting the time
+ * watermark alone, always re-pull from the earliest NON-presented period. Once
+ * presented, a period's registro is locked and safe to leave behind.
+ *
+ * First run (no `since`): start from `config.startPeriod` (YYYYMM) when set —
+ * that's the backfill knob — otherwise from the earliest open period.
+ */
+export function resolvePeriods(
+  all: Array<{ perTributario: string; codEstado: string; desEstado: string }>,
+  opts: { since?: string; startPeriod?: string },
+): string[] {
+  if (all.length === 0) return [];
+  const newest = all.reduce((a, b) => (b.perTributario > a.perTributario ? b : a)).perTributario;
+  const open = all.filter((p) => /^no/i.test(p.desEstado));
+  const earliestOpen = open.length ? open.reduce((a, b) => (b.perTributario < a.perTributario ? b : a)).perTributario : newest;
+  let start: string;
+  if (opts.since) start = periodOf(opts.since) < earliestOpen ? periodOf(opts.since) : earliestOpen;
+  else start = opts.startPeriod ?? earliestOpen;
+  return all
+    .map((p) => p.perTributario)
+    .filter((p) => p >= start && p <= newest)
+    .sort();
+}
+
+export const sunatSireConnector: FinanceConnector = {
+  provider: 'sunat-sire',
+  async *pullPages({ config, secrets, since, cursor }): AsyncIterable<PullPage> {
+    const client = makeClient(config, secrets);
+    const periods = resolvePeriods(await client.periodos(), {
+      since,
+      startPeriod: typeof config.startPeriod === 'string' ? config.startPeriod : undefined,
+    });
+    // Cursor "PERIODO|PAGE" — resume mid-period after an interrupted run.
+    const [curPeriod, curPage] = (cursor ?? '').split('|');
+    for (let pi = 0; pi < periods.length; pi++) {
+      const periodo = periods[pi];
+      if (curPeriod && periodo < curPeriod) continue;
+      let page = curPeriod === periodo ? Math.max(1, Number(curPage) || 1) : 1;
+      for (;;) {
+        const body = await client.propuestaPage(periodo, page, PER_PAGE);
+        const total = body.paginacion?.totalRegistros ?? 0;
+        const hasMore = page * PER_PAGE < total;
+        const next = hasMore ? `${periodo}|${page + 1}` : pi + 1 < periods.length ? `${periods[pi + 1]}|1` : null;
+        yield { invoices: body.registros.map(mapSireRegistro), cursor: next };
+        if (!hasMore) break;
+        page++;
+      }
+    }
+  },
+  async *pull(opts): AsyncIterable<CanonicalInvoice> {
+    for await (const page of sunatSireConnector.pullPages(opts)) yield* page.invoices;
+  },
+  /** Sum of documents across the resolved periods. Doubles as the credential probe on save. */
+  async count({ config, secrets, since }): Promise<number | null> {
+    const client = makeClient(config, secrets);
+    const periods = resolvePeriods(await client.periodos(), {
+      since,
+      startPeriod: typeof config.startPeriod === 'string' ? config.startPeriod : undefined,
+    });
+    if (periods.length === 0 || periods.length > MAX_COUNT_PROBES) {
+      // Still authenticate so a bad credential fails loudly here.
+      if (periods.length === 0) await client.login();
+      return null;
+    }
+    let sum = 0;
+    for (const p of periods) sum += (await client.count(p)) ?? 0;
+    return sum;
+  },
+};
+
+registerConnector(sunatSireConnector);

--- a/src/server/finance/connectors/sunat-sire-mapper.test.ts
+++ b/src/server/finance/connectors/sunat-sire-mapper.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { mapSireRegistro } from './sunat-sire-mapper';
+
+/** Shape taken verbatim from a real RVIE propuesta pull (2026-08-14). */
+const registro = {
+  id: '6a6ede2bb15a15e43095dbf8',
+  numRuc: '20611172967',
+  nomRazonSocial: 'FACES SCULPTORS S.A.C.',
+  perPeriodoTributario: '202608',
+  codCar: '2061117296703BE010000002376',
+  codTipoCDP: '03',
+  numSerieCDP: 'BE01',
+  numCDP: '2376',
+  codTipoCarga: '1',
+  codSituacion: '1',
+  codEstadoComprobante: '1',
+  desEstadoComprobante: 'Activo',
+  fecEmision: '01/08/2026',
+  codTipoDocIdentidad: '1',
+  numDocIdentidad: '48527624',
+  nomRazonSocialCliente: '-',
+  codMoneda: 'PEN',
+  mtoBIGravada: 1101.69,
+  mtoDsctoBI: 0.0,
+  mtoIGV: 198.31,
+  mtoTotalCP: 1300.0,
+};
+
+describe('mapSireRegistro', () => {
+  it('maps a boleta row to the canonical invoice shape', () => {
+    const inv = mapSireRegistro(registro);
+    expect(inv.provider).toBe('sunat-sire');
+    expect(inv.providerRef).toBe('2061117296703BE010000002376'); // codCar, stable across pulls
+    expect(inv.documentId).toBe('BE01-2376');
+    expect(inv.number).toBe('BE01-2376');
+    expect(inv.issuedAt).toBe('2026-08-01'); // dd/mm/yyyy → ISO
+    expect(inv.currency).toBe('PEN');
+    expect(inv.subtotal).toBe(1101.69);
+    expect(inv.tax).toBe(198.31);
+    expect(inv.total).toBe(1300.0);
+    expect(inv.status).toBeNull(); // SIRE knows validity, not collection state
+    expect(inv.items).toEqual([]);
+    expect(inv.payments).toEqual([]);
+    expect(inv.metadata).toBe(registro); // whole raw row preserved
+  });
+
+  it('keeps the client identity but nulls the "-" placeholder name', () => {
+    const inv = mapSireRegistro(registro);
+    expect(inv.client).toMatchObject({ providerRef: '1:48527624', docType: 'DNI', docNumber: '48527624', name: null });
+    expect(inv.clientDocType).toBe('DNI');
+    expect(inv.clientDocNumber).toBe('48527624');
+  });
+
+  it('drops all-same-digit sentinel documents instead of inventing a client', () => {
+    const inv = mapSireRegistro({ ...registro, numDocIdentidad: '00000000' });
+    expect(inv.client).toBeNull();
+    expect(inv.clientDocNumber).toBeNull();
+  });
+
+  it('marks anulado documents void', () => {
+    const inv = mapSireRegistro({ ...registro, desEstadoComprobante: 'Anulado' });
+    expect(inv.status).toBe('void');
+  });
+});

--- a/src/server/finance/connectors/sunat-sire-mapper.ts
+++ b/src/server/finance/connectors/sunat-sire-mapper.ts
@@ -1,0 +1,80 @@
+import type { CanonicalInvoice, CanonicalClient } from '../connector';
+
+const PROVIDER = 'sunat-sire';
+const str = (v: unknown): string | null => (v == null ? null : String(v));
+const num = (v: unknown): number | null => {
+  if (v == null || v === '') return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+};
+
+/** SUNAT doc-identity catalog (tabla 2) — only the types that actually appear in retail. */
+const DOC_TYPES: Record<string, string> = { '1': 'DNI', '4': 'CE', '6': 'RUC', '7': 'PASAPORTE' };
+
+/** SIRE placeholder for "no client name" is a literal dash. */
+const name = (v: unknown): string | null => {
+  const s = str(v)?.trim();
+  return s && s !== '-' ? s : null;
+};
+
+/** fecEmision arrives dd/mm/yyyy; canonical wants ISO. */
+const isoDate = (v: unknown): string | null => {
+  const m = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(str(v) ?? '');
+  return m ? `${m[3]}-${m[2]}-${m[1]}` : null;
+};
+
+function mapClient(r: Record<string, unknown>): CanonicalClient | null {
+  const docNumber = str(r.numDocIdentidad);
+  // No identity → no client row; the invoice keeps its own denormalised fields.
+  if (!docNumber || /^(\d)\1*$/.test(docNumber)) return null;
+  const docTypeCode = str(r.codTipoDocIdentidad) ?? '';
+  return {
+    provider: PROVIDER,
+    providerRef: `${docTypeCode}:${docNumber}`,
+    name: name(r.nomRazonSocialCliente),
+    docType: DOC_TYPES[docTypeCode] ?? (docTypeCode || null),
+    docNumber,
+    email: null,
+    phone: null,
+    metadata: {},
+  };
+}
+
+/**
+ * Map one RVIE propuesta `registros[]` row into the canonical invoice shape.
+ *
+ * SIRE is SUNAT's own ledger of emitted CPEs — it has document-level amounts
+ * only (no line items, no payments), so `items`/`payments` are always empty and
+ * `status` reflects document validity, never collection state.
+ */
+export function mapSireRegistro(r: Record<string, unknown>): CanonicalInvoice {
+  const client = mapClient(r);
+  const serie = str(r.numSerieCDP);
+  const numero = str(r.numCDP);
+  const documentId = serie && numero ? `${serie}-${numero}` : null;
+  const estado = (str(r.desEstadoComprobante) ?? '').toLowerCase();
+  return {
+    provider: PROVIDER,
+    // codCar is SUNAT's own unique carga key (RUC+tipo+serie+numero) — stable across pulls.
+    providerRef: str(r.codCar) ?? `${str(r.codTipoCDP)}-${documentId}`,
+    number: documentId,
+    documentId,
+    issuedAt: isoDate(r.fecEmision),
+    clientName: client?.name ?? null,
+    clientDocType: client?.docType ?? null,
+    clientDocNumber: client?.docNumber ?? null,
+    clientEmail: null,
+    currency: str(r.codMoneda) ?? 'PEN',
+    subtotal: num(r.mtoBIGravada),
+    tax: num(r.mtoIGV),
+    discount: num(r.mtoDsctoBI),
+    total: num(r.mtoTotalCP),
+    status: /anulad|baja/.test(estado) ? 'void' : null,
+    seller: null,
+    note: null,
+    metadata: r,
+    items: [],
+    payments: [],
+    client,
+  };
+}

--- a/src/server/services/finance-secrets.ts
+++ b/src/server/services/finance-secrets.ts
@@ -1,6 +1,7 @@
 import { encrypt, decrypt } from '../auth/crypto';
 
-export type FinanceCreds = { username: string; password: string };
+// clientSecret rides along for OAuth-style providers (sunat-sire); JSON round-trip keeps it.
+export type FinanceCreds = { username: string; password: string; clientSecret?: string };
 
 export function encryptCreds(c: FinanceCreds): { ciphertext: string; iv: string } {
   return encrypt(JSON.stringify(c));

--- a/src/server/services/finance-sync.service.ts
+++ b/src/server/services/finance-sync.service.ts
@@ -2,6 +2,7 @@ import type { CoreCtx } from '$server/auth/core-ctx';
 import { retryOnPoolDrop } from '$server/db/pg-client';
 import { getConnector } from '$server/finance/connector';
 import '$server/finance/connectors/susii-connector'; // self-registers the 'susii' connector
+import '$server/finance/connectors/sunat-sire-connector'; // self-registers the 'sunat-sire' connector
 import {
   getSource,
   upsertInvoicesBatch,
@@ -56,8 +57,9 @@ export async function advanceJob(
     await finishJob(ctx, jobId, 'failed', { error: 'no credentials configured' });
     return;
   }
-  const { username, password } = decryptCreds(String(refs.ciphertext), String(refs.iv));
-  const secrets: Record<string, string> = { username, password };
+  const creds = decryptCreds(String(refs.ciphertext), String(refs.iv));
+  const secrets: Record<string, string> = { username: creds.username, password: creds.password };
+  if (creds.clientSecret) secrets.clientSecret = creds.clientSecret;
   const config = (source.config ?? {}) as Record<string, unknown>;
   // Manual sync (no window): watermark-based `since` — an empty watermark means a
   // full history sweep. That stays a deliberate, human-triggered action.


### PR DESCRIPTION
## What

New `FinanceConnector` provider **`sunat-sire`** that mirrors SUNAT's own ledger of emitted comprobantes (SIRE RVIE *propuesta*) — the first step of replacing SUSII with a direct SUNAT integration.

- **`sunat-sire-client.ts`** — OAuth password grant against `api-seguridad.sunat.gob.pe` (username is SUNAT's `RUC+solUser` concatenation), token cache with pre-expiry refresh + one 401 re-login, `periodos` + paged `propuesta` endpoints, same timeout/backoff/pacing discipline as the SUSII client.
- **`sunat-sire-mapper.ts`** — `registros[]` row → `CanonicalInvoice`. `codCar` is the stable `providerRef`; no line items/payments exist in SIRE; `status` is document validity only (`anulado` → `void`).
- **`sunat-sire-connector.ts`** — period-scoped sync: a period keeps changing until the accountant presents it, so every run re-pulls from the earliest **non-presented** period instead of trusting the time watermark alone (presented = locked). `config.startPeriod` (YYYYMM) is the backfill knob. Cursor `"PERIODO|PAGE"` resumes mid-period on the existing `fin_sync_jobs` runner.
- **Secrets**: `FinanceCreds` grows optional `clientSecret`, carried inside the existing AES blob; `PUT /api/finances/sources` accepts it.

## Verified

- Live against RUC 20611172967 (2026-08-14): token exchange, period list, paged pulls of the open period (202608, 59 docs) **and** a presented one (202607, 156 docs).
- `bun run check` → 0 errors / 0 warnings; `bun run test` → 341 files, 2,683 passed, 0 failed (13 new tests).

## Out of scope (next PRs)

- Settings UI for the SUNAT credential (API-only for now; `'susii'` remains every UI default).
- SIRE-vs-SUSII reconciliation report.
- Emission module (SEE beta) — separate track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzD6Vn4qeMGvhXZLLeD1Ls