### PR TITLE
SUNAT emission module — beta slice (UBL 2.1 + sign + sendBill)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ sdd/
 # generated review/test artifacts
 /.lavish/
 /.playwright-cli/
+
+# SUNAT beta self-signed test cert/key — never commit key material
+/.beta-cert/

--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,7 @@
         "dompurify": "^3.4.11",
         "drizzle-orm": "^0.45.2",
         "echarts": "^6.1.0",
+        "fflate": "^0.8.3",
         "fuse.js": "^7.4.2",
         "jose": "^6",
         "katex": "^0.17.0",
@@ -89,6 +90,7 @@
         "tailwindcss": "^4.3.2",
         "tiptap-markdown": "^0.9.0",
         "wawa-lipsync": "^0.0.2",
+        "xml-crypto": "^6.1.2",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -967,6 +969,8 @@
 
     "@wterm/dom": ["@wterm/dom@0.3.0", "", { "dependencies": { "@wterm/core": "0.3.0" } }, "sha512-OiUl7reGSlW02yb5wGXMplMZhW2HBkBSFxvbFj15I832UK0QFIHRvhE2l6Xgae8ROn9bNLaALoKDFvcUuz80iQ=="],
 
+    "@xmldom/is-dom-node": ["@xmldom/is-dom-node@1.0.1", "", {}, "sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q=="],
+
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
 
     "@xyflow/svelte": ["@xyflow/svelte@1.6.2", "", { "dependencies": { "@svelte-put/shortcut": "^4.1.0", "@xyflow/system": "0.0.79" }, "peerDependencies": { "svelte": "^5.25.0" } }, "sha512-wImcz0c4mCa2SYxo5p1YSBqdTBqI4Ky2CYO6XZfNqMIxVr6mB2cdVaduJqHuqTETQuUKv4Gr0eh3Ev3iU8k8fg=="],
@@ -1301,7 +1305,7 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
@@ -1943,6 +1947,10 @@
 
     "xdg-portable": ["xdg-portable@7.3.0", "", { "dependencies": { "os-paths": "^4.0.1" } }, "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw=="],
 
