### PR TITLE
SUNAT resumen diario + comunicación de baja (beta library)

### DIFF
--- a/scripts/summary-beta-test.ts
+++ b/scripts/summary-beta-test.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env bun
+/**
+ * Manual live-beta smoke test for the resumen/baja slice — run with
+ * `bun scripts/summary-beta-test.ts` after `scripts/gen-beta-cert.sh`.
+ * Not a vitest file — SUNAT's beta endpoint is a live network dependency,
+ * this is deliberately manual (same pattern as emit-beta-test.ts).
+ *
+ * Steps (DoD from specs/2026-08-14-sunat-resumen-baja-spec.md):
+ * 1. Emit two boletas B998-1, B998-2.
+ * 2. submitResumen RC with both (estado 1) -> CDR ResponseCode 0.
+ * 3. submitResumen RC with B998-2 estado 3 (anulacion) -> accepted.
+ * 4. Emit factura F998-1, then submitBaja RA for it -> accepted.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { emitToBeta, submitBaja, submitResumen, type EmissionInvoice } from '../src/server/finance/emission/index.ts';
+
+const certDir = join(import.meta.dirname, '..', '.beta-cert');
+const certPem = readFileSync(join(certDir, 'cert.pem'), 'utf8');
+const keyPem = readFileSync(join(certDir, 'key.pem'), 'utf8');
+
+const today = new Date().toISOString().slice(0, 10);
+const emitter = { ruc: '20611172967', razonSocial: 'FACES BETA SAC' };
+
+const boleta1: EmissionInvoice = {
+  docType: '03',
+  serie: 'B998',
+  correlativo: '1',
+  issueDate: today,
+  currency: 'PEN',
+  emitter: { ...emitter, ubigeo: '150101', address: 'AV BETA 123, LIMA' },
+  client: { docType: '1', docNumber: '12345678', name: 'CLIENTE DE PRUEBA UNO' },
+  lines: [{ description: 'Servicio de prueba resumen 1', quantity: 1, unitPriceInclTax: 118 }],
+};
+
+const boleta2: EmissionInvoice = {
+  ...boleta1,
+  correlativo: '2',
+  client: { docType: '1', docNumber: '87654321', name: 'CLIENTE DE PRUEBA DOS' },
+  lines: [{ description: 'Servicio de prueba resumen 2', quantity: 1, unitPriceInclTax: 59.9 }],
+};
+
+const factura: EmissionInvoice = {
+  ...boleta1,
+  docType: '01',
+  serie: 'F998',
+  correlativo: '1',
+  client: { docType: '6', docNumber: '20611172967', name: 'EMPRESA DE PRUEBA SAC' },
+};
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function step(label: string, fn: () => Promise<unknown>) {
+  console.log(`\n--- ${label} ---`);
+  try {
+    const result = await fn();
+    console.log(result);
+  } catch (e) {
+    console.error(e);
+  }
+  await sleep(3000); // beta gateway rate-limits back-to-back requests
+}
+
+await step('emit boleta B998-1', () => emitToBeta(boleta1, certPem, keyPem));
+await step('emit boleta B998-2', () => emitToBeta(boleta2, certPem, keyPem));
+
+await step('submitResumen RC-1: B998-1 + B998-2, both estado 1', () =>
+  submitResumen(
+    {
+      emitter,
+      correlativo: '1',
+      referenceDate: today,
+      issueDate: today,
+      lines: [
+        { invoice: boleta1, estado: '1' },
+        { invoice: boleta2, estado: '1' },
+      ],
+    },
+    certPem,
+    keyPem,
+  ),
+);
+
+await step('submitResumen RC-2: B998-2 estado 3 (anulacion)', () =>
+  submitResumen(
+    {
+      emitter,
+      correlativo: '2',
+      referenceDate: today,
+      issueDate: today,
+      lines: [{ invoice: boleta2, estado: '3' }],
+    },
+    certPem,
+    keyPem,
+  ),
+);
+
+await step('emit factura F998-1', () => emitToBeta(factura, certPem, keyPem));
+
+await step('submitBaja RA-1: F998-1', () =>
+  submitBaja(
+    {
+      emitter,
+      correlativo: '1',
+      referenceDate: today,
+      issueDate: today,
+      lines: [{ docType: '01', serie: 'F998', correlativo: '1', motivo: 'ERROR EN EL COMPROBANTE' }],
+    },
+    certPem,
+    keyPem,
+  ),
+);

--- a/src/server/finance/emission/index.test.ts
+++ b/src/server/finance/emission/index.test.ts
@@ -1,0 +1,124 @@
+import { strToU8, zipSync } from 'fflate';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BajaOptions, ResumenOptions } from './summary';
+import type { EmissionInvoice } from './types';
+
+vi.mock('./sign', () => ({ signXml: (xml: string) => xml }));
+
+const sendSummaryMock = vi.fn();
+const getStatusMock = vi.fn();
+vi.mock('./soap', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./soap')>();
+  return {
+    ...actual,
+    sendSummary: (...args: Parameters<typeof actual.sendSummary>) => sendSummaryMock(...args),
+    getStatus: (...args: Parameters<typeof actual.getStatus>) => getStatusMock(...args),
+  };
+});
+
+// Import after the mocks so `submitResumen`/`submitBaja` pick up the mocked deps.
+const { submitResumen, submitBaja } = await import('./index');
+
+function cdrZip(responseCode: string, description: string): Uint8Array {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+<cac:DocumentResponse><cac:Response>
+<cbc:ResponseCode>${responseCode}</cbc:ResponseCode>
+<cbc:Description>${description}</cbc:Description>
+</cac:Response></cac:DocumentResponse>
+</ApplicationResponse>`;
+  return zipSync({ 'R-1.xml': strToU8(xml) });
+}
+
+const boleta: EmissionInvoice = {
+  docType: '03',
+  serie: 'B998',
+  correlativo: '1',
+  issueDate: '2026-08-14',
+  currency: 'PEN',
+  emitter: { ruc: '20611172967', razonSocial: 'FACES BETA SAC' },
+  client: { docType: '1', docNumber: '12345678', name: 'CLIENTE DE PRUEBA' },
+  lines: [{ description: 'Servicio', quantity: 1, unitPriceInclTax: 118 }],
+};
+
+const resumenOpts: ResumenOptions = {
+  emitter: { ruc: '20611172967', razonSocial: 'FACES BETA SAC' },
+  correlativo: '1',
+  referenceDate: '2026-08-14',
+  issueDate: '2026-08-14',
+  lines: [{ invoice: boleta, estado: '1' }],
+};
+
+const bajaOpts: BajaOptions = {
+  emitter: { ruc: '20611172967', razonSocial: 'FACES BETA SAC' },
+  correlativo: '1',
+  referenceDate: '2026-08-14',
+  issueDate: '2026-08-15',
+  lines: [{ docType: '01', serie: 'F998', correlativo: '1', motivo: 'test' }],
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  sendSummaryMock.mockReset();
+  getStatusMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('submitResumen', () => {
+  it('polls through 98 (in-process) until statusCode 0 and parses the CDR', async () => {
+    sendSummaryMock.mockResolvedValueOnce({ ticket: 'T1' });
+    getStatusMock
+      .mockResolvedValueOnce({ statusCode: '98' })
+      .mockResolvedValueOnce({ statusCode: '98' })
+      .mockResolvedValueOnce({ statusCode: '0', cdrZip: cdrZip('0', 'Resumen aceptado') });
+
+    const promise = submitResumen(resumenOpts, 'cert', 'key');
+    await vi.runAllTimersAsync();
+    const cdr = await promise;
+
+    expect(cdr).toEqual({ responseCode: '0', description: 'Resumen aceptado', notes: [] });
+    expect(getStatusMock).toHaveBeenCalledTimes(3);
+    expect(sendSummaryMock.mock.calls[0][0]).toBe('20611172967-RC-20260814-1.zip');
+  });
+
+  it('surfaces statusCode 99 (error) by returning its CDR rather than throwing', async () => {
+    sendSummaryMock.mockResolvedValueOnce({ ticket: 'T2' });
+    getStatusMock.mockResolvedValueOnce({ statusCode: '99', cdrZip: cdrZip('2800', 'Resumen rechazado') });
+
+    const promise = submitResumen(resumenOpts, 'cert', 'key');
+    await vi.runAllTimersAsync();
+    const cdr = await promise;
+
+    expect(cdr).toEqual({ responseCode: '2800', description: 'Resumen rechazado', notes: [] });
+  });
+
+  it('throws after exhausting the poll budget still in-process', async () => {
+    sendSummaryMock.mockResolvedValueOnce({ ticket: 'T3' });
+    getStatusMock.mockResolvedValue({ statusCode: '98' });
+
+    const promise = submitResumen(resumenOpts, 'cert', 'key');
+    // Attach a rejection handler before advancing timers so vitest doesn't
+    // flag the eventual rejection as unhandled while polls are in flight.
+    const assertion = expect(promise).rejects.toThrow(/still in-process after 10 polls/);
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(getStatusMock).toHaveBeenCalledTimes(10);
+  });
+});
+
+describe('submitBaja', () => {
+  it('builds the RA file name and parses the accepted CDR', async () => {
+    sendSummaryMock.mockResolvedValueOnce({ ticket: 'T4' });
+    getStatusMock.mockResolvedValueOnce({ statusCode: '0', cdrZip: cdrZip('0', 'Baja aceptada') });
+
+    const promise = submitBaja(bajaOpts, 'cert', 'key');
+    await vi.runAllTimersAsync();
+    const cdr = await promise;
+
+    expect(cdr).toEqual({ responseCode: '0', description: 'Baja aceptada', notes: [] });
+    expect(sendSummaryMock.mock.calls[0][0]).toBe('20611172967-RA-20260815-1.zip');
+  });
+});

--- a/src/server/finance/emission/index.ts
+++ b/src/server/finance/emission/index.ts
@@ -1,11 +1,14 @@
 import { parseCdr } from './cdr';
-import { SUNAT_BETA_PASSWORD, SUNAT_BETA_USERNAME, sendBill } from './soap';
+import { SUNAT_BETA_PASSWORD, SUNAT_BETA_USERNAME, getStatus, sendBill, sendSummary } from './soap';
 import { signXml } from './sign';
+import { bajaId, buildBajaXml, buildResumenXml, resumenId } from './summary';
+import type { BajaOptions, ResumenOptions } from './summary';
 import type { CdrResult, EmissionInvoice } from './types';
 import { buildInvoiceXml } from './ubl';
 import { emissionFileBaseName, zipInvoiceXml } from './zip';
 
 export type { CdrResult, EmissionInvoice } from './types';
+export type { BajaLine, BajaOptions, ResumenEstado, ResumenLine, ResumenOptions } from './summary';
 
 /**
  * Orchestrates build -> sign -> zip -> send -> parse against SUNAT's beta
@@ -22,4 +25,64 @@ export async function emitToBeta(inv: EmissionInvoice, certPem: string, keyPem: 
     password: SUNAT_BETA_PASSWORD,
   });
   return parseCdr(cdrZip);
+}
+
+const POLL_MAX_ATTEMPTS = 10;
+const POLL_INTERVAL_MS = 3_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Polls a `sendSummary` ticket every 3s (beta processes in seconds) until a
+ * terminal `statusCode` — `0` (accepted) or `99` (rejected) both carry a CDR.
+ * Throws if still `98` (in-process) after `POLL_MAX_ATTEMPTS`.
+ */
+async function pollTicket(ticket: string): Promise<CdrResult> {
+  for (let attempt = 1; attempt <= POLL_MAX_ATTEMPTS; attempt++) {
+    await sleep(POLL_INTERVAL_MS);
+    const { statusCode, cdrZip } = await getStatus(ticket, {
+      username: SUNAT_BETA_USERNAME,
+      password: SUNAT_BETA_PASSWORD,
+    });
+    if (statusCode === '98') continue;
+    if (!cdrZip) {
+      throw new Error(`SUNAT getStatus ticket ${ticket}: statusCode ${statusCode} but no CDR`);
+    }
+    return parseCdr(cdrZip);
+  }
+  throw new Error(`SUNAT getStatus ticket ${ticket}: still in-process after ${POLL_MAX_ATTEMPTS} polls`);
+}
+
+/**
+ * Orchestrates build -> sign -> zip -> sendSummary -> poll getStatus -> parse
+ * CDR for a resumen diario (RC) against SUNAT's beta sandbox.
+ */
+export async function submitResumen(opts: ResumenOptions, certPem: string, keyPem: string): Promise<CdrResult> {
+  const unsigned = buildResumenXml(opts);
+  const signed = signXml(unsigned, keyPem, certPem);
+  const fileBaseName = `${opts.emitter.ruc}-${resumenId(opts.issueDate, opts.correlativo)}`;
+  const zipBytes = zipInvoiceXml(fileBaseName, signed);
+  const { ticket } = await sendSummary(`${fileBaseName}.zip`, zipBytes, {
+    username: SUNAT_BETA_USERNAME,
+    password: SUNAT_BETA_PASSWORD,
+  });
+  return pollTicket(ticket);
+}
+
+/**
+ * Orchestrates build -> sign -> zip -> sendSummary -> poll getStatus -> parse
+ * CDR for a comunicación de baja (RA) against SUNAT's beta sandbox.
+ */
+export async function submitBaja(opts: BajaOptions, certPem: string, keyPem: string): Promise<CdrResult> {
+  const unsigned = buildBajaXml(opts);
+  const signed = signXml(unsigned, keyPem, certPem);
+  const fileBaseName = `${opts.emitter.ruc}-${bajaId(opts.issueDate, opts.correlativo)}`;
+  const zipBytes = zipInvoiceXml(fileBaseName, signed);
+  const { ticket } = await sendSummary(`${fileBaseName}.zip`, zipBytes, {
+    username: SUNAT_BETA_USERNAME,
+    password: SUNAT_BETA_PASSWORD,
+  });
+  return pollTicket(ticket);
 }

