### PR TITLE
fix(finances): documentId reads document_set[0].document_name, not the serie id

### DIFF
--- a/src/server/finance/connectors/susii-mapper.test.ts
+++ b/src/server/finance/connectors/susii-mapper.test.ts
@@ -65,6 +65,16 @@ describe('docless sale totals (SUSII sends no sale.total)', () => {
     expect(mapSusiiSale(withDoc).total).toBe(1200);
   });
 
+  it('reads documentId from document_name; numeric serial is a serie ID, not a doc number', () => {
+    // Current SUSII payload shape (verified against prod 2026-08-14): serial is
+    // a numeric serie id, the human serie-número lives in document_name.
+    const current = { ...docless, document_set: [{ serial: 38173, document_name: 'BE01-2368', total: 1200 }] };
+    expect(mapSusiiSale(current).documentId).toBe('BE01-2368');
+    // Pre-change payloads (serial WAS the string) still map via the fallback.
+    const legacy = { ...docless, document_set: [{ serial: 'BE01-2105', total: 1200 }] };
+    expect(mapSusiiSale(legacy).documentId).toBe('BE01-2105');
+  });
+
   it('leaves the total unknown rather than inventing 0 when there are no lines', () => {
     expect(mapSusiiSale({ ...docless, items: [] }).total).toBeNull();
   });

--- a/src/server/finance/connectors/susii-mapper.ts
+++ b/src/server/finance/connectors/susii-mapper.ts
@@ -88,7 +88,14 @@ export function mapSusiiSale(sale: Record<string, unknown>): CanonicalInvoice {
     provider: PROVIDER,
     providerRef: String(sale.id ?? ''),
     number: str(sale.number),
-    documentId: str((arr(sale.document_set)[0] ?? {}).serial) ?? str(sale.number),
+    // SUSII changed shape: `serial` used to BE the serie-número string
+    // ('BE01-2105') but is now a numeric serie id (38173); the human
+    // 'BE01-2368' moved to `document_name`. Prefer it, keep the old
+    // fallbacks so pre-change payloads still map.
+    documentId:
+      str((arr(sale.document_set)[0] ?? {}).document_name) ??
+      str((arr(sale.document_set)[0] ?? {}).serial) ??
+      str(sale.number),
     issuedAt: str(sale.date),
     clientName: client?.name ?? str(sale.client_name),
     clientDocType: client?.docType ?? null,


### PR DESCRIPTION
SUSII changed its sale payload: `document_set[0].serial` used to be the serie-número string (`BE01-2105`) but is now a numeric serie ID (`38173`), with the human `BE01-2368` moved to `document_name`. Every recently synced `fin_invoices` row therefore stores `38173` as `document_id` (209 of the 210 doc-backed rows since July share that one value).

Found while reconciling the mirror against SUNAT's SIRE registry (2026-08-14): the serie-número join failed for all recent rows until read from `metadata` instead.

**Fix**: prefer `document_name`, keep the old `serial` → `number` fallbacks so pre-change payloads and docless sales map exactly as before. New test covers both payload eras.

**Follow-up after merge** (existing rows keep the raw payload in `metadata`, so this is a pure derivation):

```sql
update fin_invoices set document_id = metadata->'document_set'->0->>'document_name'
where provider='susii' and metadata->'document_set'->0->>'document_name' is not null
  and document_id is distinct from metadata->'document_set'->0->>'document_name';
```

Gates: `bun run check` 0/0 · mapper tests 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzD6Vn4qeMGvhXZLLeD1Ls