+    "xml-crypto": ["xml-crypto@6.1.2", "", { "dependencies": { "@xmldom/is-dom-node": "^1.0.1", "@xmldom/xmldom": "^0.8.10", "xpath": "^0.0.33" } }, "sha512-leBOVQdVi8FvPJrMYoum7Ici9qyxfE4kVi+AkpUoYCSXaQF4IlBm1cneTK9oAxR61LpYxTx7lNcsnBIeRpGW2w=="],
+
+    "xpath": ["xpath@0.0.33", "", {}, "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA=="],
+
     "y-protocols": ["y-protocols@1.0.7", "", { "dependencies": { "lib0": "^0.2.85" }, "peerDependencies": { "yjs": "^13.0.0" } }, "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw=="],
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
@@ -2042,6 +2050,8 @@
     "libsql/detect-libc": ["detect-libc@2.0.2", "", {}, "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "posthog-js/fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
     "prosemirror-markdown/@types/markdown-it": ["@types/markdown-it@14.1.2", "", { "dependencies": { "@types/linkify-it": "^5", "@types/mdurl": "^2" } }, "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog=="],
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "dompurify": "^3.4.11",
     "drizzle-orm": "^0.45.2",
     "echarts": "^6.1.0",
+    "fflate": "^0.8.3",
     "fuse.js": "^7.4.2",
     "jose": "^6",
     "katex": "^0.17.0",
@@ -86,6 +87,7 @@
     "tailwindcss": "^4.3.2",
     "tiptap-markdown": "^0.9.0",
     "wawa-lipsync": "^0.0.2",
+    "xml-crypto": "^6.1.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/scripts/emit-beta-test.ts
+++ b/scripts/emit-beta-test.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env bun
+/**
+ * Manual live-beta smoke test — run with `bun scripts/emit-beta-test.ts` after
+ * `scripts/gen-beta-cert.sh`. Emits one boleta (B999-1, DNI client) and one
+ * factura (F999-1, RUC client) to SUNAT's public beta sandbox and prints the
+ * CDR for each. DoD = both ResponseCode 0. Not a vitest file — SUNAT's beta
+ * endpoint is a live network dependency, this is deliberately manual.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { emitToBeta, type EmissionInvoice } from '../src/server/finance/emission/index.ts';
+
+const certDir = join(import.meta.dirname, '..', '.beta-cert');
+const certPem = readFileSync(join(certDir, 'cert.pem'), 'utf8');
+const keyPem = readFileSync(join(certDir, 'key.pem'), 'utf8');
+
+const today = new Date().toISOString().slice(0, 10);
+
+const boleta: EmissionInvoice = {
+  docType: '03',
+  serie: 'B999',
+  correlativo: '1',
+  issueDate: today,
+  currency: 'PEN',
+  emitter: {
+    ruc: '20611172967',
+    razonSocial: 'FACES BETA SAC',
+    ubigeo: '150101',
+    address: 'AV BETA 123, LIMA',
+  },
+  client: { docType: '1', docNumber: '12345678', name: 'CLIENTE DE PRUEBA' },
+  lines: [
+    { description: 'Servicio de prueba 1', quantity: 1, unitPriceInclTax: 118 },
+    { description: 'Servicio de prueba 2', quantity: 2, unitPriceInclTax: 59.9 },
+  ],
+};
+
+const factura: EmissionInvoice = {
+  ...boleta,
+  docType: '01',
+  serie: 'F999',
+  client: { docType: '6', docNumber: '20611172967', name: 'EMPRESA DE PRUEBA SAC' },
+};
+
+for (const [label, inv] of [
+  ['boleta', boleta],
+  ['factura', factura],
+] as const) {
+  console.log(`\n--- emitting ${label} ${inv.serie}-${inv.correlativo} ---`);
+  try {
+    const cdr = await emitToBeta(inv, certPem, keyPem);
+    console.log(cdr);
+  } catch (e) {
+    console.error(e);
+  }
+  await new Promise((r) => setTimeout(r, 3000)); // beta gateway rate-limits back-to-back requests
+}

--- a/scripts/gen-beta-cert.sh
+++ b/scripts/gen-beta-cert.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Self-signed test cert for SUNAT's beta sandbox — no registered certificate
+# required in beta. Output is gitignored (.beta-cert/); NEVER commit key material.
+set -euo pipefail
+
+OUT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.beta-cert"
+mkdir -p "$OUT_DIR"
+
+openssl req -x509 -newkey rsa:2048 -sha256 -days 3650 -nodes \
+  -keyout "$OUT_DIR/key.pem" \
+  -out "$OUT_DIR/cert.pem" \
+  -subj "/C=PE/O=FACES BETA/CN=20611172967"
+
+echo "Wrote $OUT_DIR/cert.pem + $OUT_DIR/key.pem (gitignored, beta sandbox only)"

--- a/src/server/finance/emission/cdr.test.ts
+++ b/src/server/finance/emission/cdr.test.ts
@@ -1,0 +1,32 @@
+import { strToU8, zipSync } from 'fflate';
+import { describe, expect, it } from 'vitest';
+import { parseCdr } from './cdr';
+
+const ACCEPTED_CDR_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+<cac:DocumentResponse>
+<cac:Response>
+<cbc:ResponseCode>0</cbc:ResponseCode>
+<cbc:Description>La Boleta numero B999-1, ha sido aceptada</cbc:Description>
+</cac:Response>
+<cac:DocumentReference>
+<cbc:ID>B999-1</cbc:ID>
+</cac:DocumentReference>
+</cac:DocumentResponse>
+</ApplicationResponse>`;
+
+function fixtureZip(entryName: string, xml: string): Uint8Array {
+  return zipSync({ [entryName]: strToU8(xml) });
+}
+
+describe('parseCdr', () => {
+  it('parses ResponseCode and Description from the R-*.xml entry', () => {
+    const zip = fixtureZip('R-20611172967-03-B999-1.xml', ACCEPTED_CDR_XML);
+    expect(parseCdr(zip)).toEqual({ responseCode: '0', description: 'La Boleta numero B999-1, ha sido aceptada', notes: [] });
+  });
+
+  it('throws when the zip has no R-*.xml entry', () => {
+    const zip = fixtureZip('unexpected.xml', ACCEPTED_CDR_XML);
+    expect(() => parseCdr(zip)).toThrow(/R-\*\.xml/);
+  });
+});

--- a/src/server/finance/emission/cdr.ts
+++ b/src/server/finance/emission/cdr.ts
@@ -1,0 +1,28 @@
+import type { CdrResult } from './types';
+import { unzipToText } from './zip';
+
+/** Namespace-agnostic single-tag text extractor (same approach as soap.ts — the
+ * CDR ApplicationResponse is small and well-known, no need for a full XML parser). */
+function extractTag(xml: string, tag: string): string | null {
+  const m = xml.match(new RegExp(`<(?:\\w+:)?${tag}[^>]*>([\\s\\S]*?)</(?:\\w+:)?${tag}>`));
+  return m ? m[1].trim() : null;
+}
+
+function extractAllTags(xml: string, tag: string): string[] {
+  const re = new RegExp(`<(?:\\w+:)?${tag}[^>]*>([\\s\\S]*?)</(?:\\w+:)?${tag}>`, 'g');
+  return [...xml.matchAll(re)].map((m) => m[1].trim());
+}
+
+/** Unzips SUNAT's CDR (`R-*.xml`) and reads its ResponseCode/Description. `'0'` = accepted. */
+export function parseCdr(cdrZip: Uint8Array): CdrResult {
+  const files = unzipToText(cdrZip);
+  const entry = Object.entries(files).find(([name]) => /^R-.*\.xml$/i.test(name));
+  if (!entry) {
+    throw new Error(`SUNAT CDR zip has no R-*.xml entry (found: ${Object.keys(files).join(', ') || 'none'})`);
+  }
+  const [, xml] = entry;
+  const responseCode = extractTag(xml, 'ResponseCode') ?? '';
+  const description = extractTag(xml, 'Description') ?? '';
+  const notes = extractAllTags(xml, 'Note');
+  return { responseCode, description, notes };
+}

--- a/src/server/finance/emission/index.ts
+++ b/src/server/finance/emission/index.ts
@@ -1,0 +1,25 @@
+import { parseCdr } from './cdr';
+import { SUNAT_BETA_PASSWORD, SUNAT_BETA_USERNAME, sendBill } from './soap';
+import { signXml } from './sign';
+import type { CdrResult, EmissionInvoice } from './types';
+import { buildInvoiceXml } from './ubl';
+import { emissionFileBaseName, zipInvoiceXml } from './zip';
+
+export type { CdrResult, EmissionInvoice } from './types';
+
+/**
+ * Orchestrates build -> sign -> zip -> send -> parse against SUNAT's beta
+ * sandbox. Beta creds are hardcoded public documentation values (`MODDATOS`) —
+ * this function never touches the production endpoint.
+ */
+export async function emitToBeta(inv: EmissionInvoice, certPem: string, keyPem: string): Promise<CdrResult> {
+  const unsigned = buildInvoiceXml(inv);
+  const signed = signXml(unsigned, keyPem, certPem);
+  const fileBaseName = emissionFileBaseName(inv.emitter.ruc, inv.docType, inv.serie, inv.correlativo);
+  const zipBytes = zipInvoiceXml(fileBaseName, signed);
+  const { cdrZip } = await sendBill(`${fileBaseName}.zip`, zipBytes, {
+    username: SUNAT_BETA_USERNAME,
+    password: SUNAT_BETA_PASSWORD,
+  });
+  return parseCdr(cdrZip);
+}

--- a/src/server/finance/emission/sign.ts
+++ b/src/server/finance/emission/sign.ts
@@ -1,0 +1,37 @@
+import { SignedXml } from 'xml-crypto';
+
+/**
+ * SUNAT's documented default is RSA-SHA1. Verified live against the beta
+ * sandbox 2026-08-14: SHA1 was accepted (ResponseCode 0) — see PR description.
+ * Flip to sha256 here if a future SUNAT beta cutover starts rejecting sha1.
+ */
+const DIGEST_ALGORITHM = 'http://www.w3.org/2000/09/xmldsig#sha1';
+const SIGNATURE_ALGORITHM = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1';
+const C14N = 'http://www.w3.org/TR/2001/REC-xml-c14n-20010315';
+
+/**
+ * Enveloped XML-DSig over the whole `Invoice` document, placed inside
+ * `ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent` with Id="SignatureSP"
+ * (the Id `cac:Signature/cac:DigitalSignatureAttachment` in ubl.ts points at via
+ * `#SignatureSP`). Canonicalization/signing is xml-crypto's job — never hand-roll C14N.
+ */
+export function signXml(xml: string, key: string, cert: string): string {
+  const sig = new SignedXml({
+    privateKey: key,
+    publicCert: cert,
+    signatureAlgorithm: SIGNATURE_ALGORITHM,
+    canonicalizationAlgorithm: C14N,
+  });
+  sig.addReference({
+    xpath: '/*',
+    isEmptyUri: true,
+    transforms: ['http://www.w3.org/2000/09/xmldsig#enveloped-signature', C14N],
+    digestAlgorithm: DIGEST_ALGORITHM,
+  });
+  sig.computeSignature(xml, {
+    prefix: 'ds',
+    attrs: { Id: 'SignatureSP' },
+    location: { reference: "//*[local-name(.)='ExtensionContent']", action: 'append' },
+  });
+  return sig.getSignedXml();
+}

--- a/src/server/finance/emission/soap.test.ts
+++ b/src/server/finance/emission/soap.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { sendBill } from './soap';
+
+function xmlResponse(body: string, status = 200) {
+  return new Response(body, { status, headers: { 'content-type': 'text/xml' } });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('sendBill', () => {
+  it('extracts the base64 applicationResponse from a successful SOAP response', async () => {
+    const cdrBase64 = Buffer.from('fake-cdr-zip-bytes').toString('base64');
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      xmlResponse(`<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+<soapenv:Body><ser:sendBillResponse xmlns:ser="http://service.sunat.gob.pe">
+<applicationResponse>${cdrBase64}</applicationResponse>
+</ser:sendBillResponse></soapenv:Body></soapenv:Envelope>`),
+    );
+    const { cdrZip } = await sendBill('20611172967-03-B999-1.zip', new Uint8Array([1, 2, 3]), {
+      username: 'u',
+      password: 'p',
+    });
+    expect(Buffer.from(cdrZip).toString()).toBe('fake-cdr-zip-bytes');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://e-beta.sunat.gob.pe/ol-ti-itcpfegem-beta/billService');
+    expect((init as RequestInit).body).toContain('<fileName>20611172967-03-B999-1.zip</fileName>');
+    expect((init as RequestInit).body).toContain('<wsse:Username>u</wsse:Username>');
+  });
+
+  it('surfaces SUNAT SOAP faults with faultcode + faultstring', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      xmlResponse(`<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+<soapenv:Body><soapenv:Fault>
+<faultcode>soap-env:Client.3244</faultcode>
+<faultstring>Debe consignar la informacion del tipo de transaccion del comprobante</faultstring>
+</soapenv:Fault></soapenv:Body></soapenv:Envelope>`, 500),
+    );
+    await expect(
+      sendBill('x.zip', new Uint8Array(), { username: 'u', password: 'p' }),
+    ).rejects.toThrow(/soap-env:Client\.3244.*tipo de transaccion/s);
+  });
+
+  it('rejects with a clear message when the reply has neither a fault nor applicationResponse', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(xmlResponse('<html>not soap</html>', 401));
+    await expect(
+      sendBill('x.zip', new Uint8Array(), { username: 'u', password: 'p' }),
+    ).rejects.toThrow(/no applicationResponse/);
+  });
+});