--- a/src/server/finance/emission/soap.test.ts
+++ b/src/server/finance/emission/soap.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { sendBill } from './soap';
+import { getStatus, sendBill, sendSummary } from './soap';
 
 function xmlResponse(body: string, status = 200) {
   return new Response(body, { status, headers: { 'content-type': 'text/xml' } });
@@ -47,5 +47,75 @@ describe('sendBill', () => {
     await expect(
       sendBill('x.zip', new Uint8Array(), { username: 'u', password: 'p' }),
     ).rejects.toThrow(/no applicationResponse/);
+  });
+});
+
+describe('sendSummary', () => {
+  it('extracts the ticket from a successful SOAP response', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      xmlResponse(`<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+<soapenv:Body><ser:sendSummaryResponse xmlns:ser="http://service.sunat.gob.pe">
+<ticket>1234567890</ticket>
+</ser:sendSummaryResponse></soapenv:Body></soapenv:Envelope>`),
+    );
+    const { ticket } = await sendSummary('20611172967-RC-20260814-1.zip', new Uint8Array([1, 2, 3]), {
+      username: 'u',
+      password: 'p',
+    });
+    expect(ticket).toBe('1234567890');
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init as RequestInit).body).toContain('<fileName>20611172967-RC-20260814-1.zip</fileName>');
+  });
+
+  it('surfaces SUNAT SOAP faults with faultcode + faultstring', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      xmlResponse(`<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+<soapenv:Body><soapenv:Fault>
+<faultcode>soap-env:Client.0111</faultcode>
+<faultstring>El archivo XML esta mal formado</faultstring>
+</soapenv:Fault></soapenv:Body></soapenv:Envelope>`, 500),
+    );
+    await expect(
+      sendSummary('x.zip', new Uint8Array(), { username: 'u', password: 'p' }),
+    ).rejects.toThrow(/soap-env:Client\.0111.*mal formado/s);
+  });
+});
+
+describe('getStatus', () => {
+  it('parses statusCode 98 (in-process) with no content', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      xmlResponse(`<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+<soapenv:Body><ser:getStatusResponse xmlns:ser="http://service.sunat.gob.pe">
+<status><statusCode>98</statusCode></status>
+</ser:getStatusResponse></soapenv:Body></soapenv:Envelope>`),
+    );
+    const result = await getStatus('1234567890', { username: 'u', password: 'p' });
+    expect(result).toEqual({ statusCode: '98', cdrZip: undefined });
+  });
+
+  it('parses statusCode 0 (done) with a base64 CDR in content', async () => {
+    const cdrBase64 = Buffer.from('fake-cdr-zip-bytes').toString('base64');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      xmlResponse(`<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+<soapenv:Body><ser:getStatusResponse xmlns:ser="http://service.sunat.gob.pe">
+<status><statusCode>0</statusCode><content>${cdrBase64}</content></status>
+</ser:getStatusResponse></soapenv:Body></soapenv:Envelope>`),
+    );
+    const { statusCode, cdrZip } = await getStatus('1234567890', { username: 'u', password: 'p' });
+    expect(statusCode).toBe('0');
+    expect(Buffer.from(cdrZip!).toString()).toBe('fake-cdr-zip-bytes');
+  });
+
+  it('parses statusCode 99 (error) with a CDR explaining the rejection', async () => {
+    const cdrBase64 = Buffer.from('fake-error-cdr').toString('base64');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      xmlResponse(`<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+<soapenv:Body><ser:getStatusResponse xmlns:ser="http://service.sunat.gob.pe">
+<status><statusCode>99</statusCode><content>${cdrBase64}</content></status>
+</ser:getStatusResponse></soapenv:Body></soapenv:Envelope>`),
+    );
+    const { statusCode, cdrZip } = await getStatus('1234567890', { username: 'u', password: 'p' });
+    expect(statusCode).toBe('99');
+    expect(Buffer.from(cdrZip!).toString()).toBe('fake-error-cdr');
   });
 });