--- a/src/server/finance/emission/soap.ts
+++ b/src/server/finance/emission/soap.ts
@@ -1,0 +1,83 @@
+/** Beta sandbox — nothing sent here is legally binding. See spec 2026-08-14-sunat-emission-beta-spec.md. */
+export const SUNAT_BETA_ENDPOINT = 'https://e-beta.sunat.gob.pe/ol-ti-itcpfegem-beta/billService';
+
+/** Public SUNAT documentation credentials for the beta sandbox — not a real secret. */
+export const SUNAT_BETA_USERNAME = '20611172967MODDATOS';
+export const SUNAT_BETA_PASSWORD = 'MODDATOS';
+
+/** Per-request timeout — a hung SUNAT response aborts instead of parking the caller forever. */
+const REQUEST_TIMEOUT_MS = 30_000;
+
+export interface SendBillOptions {
+  username: string;
+  password: string;
+  endpoint?: string;
+}
+
+/** Namespace-agnostic single-tag text extractor — the SOAP responses here are
+ * small and well-known, a full XML parser would be overkill. */
+function extractTag(xml: string, tag: string): string | null {
+  const m = xml.match(new RegExp(`<(?:\\w+:)?${tag}[^>]*>([\\s\\S]*?)</(?:\\w+:)?${tag}>`));
+  return m ? m[1].trim() : null;
+}
+
+/**
+ * Hand-built SOAP 1.1 `sendBill` call (no soap library — the envelope shape
+ * was validated with curl already, see spec). WS-Security UsernameToken auth,
+ * base64 zip in `contenido`. 30s timeout, no retries in this slice.
+ */
+export async function sendBill(
+  fileName: string,
+  zipBytes: Uint8Array,
+  opts: SendBillOptions,
+): Promise<{ cdrZip: Uint8Array }> {
+  const endpoint = opts.endpoint ?? SUNAT_BETA_ENDPOINT;
+  const contentBase64 = Buffer.from(zipBytes).toString('base64');
+  const envelope = `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.sunat.gob.pe" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+<soapenv:Header>
+<wsse:Security>
+<wsse:UsernameToken>
+<wsse:Username>${opts.username}</wsse:Username>
+<wsse:Password>${opts.password}</wsse:Password>
+</wsse:UsernameToken>
+</wsse:Security>
+</soapenv:Header>
+<soapenv:Body>
+<ser:sendBill>
+<fileName>${fileName}</fileName>
+<contentFile>${contentBase64}</contentFile>
+</ser:sendBill>
+</soapenv:Body>
+</soapenv:Envelope>`;
+
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/xml;charset=UTF-8', SOAPAction: '' },
+      body: envelope,
+      signal: ctrl.signal,
+    });
+  } catch (e) {
+    throw e instanceof Error && e.name === 'AbortError'
+      ? new Error(`SUNAT sendBill timed out after ${REQUEST_TIMEOUT_MS}ms`)
+      : e;
+  } finally {
+    clearTimeout(t);
+  }
+
+  const text = await res.text();
+  const faultstring = extractTag(text, 'faultstring');
+  if (faultstring) {
+    const faultcode = extractTag(text, 'faultcode') ?? 'unknown';
+    throw new Error(`SUNAT sendBill fault (${faultcode}): ${faultstring}`);
+  }
+  const applicationResponse = extractTag(text, 'applicationResponse');
+  if (!applicationResponse) {
+    throw new Error(`SUNAT sendBill: no applicationResponse in reply (HTTP ${res.status}): ${text.slice(0, 500)}`);
+  }
+  return { cdrZip: Uint8Array.from(Buffer.from(applicationResponse, 'base64')) };
+}

--- a/src/server/finance/emission/types.ts
+++ b/src/server/finance/emission/types.ts
@@ -1,0 +1,48 @@
+/**
+ * SUNAT beta emission — shared shapes. Totals/IGV are always DERIVED (18%,
+ * tax-inclusive line prices) — never accept them as input, that's how a caller
+ * ends up submitting an invoice whose lines don't sum to its own totals.
+ */
+
+/** '01' = factura, '03' = boleta (SUNAT InvoiceTypeCode, listID 0101). */
+export type EmissionDocType = '01' | '03';
+
+/** '1' = DNI, '6' = RUC (SUNAT PartyIdentification schemeID / catalog 06). */
+export type ClientDocType = '1' | '6';
+
+export interface EmissionLine {
+  description: string;
+  quantity: number;
+  /** Unit price INCLUDING IGV (FACES prices are always tax-inclusive). */
+  unitPriceInclTax: number;
+}
+
+export interface EmissionInvoice {
+  docType: EmissionDocType;
+  /** 4-char SUNAT series, e.g. "BE01" or "F999". */
+  serie: string;
+  correlativo: string;
+  /** YYYY-MM-DD. */
+  issueDate: string;
+  currency: 'PEN';
+  emitter: {
+    ruc: string;
+    razonSocial: string;
+    /** 6-digit SUNAT ubigeo. Omit only for quick beta smoke tests. */
+    ubigeo?: string;
+    address?: string;
+  };
+  client: {
+    docType: ClientDocType;
+    docNumber: string;
+    name: string;
+  };
+  lines: EmissionLine[];
+}
+
+/** Parsed SUNAT CDR (Constancia de Recepción). `responseCode === '0'` = accepted. */
+export interface CdrResult {
+  responseCode: string;
+  description: string;
+  notes: string[];
+}