--- a/src/server/finance/emission/soap.ts
+++ b/src/server/finance/emission/soap.ts
@@ -21,6 +21,53 @@ function extractTag(xml: string, tag: string): string | null {
   return m ? m[1].trim() : null;
 }
 
+function securityEnvelope(opts: SendBillOptions, body: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.sunat.gob.pe" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+<soapenv:Header>
+<wsse:Security>
+<wsse:UsernameToken>
+<wsse:Username>${opts.username}</wsse:Username>
+<wsse:Password>${opts.password}</wsse:Password>
+</wsse:UsernameToken>
+</wsse:Security>
+</soapenv:Header>
+<soapenv:Body>
+${body}
+</soapenv:Body>
+</soapenv:Envelope>`;
+}
+
+/** POSTs a SOAP envelope with the shared 30s-timeout/abort handling every
+ * `billService` operation in this file needs — no soap library, `SOAPAction: ''`. */
+async function postSoapEnvelope(endpoint: string, envelope: string, opName: string): Promise<string> {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/xml;charset=UTF-8', SOAPAction: '' },
+      body: envelope,
+      signal: ctrl.signal,
+    });
+    return await res.text();
+  } catch (e) {
+    throw e instanceof Error && e.name === 'AbortError'
+      ? new Error(`SUNAT ${opName} timed out after ${REQUEST_TIMEOUT_MS}ms`)
+      : e;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function requireNoFault(opName: string, text: string): void {
+  const faultstring = extractTag(text, 'faultstring');
+  if (faultstring) {
+    const faultcode = extractTag(text, 'faultcode') ?? 'unknown';
+    throw new Error(`SUNAT ${opName} fault (${faultcode}): ${faultstring}`);
+  }
+}
+
 /**
  * Hand-built SOAP 1.1 `sendBill` call (no soap library — the envelope shape
  * was validated with curl already, see spec). WS-Security UsernameToken auth,
@@ -33,51 +80,72 @@ export async function sendBill(
 ): Promise<{ cdrZip: Uint8Array }> {
   const endpoint = opts.endpoint ?? SUNAT_BETA_ENDPOINT;
   const contentBase64 = Buffer.from(zipBytes).toString('base64');
-  const envelope = `<?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.sunat.gob.pe" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
-<soapenv:Header>
-<wsse:Security>
-<wsse:UsernameToken>
-<wsse:Username>${opts.username}</wsse:Username>
-<wsse:Password>${opts.password}</wsse:Password>
-</wsse:UsernameToken>
-</wsse:Security>
-</soapenv:Header>
-<soapenv:Body>
-<ser:sendBill>
+  const envelope = securityEnvelope(
+    opts,
+    `<ser:sendBill>
 <fileName>${fileName}</fileName>
 <contentFile>${contentBase64}</contentFile>
-</ser:sendBill>
-</soapenv:Body>
-</soapenv:Envelope>`;
+</ser:sendBill>`,
+  );
 
-  const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS);
-  let res: Response;
-  try {
-    res = await fetch(endpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'text/xml;charset=UTF-8', SOAPAction: '' },
-      body: envelope,
-      signal: ctrl.signal,
-    });
-  } catch (e) {
-    throw e instanceof Error && e.name === 'AbortError'
-      ? new Error(`SUNAT sendBill timed out after ${REQUEST_TIMEOUT_MS}ms`)
-      : e;
-  } finally {
-    clearTimeout(t);
-  }
-
-  const text = await res.text();
-  const faultstring = extractTag(text, 'faultstring');
-  if (faultstring) {
-    const faultcode = extractTag(text, 'faultcode') ?? 'unknown';
-    throw new Error(`SUNAT sendBill fault (${faultcode}): ${faultstring}`);
-  }
+  const text = await postSoapEnvelope(endpoint, envelope, 'sendBill');
+  requireNoFault('sendBill', text);
   const applicationResponse = extractTag(text, 'applicationResponse');
   if (!applicationResponse) {
-    throw new Error(`SUNAT sendBill: no applicationResponse in reply (HTTP ${res.status}): ${text.slice(0, 500)}`);
+    throw new Error(`SUNAT sendBill: no applicationResponse in reply: ${text.slice(0, 500)}`);
   }
   return { cdrZip: Uint8Array.from(Buffer.from(applicationResponse, 'base64')) };
+}
+
+/** `sendSummary` — submits an RC (resumen diario) or RA (comunicación de baja)
+ * zip and returns SUNAT's async ticket. Same envelope/auth as `sendBill`. */
+export async function sendSummary(
+  fileName: string,
+  zipBytes: Uint8Array,
+  opts: SendBillOptions,
+): Promise<{ ticket: string }> {
+  const endpoint = opts.endpoint ?? SUNAT_BETA_ENDPOINT;
+  const contentBase64 = Buffer.from(zipBytes).toString('base64');
+  const envelope = securityEnvelope(
+    opts,
+    `<ser:sendSummary>
+<fileName>${fileName}</fileName>
+<contentFile>${contentBase64}</contentFile>
+</ser:sendSummary>`,
+  );
+
+  const text = await postSoapEnvelope(endpoint, envelope, 'sendSummary');
+  requireNoFault('sendSummary', text);
+  const ticket = extractTag(text, 'ticket');
+  if (!ticket) {
+    throw new Error(`SUNAT sendSummary: no ticket in reply: ${text.slice(0, 500)}`);
+  }
+  return { ticket };
+}
+
+/**
+ * `getStatus` — polls a `sendSummary` ticket. `statusCode`: `0` done (CDR in
+ * `content`), `98` still in-process (no content), `99` error (CDR in `content`
+ * explaining the rejection).
+ */
+export async function getStatus(
+  ticket: string,
+  opts: SendBillOptions,
+): Promise<{ statusCode: string; cdrZip?: Uint8Array }> {
+  const endpoint = opts.endpoint ?? SUNAT_BETA_ENDPOINT;
+  const envelope = securityEnvelope(
+    opts,
+    `<ser:getStatus>
+<ticket>${ticket}</ticket>
+</ser:getStatus>`,
+  );
+
+  const text = await postSoapEnvelope(endpoint, envelope, 'getStatus');
+  requireNoFault('getStatus', text);
+  const statusCode = extractTag(text, 'statusCode');
+  if (!statusCode) {
+    throw new Error(`SUNAT getStatus: no statusCode in reply: ${text.slice(0, 500)}`);
+  }
+  const content = extractTag(text, 'content');
+  return { statusCode, cdrZip: content ? Uint8Array.from(Buffer.from(content, 'base64')) : undefined };
 }

--- a/src/server/finance/emission/summary.test.ts
+++ b/src/server/finance/emission/summary.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { bajaId, buildBajaXml, buildResumenXml, resumenId, type BajaLine, type ResumenLine } from './summary';
+import type { EmissionInvoice } from './types';
+
+const boleta: EmissionInvoice = {
+  docType: '03',
+  serie: 'B998',
+  correlativo: '1',
+  issueDate: '2026-08-14',
+  currency: 'PEN',
+  emitter: { ruc: '20611172967', razonSocial: 'FACES BETA SAC', ubigeo: '150101', address: 'AV BETA 123' },
+  client: { docType: '1', docNumber: '12345678', name: 'CLIENTE DE PRUEBA' },
+  lines: [{ description: 'Servicio de prueba', quantity: 1, unitPriceInclTax: 118 }],
+};
+
+const emitter = { ruc: '20611172967', razonSocial: 'FACES BETA SAC' };
+
+describe('resumenId / bajaId', () => {
+  it('follow the RC/RA-YYYYMMDD-N naming law from the resumen/baja own IssueDate', () => {
+    expect(resumenId('2026-08-14', '1')).toBe('RC-20260814-1');
+    expect(bajaId('2026-08-14', '7')).toBe('RA-20260814-7');
+  });
+});
+
+describe('buildResumenXml', () => {
+  const lines: ResumenLine[] = [{ invoice: boleta, estado: '1' }];
+
+  it('builds a well-formed RC with id, dates, and one SummaryDocumentsLine per boleta', () => {
+    const xml = buildResumenXml({ emitter, correlativo: '1', referenceDate: '2026-08-14', issueDate: '2026-08-14', lines });
+    expect(xml).toContain('<cbc:ID>RC-20260814-1</cbc:ID>');
+    expect(xml).toContain('<cbc:ReferenceDate>2026-08-14</cbc:ReferenceDate>');
+    expect(xml).toContain('<cbc:IssueDate>2026-08-14</cbc:IssueDate>');
+    expect(xml).toContain('<cbc:ID>B998-1</cbc:ID>'); // the line's serie-numero
+    expect(xml).toContain('<cbc:DocumentTypeCode>03</cbc:DocumentTypeCode>');
+    expect(xml).toContain('<cbc:ConditionCode>1</cbc:ConditionCode>');
+    expect(xml).toContain('<cbc:CustomerAssignedAccountID>12345678</cbc:CustomerAssignedAccountID>');
+    expect(xml).toContain('<sac:TotalAmount currencyID="PEN">118.00</sac:TotalAmount>');
+    expect(xml).toContain('<cbc:URI>#SignatureSP</cbc:URI>');
+    expect(xml).toMatch(/<sac:SummaryDocumentsLine>/);
+  });
+
+  it('derives per-line gravada/IGV from computeTotals, not accepted input', () => {
+    const xml = buildResumenXml({ emitter, correlativo: '1', referenceDate: '2026-08-14', issueDate: '2026-08-14', lines });
+    // 118 incl tax @18% => 100.00 gravada + 18.00 IGV
+    expect(xml).toContain('<cbc:PaidAmount currencyID="PEN">100.00</cbc:PaidAmount>');
+    expect(xml).toContain('<cbc:TaxAmount currencyID="PEN">18.00</cbc:TaxAmount>');
+  });
+
+  it('supports multiple lines with distinct estado (e.g. one anulada)', () => {
+    const boleta2: EmissionInvoice = { ...boleta, correlativo: '2' };
+    const xml = buildResumenXml({
+      emitter,
+      correlativo: '2',
+      referenceDate: '2026-08-14',
+      issueDate: '2026-08-14',
+      lines: [
+        { invoice: boleta, estado: '1' },
+        { invoice: boleta2, estado: '3' },
+      ],
+    });
+    expect(xml.match(/<sac:SummaryDocumentsLine>/g)).toHaveLength(2);
+    expect(xml).toContain('<cbc:ID>B998-2</cbc:ID>');
+    expect(xml).toContain('<cbc:ConditionCode>3</cbc:ConditionCode>');
+  });
+
+  it('rejects a non-boleta invoice at runtime', () => {
+    const factura: EmissionInvoice = { ...boleta, docType: '01', serie: 'F998' };
+    expect(() =>
+      buildResumenXml({
+        emitter,
+        correlativo: '1',
+        referenceDate: '2026-08-14',
+        issueDate: '2026-08-14',
+        lines: [{ invoice: factura, estado: '1' }],
+      }),
+    ).toThrow(/boletas \(03\) only/);
+  });
+});
+
+describe('buildBajaXml', () => {
+  const facturaLine: BajaLine = { docType: '01', serie: 'F998', correlativo: '1', motivo: 'ERROR EN EL COMPROBANTE' };
+
+  it('builds a well-formed RA with id, dates, and one VoidedDocumentsLine per doc', () => {
+    const xml = buildBajaXml({
+      emitter,
+      correlativo: '1',
+      referenceDate: '2026-08-14',
+      issueDate: '2026-08-15',
+      lines: [facturaLine],
+    });
+    expect(xml).toContain('<cbc:ID>RA-20260815-1</cbc:ID>');
+    expect(xml).toContain('<cbc:ReferenceDate>2026-08-14</cbc:ReferenceDate>');
+    expect(xml).toContain('<cbc:IssueDate>2026-08-15</cbc:IssueDate>');
+    expect(xml).toContain('<sac:DocumentSerialID>F998</sac:DocumentSerialID>');
+    expect(xml).toContain('<sac:DocumentNumberID>1</sac:DocumentNumberID>');
+    expect(xml).toContain('<sac:VoidReasonDescription>ERROR EN EL COMPROBANTE</sac:VoidReasonDescription>');
+    expect(xml).toContain('<cbc:URI>#SignatureSP</cbc:URI>');
+  });
+
+  it('escapes free-text VoidReasonDescription (no CDATA)', () => {
+    const xml = buildBajaXml({
+      emitter,
+      correlativo: '1',
+      referenceDate: '2026-08-14',
+      issueDate: '2026-08-15',
+      lines: [{ ...facturaLine, motivo: 'ERROR "A" & <B>' }],
+    });
+    expect(xml).toContain('<sac:VoidReasonDescription>ERROR &quot;A&quot; &amp; &lt;B&gt;</sac:VoidReasonDescription>');
+    expect(xml).not.toContain('CDATA');
+  });
+
+  it('rejects a boleta at compile time (docType is the "01" literal, not EmissionDocType)', () => {
+    // @ts-expect-error docType '03' is not assignable to BajaLine's '01' literal — the compile-time half of the estado-3 typing rule
+    const boletaLine: BajaLine = { docType: '03', serie: 'B998', correlativo: '1', motivo: 'x' };
+    void boletaLine;
+  });
+
+  it('rejects a boleta at runtime when the type is bypassed (e.g. an untyped JS caller)', () => {
+    const boletaLine = { docType: '03', serie: 'B998', correlativo: '1', motivo: 'x' } as unknown as BajaLine;
+    expect(() =>
+      buildBajaXml({ emitter, correlativo: '1', referenceDate: '2026-08-14', issueDate: '2026-08-15', lines: [boletaLine] }),
+    ).toThrow(/facturas \(01\) only/);
+  });
+});

--- a/src/server/finance/emission/summary.ts
+++ b/src/server/finance/emission/summary.ts
@@ -1,0 +1,171 @@
+/**
+ * SUNAT resumen diario (RC / `SummaryDocuments`) and comunicación de baja
+ * (RA / `VoidedDocuments`) — the two async "ticket" documents that complete
+ * the emission library alongside `ubl.ts`'s synchronous `sendBill` Invoice.
+ * Structure verified against Greenter's `summary.xml.twig` / `voided.xml.twig`
+ * templates (thegreenter/xml on GitHub) — see PR description for source.
+ */
+import type { EmissionInvoice } from './types';
+import { computeTotals } from './ubl';
+import { EXTENSION_PLACEHOLDER_XML, escapeXml, signatureBlockXml } from './ubl-common';
+
+function yyyymmdd(dateStr: string): string {
+  return dateStr.replaceAll('-', '');
+}
+
+/** `RC-YYYYMMDD-N` — YYYYMMDD from the resumen's own IssueDate (submission date). */
+export function resumenId(issueDate: string, correlativo: string): string {
+  return `RC-${yyyymmdd(issueDate)}-${correlativo}`;
+}
+
+/** `RA-YYYYMMDD-N` — YYYYMMDD from the baja's own IssueDate (communication date). */
+export function bajaId(issueDate: string, correlativo: string): string {
+  return `RA-${yyyymmdd(issueDate)}-${correlativo}`;
+}
+
+function supplierBlockXml(ruc: string, razonSocial: string): string {
+  return `<cac:AccountingSupplierParty>
+<cbc:CustomerAssignedAccountID>${escapeXml(ruc)}</cbc:CustomerAssignedAccountID>
+<cbc:AdditionalAccountID>6</cbc:AdditionalAccountID>
+<cac:Party>
+<cac:PartyLegalEntity>
+<cbc:RegistrationName>${escapeXml(razonSocial)}</cbc:RegistrationName>
+</cac:PartyLegalEntity>
+</cac:Party>
+</cac:AccountingSupplierParty>`;
+}
+
+/** `1` add, `2` modify, `3` anular (void — the boleta-void path; facturas void via `buildBajaXml`). */
+export type ResumenEstado = '1' | '2' | '3';
+
+export interface ResumenLine {
+  /** The boleta (docType `03`) this line summarizes — totals are derived, not accepted as input. */
+  invoice: EmissionInvoice;
+  estado: ResumenEstado;
+}
+
+export interface ResumenOptions {
+  emitter: { ruc: string; razonSocial: string };
+  /** Caller-supplied correlativo N for id `RC-YYYYMMDD-N`. */
+  correlativo: string;
+  /** The boletas' emission date, YYYY-MM-DD. */
+  referenceDate: string;
+  /** Resumen submission date, YYYY-MM-DD — also the ID's YYYYMMDD component. */
+  issueDate: string;
+  lines: ResumenLine[];
+}
+
+function summaryLineXml(lineId: number, line: ResumenLine): string {
+  const inv = line.invoice;
+  if (inv.docType !== '03') {
+    throw new Error(
+      `buildResumenXml: line ${lineId} is docType ${inv.docType} — resumen (RC) covers boletas (03) only`,
+    );
+  }
+  const totals = computeTotals(inv);
+  const serieNro = `${inv.serie}-${inv.correlativo}`;
+  return `<sac:SummaryDocumentsLine>
+<cbc:LineID>${lineId}</cbc:LineID>
+<cbc:DocumentTypeCode>${inv.docType}</cbc:DocumentTypeCode>
+<cbc:ID>${escapeXml(serieNro)}</cbc:ID>
+<cac:AccountingCustomerParty>
+<cbc:CustomerAssignedAccountID>${escapeXml(inv.client.docNumber)}</cbc:CustomerAssignedAccountID>
+<cbc:AdditionalAccountID>${inv.client.docType}</cbc:AdditionalAccountID>
+</cac:AccountingCustomerParty>
+<cac:Status>
+<cbc:ConditionCode>${line.estado}</cbc:ConditionCode>
+</cac:Status>
+<sac:TotalAmount currencyID="${inv.currency}">${totals.taxInclusiveAmount.toFixed(2)}</sac:TotalAmount>
+<sac:BillingPayment>
+<cbc:PaidAmount currencyID="${inv.currency}">${totals.lineExtensionAmount.toFixed(2)}</cbc:PaidAmount>
+<cbc:InstructionID>01</cbc:InstructionID>
+</sac:BillingPayment>
+<cac:TaxTotal>
+<cbc:TaxAmount currencyID="${inv.currency}">${totals.igvAmount.toFixed(2)}</cbc:TaxAmount>
+<cac:TaxSubtotal>
+<cbc:TaxAmount currencyID="${inv.currency}">${totals.igvAmount.toFixed(2)}</cbc:TaxAmount>
+<cac:TaxCategory>
+<cac:TaxScheme>
+<cbc:ID>1000</cbc:ID>
+<cbc:Name>IGV</cbc:Name>
+<cbc:TaxTypeCode>VAT</cbc:TaxTypeCode>
+</cac:TaxScheme>
+</cac:TaxCategory>
+</cac:TaxSubtotal>
+</cac:TaxTotal>
+</sac:SummaryDocumentsLine>`;
+}
+
+/** Builds the unsigned UBL 2.1 `SummaryDocuments` (RC) — resumen diario de boletas. */
+export function buildResumenXml(opts: ResumenOptions): string {
+  const id = resumenId(opts.issueDate, opts.correlativo);
+  const lines = opts.lines.map((l, i) => summaryLineXml(i + 1, l)).join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<SummaryDocuments xmlns="urn:sunat:names:specification:ubl:peru:schema:xsd:SummaryDocuments-1" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:sac="urn:sunat:names:specification:ubl:peru:schema:xsd:SunatAggregateComponents-1">
+${EXTENSION_PLACEHOLDER_XML}
+<cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+<cbc:CustomizationID>1.1</cbc:CustomizationID>
+<cbc:ID>${escapeXml(id)}</cbc:ID>
+<cbc:ReferenceDate>${opts.referenceDate}</cbc:ReferenceDate>
+<cbc:IssueDate>${opts.issueDate}</cbc:IssueDate>
+${signatureBlockXml(opts.emitter.ruc, opts.emitter.razonSocial)}
+${supplierBlockXml(opts.emitter.ruc, opts.emitter.razonSocial)}
+${lines}
+</SummaryDocuments>`;
+}
+
+export interface BajaLine {
+  /** RA covers facturas (01) only — boletas void via RC estado 3 (`buildResumenXml`), never here. */
+  docType: '01';
+  serie: string;
+  correlativo: string;
+  motivo: string;
+}
+
+export interface BajaOptions {
+  emitter: { ruc: string; razonSocial: string };
+  /** Caller-supplied correlativo N for id `RA-YYYYMMDD-N`. */
+  correlativo: string;
+  /** Date the voided document(s) were originally issued, YYYY-MM-DD. */
+  referenceDate: string;
+  /** Baja communication date, YYYY-MM-DD — also the ID's YYYYMMDD component. */
+  issueDate: string;
+  lines: BajaLine[];
+}
+
+function voidedLineXml(lineId: number, line: BajaLine): string {
+  // Runtime guard alongside the `docType: '01'` literal type — belt and
+  // suspenders against an `as any` cast or an untyped JS caller.
+  if (line.docType !== '01') {
+    throw new Error(
+      `buildBajaXml: line ${lineId} is docType ${line.docType} — RA covers facturas (01) only; boletas void via RC estado 3`,
+    );
+  }
+  return `<sac:VoidedDocumentsLine>
+<cbc:LineID>${lineId}</cbc:LineID>
+<cbc:DocumentTypeCode>${line.docType}</cbc:DocumentTypeCode>
+<sac:DocumentSerialID>${escapeXml(line.serie)}</sac:DocumentSerialID>
+<sac:DocumentNumberID>${escapeXml(line.correlativo)}</sac:DocumentNumberID>
+<sac:VoidReasonDescription>${escapeXml(line.motivo)}</sac:VoidReasonDescription>
+</sac:VoidedDocumentsLine>`;
+}
+
+/** Builds the unsigned UBL 2.1 `VoidedDocuments` (RA) — comunicación de baja de facturas. */
+export function buildBajaXml(opts: BajaOptions): string {
+  const id = bajaId(opts.issueDate, opts.correlativo);
+  const lines = opts.lines.map((l, i) => voidedLineXml(i + 1, l)).join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<VoidedDocuments xmlns="urn:sunat:names:specification:ubl:peru:schema:xsd:VoidedDocuments-1" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:sac="urn:sunat:names:specification:ubl:peru:schema:xsd:SunatAggregateComponents-1" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+${EXTENSION_PLACEHOLDER_XML}
+<cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+<cbc:CustomizationID>1.0</cbc:CustomizationID>
+<cbc:ID>${escapeXml(id)}</cbc:ID>
+<cbc:ReferenceDate>${opts.referenceDate}</cbc:ReferenceDate>
+<cbc:IssueDate>${opts.issueDate}</cbc:IssueDate>
+${signatureBlockXml(opts.emitter.ruc, opts.emitter.razonSocial)}
+${supplierBlockXml(opts.emitter.ruc, opts.emitter.razonSocial)}
+${lines}
+</VoidedDocuments>`;
+}

--- a/src/server/finance/emission/ubl-common.ts
+++ b/src/server/finance/emission/ubl-common.ts
@@ -1,0 +1,47 @@
+/**
+ * UBL markup fragments shared between `ubl.ts` (Invoice) and `summary.ts`
+ * (SummaryDocuments/VoidedDocuments) — the extension placeholder and the
+ * `cac:Signature` block are byte-identical across all three document types
+ * that this library builds.
+ */
+
+export function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** Placeholder `ext:UBLExtensions` block — `sign.ts` fills `ext:ExtensionContent`
+ * with the XML-DSig `ds:Signature` it computes over the whole document. */
+export const EXTENSION_PLACEHOLDER_XML = `<ext:UBLExtensions>
+<ext:UBLExtension>
+<ext:ExtensionContent/>
+</ext:UBLExtension>
+</ext:UBLExtensions>`;
+
+/**
+ * `cac:Signature` block pointing `DigitalSignatureAttachment` at `#SignatureSP`
+ * — the `Id` `sign.ts` gives the `ds:Signature` it appends into
+ * `ext:ExtensionContent`. Same shape for Invoice, SummaryDocuments, and
+ * VoidedDocuments.
+ */
+export function signatureBlockXml(ruc: string, razonSocial: string): string {
+  return `<cac:Signature>
+<cbc:ID>${escapeXml(ruc)}</cbc:ID>
+<cac:SignatoryParty>
+<cac:PartyIdentification>
+<cbc:ID>${escapeXml(ruc)}</cbc:ID>
+</cac:PartyIdentification>
+<cac:PartyName>
+<cbc:Name>${escapeXml(razonSocial)}</cbc:Name>
+</cac:PartyName>
+</cac:SignatoryParty>
+<cac:DigitalSignatureAttachment>
+<cac:ExternalReference>
+<cbc:URI>#SignatureSP</cbc:URI>
+</cac:ExternalReference>
+</cac:DigitalSignatureAttachment>
+</cac:Signature>`;
+}

--- a/src/server/finance/emission/ubl.ts
+++ b/src/server/finance/emission/ubl.ts
@@ -1,4 +1,5 @@
 import type { EmissionInvoice, EmissionLine } from './types';
+import { EXTENSION_PLACEHOLDER_XML, escapeXml, signatureBlockXml } from './ubl-common';
 
 /** FACES reality: IGV is always 18%, prices are always tax-inclusive. */
 const IGV_RATE = 0.18;
@@ -8,14 +9,6 @@ const IGV_RATE = 0.18;
 function round(n: number, decimals: number): number {
   const f = 10 ** decimals;
   return Math.round((n + Number.EPSILON) * f) / f;
-}
-
-function escapeXml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
 }
 
 interface LineTotals {
@@ -175,11 +168,7 @@ export function buildInvoiceXml(inv: EmissionInvoice): string {
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
-<ext:UBLExtensions>
-<ext:UBLExtension>
-<ext:ExtensionContent/>
-</ext:UBLExtension>
-</ext:UBLExtensions>
+${EXTENSION_PLACEHOLDER_XML}
 <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
 <cbc:CustomizationID>2.0</cbc:CustomizationID>
 <cbc:ID>${escapeXml(id)}</cbc:ID>
@@ -187,22 +176,7 @@ export function buildInvoiceXml(inv: EmissionInvoice): string {
 <cbc:InvoiceTypeCode listID="0101">${inv.docType}</cbc:InvoiceTypeCode>
 <cbc:Note languageLocaleID="1000">${amountInWords(totals.payableAmount)}</cbc:Note>
 <cbc:DocumentCurrencyCode>${inv.currency}</cbc:DocumentCurrencyCode>
-<cac:Signature>
-<cbc:ID>${escapeXml(inv.emitter.ruc)}</cbc:ID>
-<cac:SignatoryParty>
-<cac:PartyIdentification>
-<cbc:ID>${escapeXml(inv.emitter.ruc)}</cbc:ID>
-</cac:PartyIdentification>
-<cac:PartyName>
-<cbc:Name>${escapeXml(inv.emitter.razonSocial)}</cbc:Name>
-</cac:PartyName>
-</cac:SignatoryParty>
-<cac:DigitalSignatureAttachment>
-<cac:ExternalReference>
-<cbc:URI>#SignatureSP</cbc:URI>
-</cac:ExternalReference>
-</cac:DigitalSignatureAttachment>
-</cac:Signature>
+${signatureBlockXml(inv.emitter.ruc, inv.emitter.razonSocial)}
 <cac:AccountingSupplierParty>
 <cac:Party>
 <cac:PartyIdentification>


### PR DESCRIPTION
## What shipped

Extends `src/server/finance/emission/` (PR #97) with the two async "ticket" document types that complete the emission lifecycle library: resumen diario (RC) and comunicación de baja (RA). Spec: [`specs/2026-08-14-sunat-resumen-baja-spec.md`](https://github.com/NikolasP98/minion_hub/blob/master) (meta-repo `specs/2026-08-14-sunat-resumen-baja-spec.md`).

- **`summary.ts`** — `buildResumenXml` (UBL `SummaryDocuments` / RC): id `RC-YYYYMMDD-N`, `ReferenceDate`/`IssueDate`, one `SummaryDocumentsLine` per boleta (serie-número, estado 1/2/3, client doc, per-boleta gravada+IGV+total derived via `computeTotals`, never accepted as input). `buildBajaXml` (UBL `VoidedDocuments` / RA): id `RA-YYYYMMDD-N`, per-doc `VoidedDocumentsLine` (doc type, serie, número, `VoidReasonDescription`). `BajaLine.docType` is typed as the `'01'` literal (not `EmissionDocType`) so a boleta can't compile into a baja line — plus a runtime guard for `as any`/untyped JS callers. Structure verified against Greenter's `summary.xml.twig` / `voided.xml.twig` templates (thegreenter/xml) and confirmed live against SUNAT beta.
- **`ubl-common.ts`** (new) — extracted `escapeXml` / the `ext:UBLExtensions` placeholder / the `cac:Signature` (`#SignatureSP`) block shared byte-for-byte across `ubl.ts` (Invoice), and the new RC/RA. `ubl.ts` refactored to use them — output unchanged, existing tests untouched and still pass.
- **`soap.ts`** (extend) — `sendSummary(fileName, zipBytes, opts) -> { ticket }` and `getStatus(ticket, opts) -> { statusCode, cdrZip? }`, same envelope/auth/timeout convention as `sendBill`. Refactored the shared fetch/timeout/fault logic into `postSoapEnvelope`/`requireNoFault` rather than tripling it across three SOAP operations; `sendBill`'s behavior and tests are unchanged.
- **`index.ts`** (extend) — `submitResumen` / `submitBaja` orchestrators: build → sign → zip → `sendSummary` → poll `getStatus` (max 10 polls, 3s apart — beta processes in seconds) → parse CDR via the existing `cdr.ts`. File naming: `{RUC}-RC-{YYYYMMDD}-{N}` / `{RUC}-RA-{YYYYMMDD}-{N}`.
- **`scripts/summary-beta-test.ts`** (new) — manual live-beta DoD script, same pattern as `emit-beta-test.ts`.

Pure server library slice — no DB, no routes, no UI, no i18n, as scoped.

## Gate results

- `bun run check` → **0 errors, 0 warnings** (exit 0)
- `bun run test` → **2725 passed, 2 skipped** (was 2683 baseline before this branch) — exit 0

## Live beta DoD

Ran `bun scripts/summary-beta-test.ts` against `e-beta.sunat.gob.pe` (self-signed cert via `scripts/gen-beta-cert.sh`, gitignored, never committed). All six calls accepted on the first try, `ResponseCode 0`, ~3s spacing between calls per the known beta rate-limit:

1. **emit boleta B998-1** — `La Boleta numero B998-1, ha sido aceptada`
2. **emit boleta B998-2** — `La Boleta numero B998-2, ha sido aceptada`
3. **submitResumen RC-1** (B998-1 + B998-2, both estado 1) — `El Resumen diario RC-20260814-1, ha sido aceptado`
4. **submitResumen RC-2** (B998-2, estado 3 anulación) — `El Resumen diario RC-20260814-2, ha sido aceptado`
5. **emit factura F998-1** — `La Factura numero F998-1, ha sido aceptada`
6. **submitBaja RA-1** (F998-1) — `La Comunicacion de baja RA-20260814-1, ha sido aceptada`

## Deviations

None from the spec's contract. One extraction beyond the literal file list: `ubl-common.ts` was added (spec explicitly allowed this — "extract shared helpers rather than duplicating (`ubl-common.ts` if needed, keep it small)"). `soap.ts`'s internal fetch/timeout logic was also refactored into a shared `postSoapEnvelope` helper to avoid tripling it across `sendBill`/`sendSummary`/`getStatus` — behavior-preserving, existing `sendBill` tests pass unchanged.

## Out of scope (per spec)

Scheduling (nightly resumen job), DB records, POS wiring, prod endpoint, retry policy beyond the poll loop, notas de crédito/débito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzD6Vn4qeMGvhXZLLeD1Ls