--- a/src/server/finance/emission/ubl.test.ts
+++ b/src/server/finance/emission/ubl.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { amountInWords, buildInvoiceXml, computeTotals } from './ubl';
+import type { EmissionInvoice } from './types';
+
+const base: EmissionInvoice = {
+  docType: '03',
+  serie: 'B999',
+  correlativo: '1',
+  issueDate: '2026-08-14',
+  currency: 'PEN',
+  emitter: { ruc: '20611172967', razonSocial: 'FACES BETA SAC', ubigeo: '150101', address: 'AV BETA 123' },
+  client: { docType: '1', docNumber: '12345678', name: 'CLIENTE DE PRUEBA' },
+  lines: [
+    { description: 'Line 1', quantity: 3, unitPriceInclTax: 10.33 },
+    { description: 'Line 2', quantity: 1, unitPriceInclTax: 7.77 },
+    { description: 'Line 3', quantity: 2, unitPriceInclTax: 4.45 },
+  ],
+};
+
+describe('computeTotals', () => {
+  it('keeps document totals exactly consistent with the sum of line totals (odd céntimos)', () => {
+    const totals = computeTotals(base);
+    const sumExcl = totals.lines.reduce((s, l) => s + l.totalExclTax, 0);
+    const sumIgv = totals.lines.reduce((s, l) => s + l.igv, 0);
+    const sumIncl = totals.lines.reduce((s, l) => s + l.totalInclTax, 0);
+    expect(totals.lineExtensionAmount).toBeCloseTo(sumExcl, 10);
+    expect(totals.igvAmount).toBeCloseTo(sumIgv, 10);
+    expect(totals.taxInclusiveAmount).toBeCloseTo(sumIncl, 10);
+    expect(totals.payableAmount).toBe(totals.taxInclusiveAmount);
+    // every line's own exclTax + igv reconstructs its inclTax total exactly
+    for (const l of totals.lines) {
+      expect(Math.round((l.totalExclTax + l.igv) * 100) / 100).toBe(l.totalInclTax);
+    }
+  });
+
+  it('rounds each line half-up to 2 decimals', () => {
+    const totals = computeTotals(base);
+    for (const l of totals.lines) {
+      expect(l.totalInclTax).toBe(Math.round(l.totalInclTax * 100) / 100);
+      expect(l.totalExclTax).toBe(Math.round(l.totalExclTax * 100) / 100);
+    }
+  });
+});
+
+describe('amountInWords', () => {
+  it('renders a known amount', () => {
+    expect(amountInWords(236)).toBe('SON DOSCIENTOS TREINTA Y SEIS CON 00/100 SOLES');
+  });
+
+  it('handles cents, teens, and the twenty-one contraction', () => {
+    expect(amountInWords(21.5)).toBe('SON VEINTIUNO CON 50/100 SOLES');
+    expect(amountInWords(0.05)).toBe('SON CERO CON 05/100 SOLES');
+  });
+});
+
+describe('buildInvoiceXml', () => {
+  it('builds a well-formed document with the expected ID, type code, and extension placeholder', () => {
+    const xml = buildInvoiceXml(base);
+    expect(xml).toContain('<cbc:ID>B999-1</cbc:ID>');
+    expect(xml).toContain('<cbc:InvoiceTypeCode listID="0101">03</cbc:InvoiceTypeCode>');
+    expect(xml).toContain('<ext:ExtensionContent/>');
+    expect(xml).toContain('<cbc:URI>#SignatureSP</cbc:URI>');
+    // one InvoiceLine per input line
+    expect(xml.match(/<cac:InvoiceLine>/g)).toHaveLength(3);
+  });
+
+  it('reports document totals consistent with LegalMonetaryTotal', () => {
+    const totals = computeTotals(base);
+    const xml = buildInvoiceXml(base);
+    expect(xml).toContain(`<cbc:PayableAmount currencyID="PEN">${totals.payableAmount.toFixed(2)}</cbc:PayableAmount>`);
+    expect(xml).toContain(`<cbc:LineExtensionAmount currencyID="PEN">${totals.lineExtensionAmount.toFixed(2)}</cbc:LineExtensionAmount>`);
+  });
+
+  it('escapes XML-special characters in free-text fields (no CDATA — plain escaped text)', () => {
+    const xml = buildInvoiceXml({ ...base, client: { ...base.client, name: 'CLIENTE "A" & <B>' } });
+    expect(xml).toContain('<cbc:RegistrationName>CLIENTE &quot;A&quot; &amp; &lt;B&gt;</cbc:RegistrationName>');
+    expect(xml).not.toContain('CDATA');
+  });
+});

--- a/src/server/finance/emission/ubl.ts
+++ b/src/server/finance/emission/ubl.ts
@@ -1,0 +1,257 @@
+import type { EmissionInvoice, EmissionLine } from './types';
+
+/** FACES reality: IGV is always 18%, prices are always tax-inclusive. */
+const IGV_RATE = 0.18;
+
+/** Round half-up — Math.round already does this for positive amounts, but the
+ * intent (banker's rounding is NOT what SUNAT wants) is worth spelling out. */
+function round(n: number, decimals: number): number {
+  const f = 10 ** decimals;
+  return Math.round((n + Number.EPSILON) * f) / f;
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+interface LineTotals {
+  line: EmissionLine;
+  /** Line total WITH IGV, round2 — the authoritative source amount. */
+  totalInclTax: number;
+  /** Line total WITHOUT IGV, derived from totalInclTax so exclTax + igv === inclTax exactly. */
+  totalExclTax: number;
+  igv: number;
+  /** Reference unit price without IGV, 6dp (informational — LineExtensionAmount is authoritative). */
+  unitPriceExclTax: number;
+}
+
+export interface InvoiceTotals {
+  lines: LineTotals[];
+  lineExtensionAmount: number;
+  igvAmount: number;
+  taxInclusiveAmount: number;
+  payableAmount: number;
+}
+
+/**
+ * Derive per-line and document totals from tax-inclusive unit prices.
+ * Every line's exclTax/igv split is computed FROM its own rounded inclTax
+ * total, so document totals (plain sums of line totals) are consistent with
+ * the lines by construction — no independent rounding path that could drift.
+ */
+export function computeTotals(inv: EmissionInvoice): InvoiceTotals {
+  const lines = inv.lines.map((line): LineTotals => {
+    const totalInclTax = round(line.quantity * line.unitPriceInclTax, 2);
+    const totalExclTax = round(totalInclTax / (1 + IGV_RATE), 2);
+    const igv = round(totalInclTax - totalExclTax, 2);
+    const unitPriceExclTax = round(totalExclTax / line.quantity, 6);
+    return { line, totalInclTax, totalExclTax, igv, unitPriceExclTax };
+  });
+  const lineExtensionAmount = round(lines.reduce((s, l) => s + l.totalExclTax, 0), 2);
+  const igvAmount = round(lines.reduce((s, l) => s + l.igv, 0), 2);
+  const taxInclusiveAmount = round(lines.reduce((s, l) => s + l.totalInclTax, 0), 2);
+  return { lines, lineExtensionAmount, igvAmount, taxInclusiveAmount, payableAmount: taxInclusiveAmount };
+}
+
+const UNITS = ['', 'UNO', 'DOS', 'TRES', 'CUATRO', 'CINCO', 'SEIS', 'SIETE', 'OCHO', 'NUEVE'];
+const TEENS = [
+  'DIEZ', 'ONCE', 'DOCE', 'TRECE', 'CATORCE', 'QUINCE',
+  'DIECISEIS', 'DIECISIETE', 'DIECIOCHO', 'DIECINUEVE',
+];
+const TWENTIES = [
+  'VEINTE', 'VEINTIUNO', 'VEINTIDOS', 'VEINTITRES', 'VEINTICUATRO',
+  'VEINTICINCO', 'VEINTISEIS', 'VEINTISIETE', 'VEINTIOCHO', 'VEINTINUEVE',
+];
+const TENS = ['', '', '', 'TREINTA', 'CUARENTA', 'CINCUENTA', 'SESENTA', 'SETENTA', 'OCHENTA', 'NOVENTA'];
+const HUNDREDS = [
+  '', 'CIENTO', 'DOSCIENTOS', 'TRESCIENTOS', 'CUATROCIENTOS', 'QUINIENTOS',
+  'SEISCIENTOS', 'SETECIENTOS', 'OCHOCIENTOS', 'NOVECIENTOS',
+];
+
+function twoDigits(n: number): string {
+  if (n < 10) return UNITS[n];
+  if (n < 20) return TEENS[n - 10];
+  if (n < 30) return TWENTIES[n - 20];
+  const t = Math.floor(n / 10);
+  const u = n % 10;
+  return u > 0 ? `${TENS[t]} Y ${UNITS[u]}` : TENS[t];
+}
+
+function threeDigits(n: number): string {
+  if (n === 0) return '';
+  if (n === 100) return 'CIEN';
+  const h = Math.floor(n / 100);
+  const r = n % 100;
+  const parts: string[] = [];
+  if (h > 0) parts.push(HUNDREDS[h]);
+  if (r > 0) parts.push(twoDigits(r));
+  return parts.join(' ');
+}
+
+/** Spanish (Peru) integer-to-words. Caps at 999,999,999 — FACES invoices never
+ * get near that, and SUNAT doesn't machine-validate this legend's wording. */
+function integerToWords(n: number): string {
+  if (n === 0) return 'CERO';
+  const millones = Math.floor(n / 1_000_000);
+  const miles = Math.floor((n % 1_000_000) / 1000);
+  const resto = n % 1000;
+  const parts: string[] = [];
+  if (millones > 0) parts.push(millones === 1 ? 'UN MILLON' : `${threeDigits(millones)} MILLONES`);
+  if (miles > 0) parts.push(miles === 1 ? 'MIL' : `${threeDigits(miles)} MIL`);
+  if (resto > 0 || parts.length === 0) parts.push(threeDigits(resto));
+  return parts.join(' ');
+}
+
+/** SUNAT legend 1000: "SON <monto en letras> CON NN/100 SOLES". */
+export function amountInWords(amount: number): string {
+  const intPart = Math.floor(amount);
+  const cents = Math.round((amount - intPart) * 100);
+  return `SON ${integerToWords(intPart)} CON ${String(cents).padStart(2, '0')}/100 SOLES`;
+}
+
+function supplierAddress(inv: EmissionInvoice): string {
+  if (!inv.emitter.ubigeo) return '<cac:Country><cbc:IdentificationCode>PE</cbc:IdentificationCode></cac:Country>';
+  const line = inv.emitter.address
+    ? `<cac:AddressLine><cbc:Line>${escapeXml(inv.emitter.address)}</cbc:Line></cac:AddressLine>`
+    : '';
+  return (
+    `<cbc:ID>${escapeXml(inv.emitter.ubigeo)}</cbc:ID>` +
+    '<cbc:AddressTypeCode>0000</cbc:AddressTypeCode>' +
+    `${line}` +
+    '<cac:Country><cbc:IdentificationCode>PE</cbc:IdentificationCode></cac:Country>'
+  );
+}
+
+function lineXml(id: number, l: LineTotals): string {
+  return `<cac:InvoiceLine>
+<cbc:ID>${id}</cbc:ID>
+<cbc:InvoicedQuantity unitCode="NIU">${l.line.quantity}</cbc:InvoicedQuantity>
+<cbc:LineExtensionAmount currencyID="PEN">${l.totalExclTax.toFixed(2)}</cbc:LineExtensionAmount>
+<cac:PricingReference>
+<cac:AlternativeConditionPrice>
+<cbc:PriceAmount currencyID="PEN">${l.line.unitPriceInclTax.toFixed(6)}</cbc:PriceAmount>
+<cbc:PriceTypeCode>01</cbc:PriceTypeCode>
+</cac:AlternativeConditionPrice>
+</cac:PricingReference>
+<cac:TaxTotal>
+<cbc:TaxAmount currencyID="PEN">${l.igv.toFixed(2)}</cbc:TaxAmount>
+<cac:TaxSubtotal>
+<cbc:TaxableAmount currencyID="PEN">${l.totalExclTax.toFixed(2)}</cbc:TaxableAmount>
+<cbc:TaxAmount currencyID="PEN">${l.igv.toFixed(2)}</cbc:TaxAmount>
+<cac:TaxCategory>
+<cbc:Percent>18</cbc:Percent>
+<cbc:TaxExemptionReasonCode>10</cbc:TaxExemptionReasonCode>
+<cac:TaxScheme>
+<cbc:ID>1000</cbc:ID>
+<cbc:Name>IGV</cbc:Name>
+<cbc:TaxTypeCode>VAT</cbc:TaxTypeCode>
+</cac:TaxScheme>
+</cac:TaxCategory>
+</cac:TaxSubtotal>
+</cac:TaxTotal>
+<cac:Item>
+<cbc:Description>${escapeXml(l.line.description)}</cbc:Description>
+</cac:Item>
+<cac:Price>
+<cbc:PriceAmount currencyID="PEN">${l.unitPriceExclTax.toFixed(6)}</cbc:PriceAmount>
+</cac:Price>
+</cac:InvoiceLine>`;
+}
+
+/**
+ * Build the unsigned UBL 2.1 Invoice document. `sign.ts` fills the
+ * `ext:ExtensionContent` placeholder below. Structure verified against a
+ * known-accepted Greenter Factura-Gravada.xml sample (Peru UBL 2.1,
+ * CustomizationID 2.0) — see PR description for source.
+ */
+export function buildInvoiceXml(inv: EmissionInvoice): string {
+  const totals = computeTotals(inv);
+  const id = `${inv.serie}-${inv.correlativo}`;
+  const lines = totals.lines.map((l, i) => lineXml(i + 1, l)).join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+<ext:UBLExtensions>
+<ext:UBLExtension>
+<ext:ExtensionContent/>
+</ext:UBLExtension>
+</ext:UBLExtensions>
+<cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+<cbc:CustomizationID>2.0</cbc:CustomizationID>
+<cbc:ID>${escapeXml(id)}</cbc:ID>
+<cbc:IssueDate>${inv.issueDate}</cbc:IssueDate>
+<cbc:InvoiceTypeCode listID="0101">${inv.docType}</cbc:InvoiceTypeCode>
+<cbc:Note languageLocaleID="1000">${amountInWords(totals.payableAmount)}</cbc:Note>
+<cbc:DocumentCurrencyCode>${inv.currency}</cbc:DocumentCurrencyCode>
+<cac:Signature>
+<cbc:ID>${escapeXml(inv.emitter.ruc)}</cbc:ID>
+<cac:SignatoryParty>
+<cac:PartyIdentification>
+<cbc:ID>${escapeXml(inv.emitter.ruc)}</cbc:ID>
+</cac:PartyIdentification>
+<cac:PartyName>
+<cbc:Name>${escapeXml(inv.emitter.razonSocial)}</cbc:Name>
+</cac:PartyName>
+</cac:SignatoryParty>
+<cac:DigitalSignatureAttachment>
+<cac:ExternalReference>
+<cbc:URI>#SignatureSP</cbc:URI>
+</cac:ExternalReference>
+</cac:DigitalSignatureAttachment>
+</cac:Signature>
+<cac:AccountingSupplierParty>
+<cac:Party>
+<cac:PartyIdentification>
+<cbc:ID schemeID="6">${escapeXml(inv.emitter.ruc)}</cbc:ID>
+</cac:PartyIdentification>
+<cac:PartyLegalEntity>
+<cbc:RegistrationName>${escapeXml(inv.emitter.razonSocial)}</cbc:RegistrationName>
+<cac:RegistrationAddress>
+${supplierAddress(inv)}
+</cac:RegistrationAddress>
+</cac:PartyLegalEntity>
+</cac:Party>
+</cac:AccountingSupplierParty>
+<cac:AccountingCustomerParty>
+<cac:Party>
+<cac:PartyIdentification>
+<cbc:ID schemeID="${inv.client.docType}">${escapeXml(inv.client.docNumber)}</cbc:ID>
+</cac:PartyIdentification>
+<cac:PartyLegalEntity>
+<cbc:RegistrationName>${escapeXml(inv.client.name)}</cbc:RegistrationName>
+</cac:PartyLegalEntity>
+</cac:Party>
+</cac:AccountingCustomerParty>
+<!-- Facturas rejected by beta with SUNAT fault 3244 ("tipo de transaccion del
+     comprobante") until FormaPago was added — not in the spec's element list,
+     added after live iteration. Harmless (and accepted) on boletas too. -->
+<cac:PaymentTerms>
+<cbc:ID>FormaPago</cbc:ID>
+<cbc:PaymentMeansID>Contado</cbc:PaymentMeansID>
+</cac:PaymentTerms>
+<cac:TaxTotal>
+<cbc:TaxAmount currencyID="PEN">${totals.igvAmount.toFixed(2)}</cbc:TaxAmount>
+<cac:TaxSubtotal>
+<cbc:TaxableAmount currencyID="PEN">${totals.lineExtensionAmount.toFixed(2)}</cbc:TaxableAmount>
+<cbc:TaxAmount currencyID="PEN">${totals.igvAmount.toFixed(2)}</cbc:TaxAmount>
+<cac:TaxCategory>
+<cac:TaxScheme>
+<cbc:ID>1000</cbc:ID>
+<cbc:Name>IGV</cbc:Name>
+<cbc:TaxTypeCode>VAT</cbc:TaxTypeCode>
+</cac:TaxScheme>
+</cac:TaxCategory>
+</cac:TaxSubtotal>
+</cac:TaxTotal>
+<cac:LegalMonetaryTotal>
+<cbc:LineExtensionAmount currencyID="PEN">${totals.lineExtensionAmount.toFixed(2)}</cbc:LineExtensionAmount>
+<cbc:TaxInclusiveAmount currencyID="PEN">${totals.taxInclusiveAmount.toFixed(2)}</cbc:TaxInclusiveAmount>
+<cbc:PayableAmount currencyID="PEN">${totals.payableAmount.toFixed(2)}</cbc:PayableAmount>
+</cac:LegalMonetaryTotal>
+${lines}
+</Invoice>`;
+}

--- a/src/server/finance/emission/zip.test.ts
+++ b/src/server/finance/emission/zip.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { emissionFileBaseName, unzipToText, zipInvoiceXml } from './zip';
+
+describe('emissionFileBaseName', () => {
+  it('follows SUNAT file naming law: RUC-docType-SERIE-CORRELATIVO', () => {
+    expect(emissionFileBaseName('20611172967', '03', 'B999', '1')).toBe('20611172967-03-B999-1');
+  });
+});
+
+describe('zipInvoiceXml / unzipToText', () => {
+  it('round-trips the XML under {fileBaseName}.xml inside {fileBaseName}.zip', () => {
+    const base = emissionFileBaseName('20611172967', '01', 'F999', '1');
+    const xml = '<Invoice>hello</Invoice>';
+    const zipped = zipInvoiceXml(base, xml);
+    const files = unzipToText(zipped);
+    expect(Object.keys(files)).toEqual([`${base}.xml`]);
+    expect(files[`${base}.xml`]).toBe(xml);
+  });
+});

--- a/src/server/finance/emission/zip.ts
+++ b/src/server/finance/emission/zip.ts
@@ -1,0 +1,19 @@
+import { strFromU8, strToU8, unzipSync, zipSync } from 'fflate';
+
+/** SUNAT's file naming law: `{RUC}-{docType}-{SERIE}-{CORRELATIVO}`. */
+export function emissionFileBaseName(ruc: string, docType: string, serie: string, correlativo: string): string {
+  return `${ruc}-${docType}-${serie}-${correlativo}`;
+}
+
+/** Zips the signed XML under `{fileBaseName}.xml` inside `{fileBaseName}.zip`, as SUNAT requires. */
+export function zipInvoiceXml(fileBaseName: string, xml: string): Uint8Array {
+  return zipSync({ [`${fileBaseName}.xml`]: strToU8(xml) }, { level: 6 });
+}
+
+/** Unzips a CDR (or any single/multi-entry SUNAT zip) into filename -> decoded text. */
+export function unzipToText(bytes: Uint8Array): Record<string, string> {
+  const entries = unzipSync(bytes);
+  const out: Record<string, string> = {};
+  for (const [name, data] of Object.entries(entries)) out[name] = strFromU8(data);
+  return out;
+}


### PR DESCRIPTION
## What

Spec: `specs/2026-08-14-sunat-emission-beta-spec.md` (meta-repo). First slice of
the write side of direct SUNAT integration — given an invoice-shaped input,
produce a signed UBL 2.1 XML, submit it to SUNAT's beta sandbox via SOAP
`sendBill`, and parse the CDR. Beta only, nothing legally binding.

New `src/server/finance/emission/`: `types.ts`, `ubl.ts` (build + totals +
es-PE amount-in-words legend), `sign.ts` (xml-crypto enveloped XML-DSig),
`soap.ts` (hand-built SOAP 1.1 envelope, WS-Security UsernameToken),
`zip.ts` (fflate), `cdr.ts` (CDR parse), `index.ts` (`emitToBeta()`
orchestration). Plus `scripts/gen-beta-cert.sh` (self-signed test cert,
gitignored output) and `scripts/emit-beta-test.ts` (manual live-beta script).

## Live beta results (verbatim CDRs)

Both runs against `https://e-beta.sunat.gob.pe/ol-ti-itcpfegem-beta/billService`,
credentials `20611172967MODDATOS` / `MODDATOS` (public SUNAT documentation
values), digest/signature algorithm **RSA-SHA1** (SUNAT's documented default —
accepted on the first try, no need to fall back to SHA256):

**Boleta B999-1** (2 lines, DNI client):
```
{
  responseCode: "0",
  description: "La Boleta numero B999-1, ha sido aceptada",
  notes: [],
}
```

**Factura F999-1** (RUC client):
```
{
  responseCode: "0",
  description: "La Factura numero F999-1, ha sido aceptada",
  notes: [],
}
```

Both `ResponseCode 0` — DoD met, no resumen-diario fallback needed.

## Spec deviations

- **Added `cac:PaymentTerms`/FormaPago** (not in the spec's element list). The
  factura was first rejected by beta with SOAP fault `soap-env:Client.3244`:
  "Debe consignar la informacion del tipo de transaccion del comprobante."
  Cross-referencing a known-accepted Greenter `Factura-Gravada.xml` sample
  showed a `cac:PaymentTerms` block (`FormaPago` / `Contado`) that my initial
  build omitted. Adding it fixed the fault; it's harmless (and accepted) on
  boletas too, so both doc types always emit it.
- **`cac:Signature` element added** (also not explicitly in the spec's element
  table, but present in every working reference sample and required by SUNAT's
  structuring rules) — points at the extension signature via
  `cac:DigitalSignatureAttachment/cac:ExternalReference/cbc:URI = #SignatureSP`,
  matching the `Id="SignatureSP"` used in `sign.ts`.
- Free text (customer/supplier names, item descriptions, address lines) is
  emitted as plain XML-escaped text, not `CDATA`. An earlier draft wrapped
  escaped text in CDATA, which double-encodes (CDATA content is literal, not
  entity-decoded) — caught before commit via a dedicated escaping unit test,
  not by the live run (my beta smoke-test strings happened to contain no
  special characters).

## SUNAT beta quirks worth remembering

- `SOAPAction: ''` (empty) is accepted — no need to guess the actual action URI.
- The beta gateway rate-limits back-to-back requests: firing two `sendBill`
  calls immediately in sequence got a plain nginx `401 Authorization Required`
  (not a SUNAT-level fault) on the second one. `scripts/emit-beta-test.ts`
  waits 3s between the boleta and factura calls to avoid this.
- Boletas travel fine via `sendBill` in beta (not just resumen diario) — no
  need to build the resumen-diario path for this slice, per spec §2.3.
- SUNAT's fault XML is genuinely descriptive (`faultstring` names the exact
  missing field/rule) — iterating against it was fast once the SOAP envelope
  and CDR unzip were both plumbed correctly.

## Gates

- `bun run check` — 0 errors, 0 warnings.
- `bun run test` — 343 files / 2684 tests passed, 0 failures (full suite,
  exit code captured directly, not through a pipe).
- 14 new unit tests: totals consistency (3 lines, odd céntimos), file naming,
  CDR parse of a fixture, SOAP fault surfacing, XML escaping.

## Out of scope (per spec)

Production endpoint & real certificate, serie/correlativo allocation (DB),
resumen diario / comunicación de baja, POS wiring, DB writes, retry/queue
infra, credential UI, new API routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzD6Vn4qeMGvhXZLLeD1Ls